### PR TITLE
feat(setup): Skip agents not found on PATH during install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Custom agents via `agents` key in `~/.config/ccmux/ccmux.json` (types in `src/li
 
 ### Session Matching
 
-For reliable multi-session matching, install hooks via `ccmux setup` (all agents) or `ccmux setup --agent <name>`. Currently supported: Claude Code, Codex, Cursor, OpenCode, and Pi.
+For reliable multi-session matching, install hooks via `ccmux setup` (all agents detected on PATH) or `ccmux setup --agent <name>`. Currently supported: Claude Code, Codex, Cursor, OpenCode, and Pi.
 
 **Hook-driven flow:**
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ bun link
 ccmux setup
 ```
 
-`ccmux setup` installs agent hooks for authoritative session matching. ccmux works without it, but it's recommended; see [Session Matching with Hooks](#-session-matching-with-hooks).
+`ccmux setup` installs agent hooks for authoritative session matching. ccmux works without it, but it's recommended; see [Session Matching with Hooks](#-session-matching-with-hooks). Bare `ccmux setup` only configures agents whose executable is found on PATH; use `ccmux setup --agent <name>` to install for a specific agent even if it isn't detected.
 
 ## 🚀 Quick Start
 
@@ -86,38 +86,38 @@ ccmux setup
 
 ### CLI Commands
 
-| Command                                     | Description                                                                       |
-| :------------------------------------------ | :-------------------------------------------------------------------------------- |
-| `ccmux`                                     | Launch interactive TUI picker (default)                                           |
-| `ccmux picker`                              | Launch TUI with options (`--preview`, `--icons <style>`)                          |
-| `ccmux picker --persistent`                 | Dashboard mode (stay open after switching sessions)                               |
-| `ccmux spawn [agent]`                       | Spawn a new agent session in a tmux pane                                          |
-| `ccmux invoke [agent] "prompt"`             | Run a single agent turn and write the response to stdout ([docs](docs/invoke.md)) |
-| `ccmux invoke list`                         | List active and recently-finished invocations (`-j` for JSON)                     |
-| `ccmux invoke cancel <id>`                  | Cancel a running invocation by id (idempotent)                                    |
-| `ccmux invoke result <id>`                  | Print an invocation's full captured output (subprocess agents only)               |
-| `ccmux show`                                | List all active sessions                                                          |
-| `ccmux show --json`                         | Output sessions as JSON                                                           |
-| `ccmux status`                              | Show daemon and session overview                                                  |
-| `ccmux switch <id>`                         | Switch tmux client to a session's pane                                            |
-| `ccmux kill <id>`                           | Kill a session's process                                                          |
-| `ccmux restart <id>`                        | Kill and resume a session                                                         |
-| `ccmux send <id> <text>`                    | Send text to a session's tmux pane                                                |
-| `ccmux screen [id]`                         | Capture pane content                                                              |
-| `ccmux screen --grep <pattern>`             | Search across all session panes                                                   |
-| `ccmux dismiss <id>`                        | Remove a session from tracking                                                    |
-| `ccmux daemon start\|stop\|restart\|status` | Manage the background daemon                                                      |
-| `ccmux config set <key> <value>`            | Set a preference                                                                  |
-| `ccmux config get <key>`                    | Get a single preference value                                                     |
-| `ccmux config list`                         | List all preferences                                                              |
-| `ccmux config themes`                       | List built-in themes (marks the active one)                                       |
-| `ccmux setup`                               | Install hooks for every supported agent (Claude + Codex + Cursor + OpenCode + Pi) |
-| `ccmux setup --agent <name>`                | Limit install/uninstall/status to specific agent(s)                               |
-| `ccmux setup --status`                      | Report install state without writing anything                                     |
-| `ccmux setup --uninstall`                   | Remove hooks (preserves user-owned hook entries)                                  |
-| `ccmux debug`                               | Diagnose session tracking discrepancies                                           |
-| `ccmux sidebar`                             | Launch narrow sidebar TUI (no preview/footer)                                     |
-| `ccmux sidebar --toggle`                    | Smart toggle: spawn/kill sidebars in every window across all tmux sessions        |
+| Command                                     | Description                                                                                     |
+| :------------------------------------------ | :---------------------------------------------------------------------------------------------- |
+| `ccmux`                                     | Launch interactive TUI picker (default)                                                         |
+| `ccmux picker`                              | Launch TUI with options (`--preview`, `--icons <style>`)                                        |
+| `ccmux picker --persistent`                 | Dashboard mode (stay open after switching sessions)                                             |
+| `ccmux spawn [agent]`                       | Spawn a new agent session in a tmux pane                                                        |
+| `ccmux invoke [agent] "prompt"`             | Run a single agent turn and write the response to stdout ([docs](docs/invoke.md))               |
+| `ccmux invoke list`                         | List active and recently-finished invocations (`-j` for JSON)                                   |
+| `ccmux invoke cancel <id>`                  | Cancel a running invocation by id (idempotent)                                                  |
+| `ccmux invoke result <id>`                  | Print an invocation's full captured output (subprocess agents only)                             |
+| `ccmux show`                                | List all active sessions                                                                        |
+| `ccmux show --json`                         | Output sessions as JSON                                                                         |
+| `ccmux status`                              | Show daemon and session overview                                                                |
+| `ccmux switch <id>`                         | Switch tmux client to a session's pane                                                          |
+| `ccmux kill <id>`                           | Kill a session's process                                                                        |
+| `ccmux restart <id>`                        | Kill and resume a session                                                                       |
+| `ccmux send <id> <text>`                    | Send text to a session's tmux pane                                                              |
+| `ccmux screen [id]`                         | Capture pane content                                                                            |
+| `ccmux screen --grep <pattern>`             | Search across all session panes                                                                 |
+| `ccmux dismiss <id>`                        | Remove a session from tracking                                                                  |
+| `ccmux daemon start\|stop\|restart\|status` | Manage the background daemon                                                                    |
+| `ccmux config set <key> <value>`            | Set a preference                                                                                |
+| `ccmux config get <key>`                    | Get a single preference value                                                                   |
+| `ccmux config list`                         | List all preferences                                                                            |
+| `ccmux config themes`                       | List built-in themes (marks the active one)                                                     |
+| `ccmux setup`                               | Install hooks for every supported agent found on PATH (Claude + Codex + Cursor + OpenCode + Pi) |
+| `ccmux setup --agent <name>`                | Limit install/uninstall/status to specific agent(s); forces install even if not found on PATH   |
+| `ccmux setup --status`                      | Report install state without writing anything                                                   |
+| `ccmux setup --uninstall`                   | Remove hooks (preserves user-owned hook entries)                                                |
+| `ccmux debug`                               | Diagnose session tracking discrepancies                                                         |
+| `ccmux sidebar`                             | Launch narrow sidebar TUI (no preview/footer)                                                   |
+| `ccmux sidebar --toggle`                    | Smart toggle: spawn/kill sidebars in every window across all tmux sessions                      |
 
 The daemon starts automatically the first time you run a ccmux command (picker, show, invoke, etc.). It runs on `127.0.0.1:2269` and provides both a REST API and SSE event stream.
 
@@ -370,8 +370,8 @@ An unknown base name falls back to the default theme; an invalid hex value or un
 For reliable session-to-pane mapping (especially with multiple sessions of the same agent in the same project), install hooks:
 
 ```bash
-ccmux setup                    # Install hooks for every supported agent
-ccmux setup --agent codex      # Limit to a single agent
+ccmux setup                    # Install hooks for every supported agent found on PATH
+ccmux setup --agent codex      # Limit to a single agent (installs even if not on PATH)
 ccmux setup --status           # Report install state without writing
 ccmux setup --uninstall        # Remove hooks
 ```

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -1,56 +1,48 @@
 import { describe, it, expect } from "bun:test";
-import { agentExecutable, findMissingAgents } from "./setup";
-import { createBuiltinHookAdapters } from "../daemon/adapters";
+import { findMissingAgents } from "./setup";
+import { getAgentExecutable } from "../lib/agents";
 import type { HookAdapter } from "../daemon/hook-adapter";
 
-describe("agentExecutable", () => {
+function fakeAdapters(...agentTypes: string[]): HookAdapter[] {
+  return agentTypes.map((agentType) => ({ agentType }) as HookAdapter);
+}
+
+describe("getAgentExecutable", () => {
   it("returns cursor-agent for cursor (interactive binary differs from agent name)", () => {
-    expect(agentExecutable("cursor")).toBe("cursor-agent");
+    expect(getAgentExecutable("cursor")).toBe("cursor-agent");
   });
 
   it("returns the agent name itself when no executable override is set", () => {
-    expect(agentExecutable("claude")).toBe("claude");
+    expect(getAgentExecutable("claude")).toBe("claude");
   });
 
   it("falls back to the agentType itself when no matching AgentDef exists", () => {
-    expect(agentExecutable("not-a-real-agent")).toBe("not-a-real-agent");
+    expect(getAgentExecutable("not-a-real-agent")).toBe("not-a-real-agent");
   });
 });
 
 describe("findMissingAgents", () => {
   it("returns exactly the agentTypes whose executable resolves to null", () => {
-    const adapters = createBuiltinHookAdapters();
-    const present = new Set(["claude", "codex"]);
+    const adapters = fakeAdapters("claude", "codex", "cursor");
+    const present = new Set(["claude", "cursor-agent"]);
     const which = (cmd: string): string | null =>
       present.has(cmd) ? `/usr/local/bin/${cmd}` : null;
 
-    const missing = findMissingAgents(adapters, which);
-    const expectedMissing = new Set(
-      adapters
-        .filter((a) => !present.has(agentExecutable(a.agentType)))
-        .map((a) => a.agentType),
-    );
-    expect(missing).toEqual(expectedMissing);
+    expect(findMissingAgents(adapters, which)).toEqual(new Set(["codex"]));
   });
 
   it("returns an empty set when all agent executables are present", () => {
-    const adapters: HookAdapter[] = [
-      { agentType: "claude" } as HookAdapter,
-      { agentType: "cursor" } as HookAdapter,
-    ];
     const which = (cmd: string): string | null => `/usr/local/bin/${cmd}`;
 
-    expect(findMissingAgents(adapters, which)).toEqual(new Set());
+    expect(findMissingAgents(fakeAdapters("claude", "cursor"), which)).toEqual(
+      new Set(),
+    );
   });
 
   it("returns every agentType when no executables are present", () => {
-    const adapters: HookAdapter[] = [
-      { agentType: "claude" } as HookAdapter,
-      { agentType: "cursor" } as HookAdapter,
-    ];
     const which = (_cmd: string): string | null => null;
 
-    expect(findMissingAgents(adapters, which)).toEqual(
+    expect(findMissingAgents(fakeAdapters("claude", "cursor"), which)).toEqual(
       new Set(["claude", "cursor"]),
     );
   });

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "bun:test";
+import { agentExecutable, findMissingAgents } from "./setup";
+import { createBuiltinHookAdapters } from "../daemon/adapters";
+import type { HookAdapter } from "../daemon/hook-adapter";
+
+describe("agentExecutable", () => {
+  it("returns cursor-agent for cursor (interactive binary differs from agent name)", () => {
+    expect(agentExecutable("cursor")).toBe("cursor-agent");
+  });
+
+  it("returns the agent name itself when no executable override is set", () => {
+    expect(agentExecutable("claude")).toBe("claude");
+  });
+
+  it("falls back to the agentType itself when no matching AgentDef exists", () => {
+    expect(agentExecutable("not-a-real-agent")).toBe("not-a-real-agent");
+  });
+});
+
+describe("findMissingAgents", () => {
+  it("returns exactly the agentTypes whose executable resolves to null", () => {
+    const adapters = createBuiltinHookAdapters();
+    const present = new Set(["claude", "codex"]);
+    const which = (cmd: string): string | null =>
+      present.has(cmd) ? `/usr/local/bin/${cmd}` : null;
+
+    const missing = findMissingAgents(adapters, which);
+    const expectedMissing = new Set(
+      adapters
+        .filter((a) => !present.has(agentExecutable(a.agentType)))
+        .map((a) => a.agentType),
+    );
+    expect(missing).toEqual(expectedMissing);
+  });
+
+  it("returns an empty set when all agent executables are present", () => {
+    const adapters: HookAdapter[] = [
+      { agentType: "claude" } as HookAdapter,
+      { agentType: "cursor" } as HookAdapter,
+    ];
+    const which = (cmd: string): string | null => `/usr/local/bin/${cmd}`;
+
+    expect(findMissingAgents(adapters, which)).toEqual(new Set());
+  });
+
+  it("returns every agentType when no executables are present", () => {
+    const adapters: HookAdapter[] = [
+      { agentType: "claude" } as HookAdapter,
+      { agentType: "cursor" } as HookAdapter,
+    ];
+    const which = (_cmd: string): string | null => null;
+
+    expect(findMissingAgents(adapters, which)).toEqual(
+      new Set(["claude", "cursor"]),
+    );
+  });
+});

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { isDaemonRunningAsync } from "../daemon";
 import { createBuiltinHookAdapters } from "../daemon/adapters";
 import type { HookAdapter, HookAdapterOutcome } from "../daemon/hook-adapter";
-import { BUILTIN_AGENTS } from "../lib/agents";
+import { getAgentExecutable } from "../lib/agents";
 
 function appendAgent(value: string, prev: string[]): string[] {
   return [...prev, value];
@@ -51,27 +51,17 @@ function plural(word: string, n: number): string {
 }
 
 /**
- * The binary an adapter's agent actually launches, for PATH detection.
- * Falls back to the agentType itself when no matching AgentDef exists
- * (shouldn't happen for built-in adapters, but keeps this total).
- */
-export function agentExecutable(agentType: string): string {
-  const def = BUILTIN_AGENTS.find((a) => a.name === agentType);
-  return def?.executable ?? def?.name ?? agentType;
-}
-
-/**
  * agentTypes whose executable isn't found on PATH. Used to skip installing
  * hooks for agents the user doesn't have, unless explicitly named via
  * `--agent`.
  */
 export function findMissingAgents(
   adapters: HookAdapter[],
-  which: (cmd: string) => string | null = (cmd) => Bun.which(cmd),
+  which: (cmd: string) => string | null = Bun.which,
 ): Set<string> {
   const missing = new Set<string>();
   for (const adapter of adapters) {
-    if (which(agentExecutable(adapter.agentType)) === null) {
+    if (which(getAgentExecutable(adapter.agentType)) === null) {
       missing.add(adapter.agentType);
     }
   }
@@ -81,7 +71,7 @@ export function findMissingAgents(
 interface AdapterCommand {
   banner: string;
   run: (adapter: HookAdapter) => Promise<HookAdapterOutcome>;
-  summarize: (changed: number, total: number) => string;
+  summarize: (changed: number, skipped: number, total: number) => string;
 }
 
 async function runAdapterCommand(
@@ -90,6 +80,7 @@ async function runAdapterCommand(
 ): Promise<void> {
   console.log(`${command.banner}\n`);
   let changed = 0;
+  let skipped = 0;
   for (const adapter of adapters) {
     console.log(`${adapter.agentType}:`);
     // One adapter's failure must not abort the rest: a combined run
@@ -98,6 +89,7 @@ async function runAdapterCommand(
       const outcome = await command.run(adapter);
       for (const line of outcome.lines) console.log(`  ${line}`);
       if (outcome.changed) changed += 1;
+      if (outcome.skipped) skipped += 1;
     } catch (error) {
       console.log(
         `  Failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -106,49 +98,43 @@ async function runAdapterCommand(
     }
     console.log();
   }
-  console.log(command.summarize(changed, adapters.length));
+  console.log(command.summarize(changed, skipped, adapters.length));
   await printDaemonRestartHint();
 }
 
-function runInstall(
-  adapters: HookAdapter[],
-  skipped: Set<string>,
-): Promise<void> {
+function runInstall(adapters: HookAdapter[], skip: Set<string>): Promise<void> {
   return runAdapterCommand(adapters, {
     banner: "Setting up ccmux hooks...",
     run: (adapter) => {
-      if (skipped.has(adapter.agentType)) {
+      if (skip.has(adapter.agentType)) {
         return Promise.resolve({
           changed: false,
+          skipped: true,
           lines: [
-            `Skipped: '${agentExecutable(adapter.agentType)}' not found on PATH (use --agent ${adapter.agentType} to install anyway)`,
+            `Skipped: '${getAgentExecutable(adapter.agentType)}' not found on PATH (use --agent ${adapter.agentType} to install anyway)`,
           ],
         });
       }
       return adapter.install();
     },
-    summarize: (changed, total) => {
-      const skippedCount = skipped.size;
-      const attempted = total - skippedCount;
-      if (skippedCount === 0) {
-        if (changed === 0) {
-          return `No changes (${total} ${plural("agent", total)} already set up).`;
-        }
-        if (changed === total) {
-          return `Setup complete for ${total} ${plural("agent", total)}. Restart sessions to pick up hooks.`;
-        }
-        return `Setup complete: ${changed} of ${total} ${plural("agent", total)} newly configured (others already set up).`;
-      }
+    summarize: (changed, skipped, total) => {
+      const attempted = total - skipped;
+      const skipNote =
+        skipped > 0 ? ` (${skipped} skipped: not found on PATH)` : "";
       if (attempted === 0) {
         return "No agents set up: no supported agent executables found on PATH. Use --agent <name> to force install.";
       }
       if (changed === 0) {
-        return `No changes (${attempted} ${plural("agent", attempted)} already set up, ${skippedCount} skipped: not found on PATH).`;
+        const skipDetail =
+          skipped > 0 ? `, ${skipped} skipped: not found on PATH` : "";
+        return `No changes (${attempted} ${plural("agent", attempted)} already set up${skipDetail}).`;
       }
       if (changed === attempted) {
-        return `Setup complete for ${changed} ${plural("agent", changed)} (${skippedCount} skipped: not found on PATH). Restart sessions to pick up hooks.`;
+        return `Setup complete for ${changed} ${plural("agent", changed)}${skipNote}. Restart sessions to pick up hooks.`;
       }
-      return `Setup complete: ${changed} of ${attempted} ${plural("agent", attempted)} newly configured (${skippedCount} skipped: not found on PATH).`;
+      return `Setup complete: ${changed} of ${attempted} ${plural("agent", attempted)} newly configured${
+        skipped > 0 ? skipNote : " (others already set up)"
+      }.`;
     },
   });
 }
@@ -157,7 +143,7 @@ function runUninstall(adapters: HookAdapter[]): Promise<void> {
   return runAdapterCommand(adapters, {
     banner: "Removing ccmux hooks...",
     run: (adapter) => adapter.uninstall(),
-    summarize: (changed, total) => {
+    summarize: (changed, _skipped, total) => {
       if (changed === 0) return "No changes made (see messages above).";
       if (changed === total) return "Hooks fully removed.";
       return `Removed hooks for ${changed} of ${total} ${plural("agent", total)} (see messages above for skipped).`;

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { isDaemonRunningAsync } from "../daemon";
 import { createBuiltinHookAdapters } from "../daemon/adapters";
 import type { HookAdapter, HookAdapterOutcome } from "../daemon/hook-adapter";
+import { BUILTIN_AGENTS } from "../lib/agents";
 
 function appendAgent(value: string, prev: string[]): string[] {
   return [...prev, value];
@@ -49,6 +50,34 @@ function plural(word: string, n: number): string {
   return n === 1 ? word : `${word}s`;
 }
 
+/**
+ * The binary an adapter's agent actually launches, for PATH detection.
+ * Falls back to the agentType itself when no matching AgentDef exists
+ * (shouldn't happen for built-in adapters, but keeps this total).
+ */
+export function agentExecutable(agentType: string): string {
+  const def = BUILTIN_AGENTS.find((a) => a.name === agentType);
+  return def?.executable ?? def?.name ?? agentType;
+}
+
+/**
+ * agentTypes whose executable isn't found on PATH. Used to skip installing
+ * hooks for agents the user doesn't have, unless explicitly named via
+ * `--agent`.
+ */
+export function findMissingAgents(
+  adapters: HookAdapter[],
+  which: (cmd: string) => string | null = (cmd) => Bun.which(cmd),
+): Set<string> {
+  const missing = new Set<string>();
+  for (const adapter of adapters) {
+    if (which(agentExecutable(adapter.agentType)) === null) {
+      missing.add(adapter.agentType);
+    }
+  }
+  return missing;
+}
+
 interface AdapterCommand {
   banner: string;
   run: (adapter: HookAdapter) => Promise<HookAdapterOutcome>;
@@ -81,18 +110,45 @@ async function runAdapterCommand(
   await printDaemonRestartHint();
 }
 
-function runInstall(adapters: HookAdapter[]): Promise<void> {
+function runInstall(
+  adapters: HookAdapter[],
+  skipped: Set<string>,
+): Promise<void> {
   return runAdapterCommand(adapters, {
     banner: "Setting up ccmux hooks...",
-    run: (adapter) => adapter.install(),
+    run: (adapter) => {
+      if (skipped.has(adapter.agentType)) {
+        return Promise.resolve({
+          changed: false,
+          lines: [
+            `Skipped: '${agentExecutable(adapter.agentType)}' not found on PATH (use --agent ${adapter.agentType} to install anyway)`,
+          ],
+        });
+      }
+      return adapter.install();
+    },
     summarize: (changed, total) => {
+      const skippedCount = skipped.size;
+      const attempted = total - skippedCount;
+      if (skippedCount === 0) {
+        if (changed === 0) {
+          return `No changes (${total} ${plural("agent", total)} already set up).`;
+        }
+        if (changed === total) {
+          return `Setup complete for ${total} ${plural("agent", total)}. Restart sessions to pick up hooks.`;
+        }
+        return `Setup complete: ${changed} of ${total} ${plural("agent", total)} newly configured (others already set up).`;
+      }
+      if (attempted === 0) {
+        return "No agents set up: no supported agent executables found on PATH. Use --agent <name> to force install.";
+      }
       if (changed === 0) {
-        return `No changes (${total} ${plural("agent", total)} already set up).`;
+        return `No changes (${attempted} ${plural("agent", attempted)} already set up, ${skippedCount} skipped: not found on PATH).`;
       }
-      if (changed === total) {
-        return `Setup complete for ${total} ${plural("agent", total)}. Restart sessions to pick up hooks.`;
+      if (changed === attempted) {
+        return `Setup complete for ${changed} ${plural("agent", changed)} (${skippedCount} skipped: not found on PATH). Restart sessions to pick up hooks.`;
       }
-      return `Setup complete: ${changed} of ${total} ${plural("agent", total)} newly configured (others already set up).`;
+      return `Setup complete: ${changed} of ${attempted} ${plural("agent", attempted)} newly configured (${skippedCount} skipped: not found on PATH).`;
     },
   });
 }
@@ -115,7 +171,7 @@ export function createSetupCommand(): Command {
     .option("--uninstall", "Remove hooks and clean agent settings")
     .option(
       "--agent <name>",
-      "Limit to a specific agent (repeatable)",
+      "Limit to a specific agent (repeatable; forces install even if the agent is not on PATH)",
       appendAgent,
       [] as string[],
     )
@@ -148,7 +204,11 @@ export function createSetupCommand(): Command {
       if (options.uninstall) {
         await runUninstall(selected);
       } else {
-        await runInstall(selected);
+        const explicit = (options.agent ?? []).length > 0;
+        const missing = explicit
+          ? new Set<string>()
+          : findMissingAgents(selected);
+        await runInstall(selected, missing);
       }
     });
 }

--- a/src/daemon/hook-adapter.ts
+++ b/src/daemon/hook-adapter.ts
@@ -48,6 +48,12 @@ export interface HookManagerContext {
 export interface HookAdapterOutcome {
   lines: string[];
   changed: boolean;
+  /**
+   * True when the operation was skipped before running (e.g., the agent's
+   * executable isn't on PATH), as opposed to an idempotent no-op. Lets the
+   * CLI summary count skips separately from "already set up".
+   */
+  skipped?: boolean;
 }
 
 /**

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -727,6 +727,19 @@ export function getAgentShortCode(agentType: string): string {
   );
 }
 
+/** Map of agent name → interactive launcher binary, for agents where they differ */
+const AGENT_EXECUTABLES: Record<string, string> = Object.fromEntries(
+  BUILTIN_AGENTS.filter((a) => a.executable).map((a) => [
+    a.name,
+    a.executable!,
+  ]),
+);
+
+/** The binary an agent launches (e.g. cursor → cursor-agent), for PATH detection */
+export function getAgentExecutable(agentType: string): string {
+  return AGENT_EXECUTABLES[agentType] ?? agentType;
+}
+
 export function findAgentForProcess(
   command: string,
   agents: AgentDef[],


### PR DESCRIPTION
## Overview

Makes bare `ccmux setup` presence-aware: agents whose executable is not found on PATH are skipped instead of installed unconditionally. `--agent <name>` remains the explicit override that installs regardless of detection.

## Motivation

`ccmux setup` previously installed hooks for all five built-in agents no matter what was on the machine. On a Claude-only box it created `~/.codex/` (including a `config.toml` with the hooks feature flag), `~/.config/opencode/plugin/ccmux.js`, and `~/.pi/agent/extensions/ccmux.js` for agents that were never installed, and exited 1 whenever `cursor-agent` was missing. Setup now only touches config for agents you actually have.

## Changes

### PATH detection

- **src/commands/setup.ts** - Adds `findMissingAgents()` (injectable `which` for tests, defaults to `Bun.which`); bare install skips missing agents with a per-agent `Skipped: ...` line and a PATH-aware summary, while `--agent` forces install with an empty skip set
- **src/lib/agents.ts** - Adds `getAgentExecutable()` next to `getAgentDisplayName`/`getAgentShortCode`, resolving the launcher binary per agent (e.g. `cursor` resolves to `cursor-agent`)
- **src/daemon/hook-adapter.ts** - Adds an optional `skipped` flag to `HookAdapterOutcome` so the CLI summary counts skips separately from idempotent no-ops

### Tests

- **src/commands/setup.test.ts** - Covers executable resolution (including the cursor/cursor-agent split) and `findMissingAgents` partitioning with a stubbed `which`

### Docs

- **README.md** - Documents PATH-aware setup in the install section, commands table, and hooks section
- **AGENTS.md** - Updates the Session Matching note to "all agents detected on PATH"

## Breaking Changes

None for installed agents; hooks install exactly as before. Bare `ccmux setup` no longer writes config for agents missing from PATH (use `--agent <name>` to restore the old unconditional behavior per agent) and no longer exits 1 when `cursor-agent` is absent.

## Testing

- [x] Unit tests pass (2208 tests, including 6 new for `getAgentExecutable`/`findMissingAgents`)
- [x] Typecheck passes
- [x] End-to-end in an isolated fake `$HOME` with a controlled PATH: all-missing (all skipped, exit 0), mixed (Claude installs, 4 skipped), idempotent rerun (`No changes (1 agent already set up, 4 skipped: not found on PATH)`), and `--agent codex` force install with no codex binary