### PR TITLE
fix(tui): Keep picker columns aligned on waiting rows

### DIFF
--- a/src/tui/components/SessionItem.test.tsx
+++ b/src/tui/components/SessionItem.test.tsx
@@ -235,6 +235,39 @@ describe("SessionItem", () => {
     expect(frame).toContain("2 Agent");
   });
 
+  it("ellipsizes an attention label longer than the cap", async () => {
+    const frame = await renderItem(
+      {
+        session: mockEnrichedSession({
+          status: "waiting",
+          attentionType: "permission",
+          pendingTool: "Bash(git status --porcelain)",
+        }),
+      },
+      160,
+    );
+    // Capped to 12 chars with an ellipsis; the full tool string never shows.
+    expect(frame).toContain("…");
+    expect(frame).not.toContain("Bash(git status --porcelain)");
+  });
+
+  it("ellipsizes a long path instead of clipping it mid-word", async () => {
+    // At a narrow width the dirname no longer fits; it must show `…`, not a
+    // silent hard clip like "claude-tool".
+    const frame = await renderItem(
+      {
+        session: mockEnrichedSession({
+          cwd: "/Users/epilande/Code/epilande/claude-toolkit",
+          gitBranch: "main",
+        }),
+      },
+      40,
+    );
+    expect(frame).toContain("…");
+    expect(frame).toContain("claude-to");
+    expect(frame).not.toContain("claude-toolkit");
+  });
+
   it("shows agent column at wide width", async () => {
     const frame = await renderItem(
       { session: mockEnrichedSession({ agentType: "claude" }) },

--- a/src/tui/components/SessionItem.test.tsx
+++ b/src/tui/components/SessionItem.test.tsx
@@ -23,6 +23,7 @@ async function renderItem(
     isActiveSession?: boolean;
     columns?: import("../../lib/preferences").ColumnsConfig;
     promptDisplay?: import("../../lib/preferences").PromptDisplay;
+    highlights?: import("../utils/grouping").FilteredSession["highlights"];
   },
   width = 100,
   height = 3,
@@ -41,6 +42,7 @@ async function renderItem(
           isActiveSession={props.isActiveSession}
           columns={props.columns}
           promptDisplay={props.promptDisplay}
+          highlights={props.highlights}
         />
       </TickContext.Provider>
     ),
@@ -273,6 +275,21 @@ describe("SessionItem", () => {
       { session: mockEnrichedSession({ agentType: "claude" }) },
       160,
     );
+    expect(frame).toContain("Claude");
+  });
+
+  it("keeps sibling columns on the row when a search highlight overflows the project cell", async () => {
+    // A search highlight renders untruncated, so the cell must flex-clip it
+    // instead of shoving siblings off-row (see SessionItem's `highlightUnbounded`).
+    const longPath = "/Users/epilande/Code/" + "a".repeat(180);
+    const frame = await renderItem(
+      {
+        session: mockEnrichedSession({ agentType: "claude", cwd: longPath }),
+        highlights: { project: longPath },
+      },
+      160,
+    );
+    // The agent column survives at the row's right edge.
     expect(frame).toContain("Claude");
   });
 

--- a/src/tui/components/SessionItem.tsx
+++ b/src/tui/components/SessionItem.tsx
@@ -31,6 +31,11 @@ import {
   rowHasContent,
   rowHasPrompt,
   entryRightWidth,
+  getAttentionLabel,
+  subagentCountLabel,
+  trailingLabelsWidth,
+  fitProjectCell,
+  ATTENTION_LABEL_MAX,
 } from "./session-columns";
 import { theme } from "../theme";
 import { formatRelativeTime, formatVersion, shortenCwd } from "../utils/format";
@@ -94,27 +99,48 @@ function formatProjectPath(
 }
 
 /**
- * Rendered char width of the `project` cell, used to budget an inline prompt
- * that shares row 1 with it. Mirrors the project FieldCell: dirname (plus the
- * path prefix in `full` mode) and the `:branch` suffix (branch truncated to
- * `maxBranchLen`, `+` appended for worktrees).
+ * The project cell's path parts fit to a width budget. The compact/dirname
+ * mode drops the prefix, so pass "" for it. Computed off the same
+ * `fitProjectCell` the FieldCell renders from, so the render and the width
+ * budget can never diverge.
  */
-function projectCellWidth(
+function fittedProjectCell(
   session: EnrichedSession,
   mode: string | undefined,
+  budget: number,
   maxBranchLen: number,
-): number {
+) {
   const { prefix, dirname } = formatProjectPath(
     session.paneCwd ?? session.cwd,
     2,
   );
-  let width = dirname.length;
-  if (mode === "full") width += prefix.length;
-  if (session.gitBranch) {
-    const shown = Math.min(session.gitBranch.length, maxBranchLen);
-    width += 1 + shown + (session.isWorktree ? 1 : 0);
-  }
-  return width;
+  return fitProjectCell(
+    {
+      prefix: mode === "full" ? prefix : "",
+      dirname,
+      branch: session.gitBranch,
+      isWorktree: session.isWorktree,
+    },
+    budget,
+    maxBranchLen,
+  );
+}
+
+/**
+ * Rendered char width of the `project` cell, used to budget an inline prompt
+ * that shares row 1 with it. Derived from {@link fittedProjectCell} so it
+ * reflects the truncated (`…`) rendering, not the natural width.
+ */
+function projectCellWidth(
+  session: EnrichedSession,
+  mode: string | undefined,
+  budget: number,
+  maxBranchLen: number,
+): number {
+  const fitted = fittedProjectCell(session, mode, budget, maxBranchLen);
+  return (
+    fitted.prefix.length + fitted.dirname.length + fitted.branchLabel.length
+  );
 }
 
 const Bold: Component<{ when: boolean; children: string }> = (p) => (
@@ -122,17 +148,6 @@ const Bold: Component<{ when: boolean; children: string }> = (p) => (
     <b>{p.children}</b>
   </Show>
 );
-
-function getAttentionLabel(session: EnrichedSession): string | null {
-  if (session.pendingTool) return session.pendingTool;
-  if (session.inPlanMode || session.attentionType === "plan_approval") {
-    return "Plan";
-  }
-  if (session.status !== "waiting") return null;
-  if (session.attentionType === "permission") return "Permission";
-  if (session.attentionType === "question") return "Question";
-  return null;
-}
 
 function getAttentionColor(session: EnrichedSession): string {
   if (session.pendingTool) return theme.yellow;
@@ -197,6 +212,8 @@ interface FieldRenderContext {
   maxBranchLen: number;
   /** Char budget for the prompt cell; keeps it from overflowing its row. */
   maxPromptLen: number;
+  /** Char budget for the project cell; drives its `…` truncation. */
+  maxProjectLen: number;
 }
 
 function dimColor(ctx: FieldRenderContext, color?: string): string | undefined {
@@ -290,17 +307,31 @@ const FieldCell: Component<{
       const compact = entry.mode !== "full";
       // Functions, not consts: this component body runs once per mount,
       // and rows stay mounted across SSE deltas — a const here would
-      // freeze the cell on its mount-time value.
-      const path = () =>
-        formatProjectPath(ctx.session.paneCwd ?? ctx.session.cwd, 2);
+      // freeze the cell on its mount-time value. `fitted` applies the `…`
+      // truncation for the non-highlighted path; the search-highlight path
+      // stays untruncated (its markup can't be sliced by char count, same
+      // documented tradeoff as the prompt cell).
+      const fitted = () =>
+        fittedProjectCell(
+          ctx.session,
+          entry.mode,
+          ctx.maxProjectLen,
+          ctx.maxBranchLen,
+        );
       const dirnameColor = () =>
         ctx.isActiveSession && !ctx.selected
           ? dimColor(ctx, theme.text)
           : dimColor(ctx, undefined);
       return (
+        // When a prompt shares this row (inline mode), the prompt is the
+        // flexible filler and the project must NOT shrink below its fitted
+        // width, else flex squeezes the path into a mid-word clip (the `…`
+        // and gap artifacts). The prompt (flexShrink=1) absorbs the squeeze
+        // instead. When the project is the filler (no prompt), keep
+        // flexShrink=1 as the backstop behind `fitProjectCell`.
         <box
           flexGrow={props.promptOnRow ? 0 : 1}
-          flexShrink={1}
+          flexShrink={props.promptOnRow ? 0 : 1}
           flexDirection="row"
         >
           <Show
@@ -313,12 +344,12 @@ const FieldCell: Component<{
               />
             }
           >
-            <Show when={!compact}>
-              <text fg={dimColor(ctx, theme.subtext)}>{path().prefix}</text>
+            <Show when={!compact && fitted().prefix}>
+              <text fg={dimColor(ctx, theme.subtext)}>{fitted().prefix}</text>
             </Show>
             <text fg={dirnameColor()}>
               <Bold when={ctx.selected || !!ctx.isActiveSession}>
-                {path().dirname}
+                {fitted().dirname}
               </Bold>
             </text>
           </Show>
@@ -331,11 +362,7 @@ const FieldCell: Component<{
                 }
                 fallback={
                   <text fg={dimColor(ctx, theme.blue)}>
-                    :
-                    {branch().length > ctx.maxBranchLen
-                      ? branch().slice(0, ctx.maxBranchLen - 1) + "~"
-                      : branch()}
-                    {ctx.session.isWorktree ? "+" : ""}
+                    {fitted().branchLabel}
                   </text>
                 }
               >
@@ -469,8 +496,12 @@ function row2LeadingIndent(row1Left: ResolvedEntry[]): number {
 const RowRender: Component<{
   row: ResolvedRow;
   ctx: FieldRenderContext;
-  /** Render attention indicator + subagent count after row.left (row 1 only). */
+  /** Render the trailing attention/subagent cell after row.left (row 1 only). */
   showAttention?: boolean;
+  /** This row's own trailing-labels width (attention + subagent count). The
+   * cell is sized to exactly its content, so an unlabeled row reserves 0 and
+   * its prompt runs all the way to the right-side metadata. */
+  attentionWidth?: number;
   /** Optional fixed-width spacer prepended after the active indicator. */
   leadingIndent?: number;
 }> = (props) => {
@@ -478,6 +509,16 @@ const RowRender: Component<{
   // so the standalone spacer would double up and split the space. Drop it, and
   // tell the project cell to give up its own flex-grow.
   const hasPrompt = createMemo(() => rowHasPrompt(props.row));
+  // The project cell also flex-grows (when no prompt shares its row), so it is
+  // the filler and the standalone spacer is redundant. Rendering both splits
+  // the slack and squeezes the project cell by ~1 column, which drops its `…`.
+  // Only add the spacer when the row has no flexible filler of its own.
+  const hasFlexFiller = createMemo(
+    () =>
+      hasPrompt() ||
+      props.row.left.some((e) => e.field === "project") ||
+      props.row.right.some((e) => e.field === "project"),
+  );
   return (
     <box flexDirection="row" gap={1} width="100%" height={1}>
       <Show when={(props.leadingIndent ?? 0) > 0}>
@@ -493,27 +534,40 @@ const RowRender: Component<{
           />
         )}
       </For>
-      <Show when={!hasPrompt()}>
+      <Show when={!hasFlexFiller()}>
         <box flexGrow={1} flexShrink={1} />
       </Show>
-      <Show when={props.showAttention && props.ctx.attentionLabel}>
-        <text fg={props.ctx.attentionColor}>
-          {props.ctx.sidebar ? "!" : props.ctx.attentionLabel}
-        </text>
-      </Show>
-      <Show
-        when={
-          props.showAttention &&
-          !props.ctx.sidebar &&
-          !props.ctx.session.pendingTool &&
-          !props.ctx.session.inPlanMode &&
-          props.ctx.session.subagents &&
-          props.ctx.session.subagents.length > 0
-        }
-      >
-        <text fg={props.ctx.dimmed ? theme.border : theme.teal}>
-          {props.ctx.session.subagents.length} Agent
-        </text>
+      {/* Per-row trailing-labels cell, sized to exactly its own content
+          (`attentionWidth`), so an unlabeled row reserves nothing and its
+          prompt extends into this space. `width` + `flexShrink={0}` keep the
+          rendered width identical to the value the prompt/project budgets
+          subtract, so the truncation `…` lands right before the label. */}
+      <Show when={props.showAttention && (props.attentionWidth ?? 0) > 0}>
+        <box
+          width={props.attentionWidth}
+          flexShrink={0}
+          flexDirection="row"
+          gap={1}
+        >
+          <Show when={props.ctx.attentionLabel}>
+            {(label: () => string) => (
+              <text fg={props.ctx.attentionColor}>
+                {props.ctx.sidebar
+                  ? "!"
+                  : truncateText(label(), ATTENTION_LABEL_MAX)}
+              </text>
+            )}
+          </Show>
+          <Show
+            when={!props.ctx.sidebar && subagentCountLabel(props.ctx.session)}
+          >
+            {(label: () => string) => (
+              <text fg={props.ctx.dimmed ? theme.border : theme.teal}>
+                {label()}
+              </text>
+            )}
+          </Show>
+        </box>
       </Show>
       <For each={props.row.right}>
         {(entry) => (
@@ -565,12 +619,72 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
     return 60;
   };
 
+  // This row's own trailing-labels cell width. Per-row (not a list-wide max),
+  // so an unlabeled row reserves nothing and its prompt runs to the right-side
+  // metadata; a labeled row's prompt/project budgets subtract exactly this so
+  // the truncation `…` lands right before the label.
+  const attentionWidth = () =>
+    trailingLabelsWidth(props.session, !!props.sidebar);
+
+  // The project cell renders inside SessionList's scrollbox, whose scrollbar
+  // (and content inset) consume a couple of columns the terminal width does
+  // not reflect. Without reserving them, `fitProjectCell` fills right up to a
+  // box that is a hair narrower than budgeted and OpenTUI hard-clips the
+  // trailing char, dropping the very `…` we added. A direct mount (tests, no
+  // scrollbox) still needs a 1-char cushion so content never exactly equals
+  // its box (OpenTUI clips on an exact fit too). `props.layout` is supplied
+  // only by SessionList, so it distinguishes the two contexts.
+  const scrollbarReserve = () => (props.layout ? 3 : 1);
+
+  // Prompt-floor budgeting shorthand: how many chars an inline prompt is
+  // guaranteed on row 1 before the project cell starts yielding width. The
+  // prompt truncates down to this floor first; only then does the path give
+  // up space. Bounded by data length so a short prompt reserves less.
+  const PROMPT_MIN = 16;
+
+  // Budget for the project cell's `…` truncation. Full width minus the item
+  // padding, every row-1 sibling except project (and the prompt, budgeted via
+  // its floor below), the reserved attention cell, and a small margin. Reads
+  // only the raw prompt length (capped at PROMPT_MIN), never maxPromptLen, so
+  // maxPromptLen can depend on the fitted project width without a cycle.
+  const maxProjectLen = () => {
+    const cols = columns();
+    const promptOnRow1 = rowHasPrompt(cols.row1);
+    const siblings = [...cols.row1.left, ...cols.row1.right].filter(
+      (e) => e.field !== "project" && e.field !== "prompt",
+    );
+    const cells = siblings.reduce((acc, e) => {
+      const w =
+        e.field === "pr"
+          ? prLabel(props.session, e.mode).length
+          : entryRightWidth(e);
+      return acc + (w > 0 ? w + 1 : 0); // +1 for the inter-cell gap
+    }, 0);
+    const attn = attentionWidth();
+    const promptFloor =
+      promptOnRow1 && hasFieldData(props.session, "prompt")
+        ? Math.min(
+            normalizePrompt(props.session.lastPrompt ?? "").length,
+            PROMPT_MIN,
+          ) + 1
+        : 0;
+    const reserved =
+      2 + // item paddingLeft/paddingRight
+      cells +
+      (attn > 0 ? attn + 1 : 0) +
+      promptFloor +
+      2 + // small margin so the truncated content sits inside its flex box
+      scrollbarReserve(); // scrollbox eats width the terminal size hides
+    return Math.max(12, effectiveWidth() - reserved);
+  };
+
   // Budget for the prompt cell: full width minus the item's horizontal
   // padding, the leading indent, every sibling cell on the prompt's row, and
   // the inter-cell gaps. The prompt rides row 1 when inline (sharing it with
-  // project) and row 2 otherwise; budget against whichever row it landed on
-  // so the `…` truncation lands just before the right-aligned metadata.
-  // Conservative floor so tiny viewports still show something identifiable.
+  // project, and with the reserved attention cell) and row 2 otherwise; budget
+  // against whichever row it landed on so the `…` truncation lands just before
+  // the right-aligned metadata. Conservative floor so tiny viewports still
+  // show something identifiable.
   const maxPromptLen = () => {
     const cols = columns();
     const onRow1 = rowHasPrompt(cols.row1);
@@ -583,14 +697,23 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
         e.field === "pr"
           ? prLabel(props.session, e.mode).length
           : e.field === "project"
-            ? projectCellWidth(props.session, e.mode, maxBranchLen())
+            ? projectCellWidth(
+                props.session,
+                e.mode,
+                maxProjectLen(),
+                maxBranchLen(),
+              )
             : entryRightWidth(e);
       return acc + (w > 0 ? w + 1 : 0); // +1 for the inter-cell gap
     }, 0);
+    // The reserved attention cell only exists on row 1, so it eats into the
+    // prompt budget only when the prompt shares that row (inline mode).
+    const attn = onRow1 ? attentionWidth() : 0;
     const reserved =
       2 + // item paddingLeft/paddingRight
       (onRow1 ? 0 : row2LeadingIndent(cols.row1.left)) +
       cells +
+      (attn > 0 ? attn + 1 : 0) +
       2; // small margin so the `…` lands inside the flexed box, not clipped
     return Math.max(16, effectiveWidth() - reserved);
   };
@@ -681,6 +804,9 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
     get maxPromptLen() {
       return maxPromptLen();
     },
+    get maxProjectLen() {
+      return maxProjectLen();
+    },
   };
 
   const row2HasContent = createMemo(() =>
@@ -726,7 +852,12 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
           }
         }}
       >
-        <RowRender row={row1()} ctx={ctx} showAttention />
+        <RowRender
+          row={row1()}
+          ctx={ctx}
+          showAttention
+          attentionWidth={attentionWidth()}
+        />
         <Show when={row2HasContent()}>
           <RowRender
             row={row2()}

--- a/src/tui/components/SessionItem.tsx
+++ b/src/tui/components/SessionItem.tsx
@@ -305,19 +305,22 @@ const FieldCell: Component<{
     }
     case "project": {
       const compact = entry.mode !== "full";
-      // Functions, not consts: this component body runs once per mount,
-      // and rows stay mounted across SSE deltas — a const here would
-      // freeze the cell on its mount-time value. `fitted` applies the `…`
-      // truncation for the non-highlighted path; the search-highlight path
+      // A createMemo, not a plain const: this component body runs once per
+      // mount and rows stay mounted across SSE deltas, so a const would freeze
+      // the cell on its mount-time value. The memo instead recomputes reactively
+      // when the budget changes, while collapsing the cell's several JSX reads
+      // (prefix/dirname/branchLabel) into one fit per pass. `fitted` applies the
+      // `…` truncation for the non-highlighted path; the search-highlight path
       // stays untruncated (its markup can't be sliced by char count, same
       // documented tradeoff as the prompt cell).
-      const fitted = () =>
+      const fitted = createMemo(() =>
         fittedProjectCell(
           ctx.session,
           entry.mode,
           ctx.maxProjectLen,
           ctx.maxBranchLen,
-        );
+        ),
+      );
       const dirnameColor = () =>
         ctx.isActiveSession && !ctx.selected
           ? dimColor(ctx, theme.text)
@@ -623,8 +626,9 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
   // so an unlabeled row reserves nothing and its prompt runs to the right-side
   // metadata; a labeled row's prompt/project budgets subtract exactly this so
   // the truncation `…` lands right before the label.
-  const attentionWidth = () =>
-    trailingLabelsWidth(props.session, !!props.sidebar);
+  const attentionWidth = createMemo(() =>
+    trailingLabelsWidth(props.session, !!props.sidebar),
+  );
 
   // The project cell renders inside SessionList's scrollbox, whose scrollbar
   // (and content inset) consume a couple of columns the terminal width does
@@ -647,7 +651,7 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
   // its floor below), the reserved attention cell, and a small margin. Reads
   // only the raw prompt length (capped at PROMPT_MIN), never maxPromptLen, so
   // maxPromptLen can depend on the fitted project width without a cycle.
-  const maxProjectLen = () => {
+  const maxProjectLen = createMemo(() => {
     const cols = columns();
     const promptOnRow1 = rowHasPrompt(cols.row1);
     const siblings = [...cols.row1.left, ...cols.row1.right].filter(
@@ -676,7 +680,7 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
       2 + // small margin so the truncated content sits inside its flex box
       scrollbarReserve(); // scrollbox eats width the terminal size hides
     return Math.max(12, effectiveWidth() - reserved);
-  };
+  });
 
   // Budget for the prompt cell: full width minus the item's horizontal
   // padding, the leading indent, every sibling cell on the prompt's row, and
@@ -685,7 +689,7 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
   // against whichever row it landed on so the `…` truncation lands just before
   // the right-aligned metadata. Conservative floor so tiny viewports still
   // show something identifiable.
-  const maxPromptLen = () => {
+  const maxPromptLen = createMemo(() => {
     const cols = columns();
     const onRow1 = rowHasPrompt(cols.row1);
     const row = onRow1 ? cols.row1 : cols.row2;
@@ -716,7 +720,7 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
       (attn > 0 ? attn + 1 : 0) +
       2; // small margin so the `…` lands inside the flexed box, not clipped
     return Math.max(16, effectiveWidth() - reserved);
-  };
+  });
 
   const agentColor = () => agentColorFor(props.session.agentType);
 

--- a/src/tui/components/SessionItem.tsx
+++ b/src/tui/components/SessionItem.tsx
@@ -35,6 +35,7 @@ import {
   subagentCountLabel,
   trailingLabelsWidth,
   fitProjectCell,
+  sliceEllipsis,
   ATTENTION_LABEL_MAX,
 } from "./session-columns";
 import { theme } from "../theme";
@@ -155,11 +156,6 @@ function getAttentionColor(session: EnrichedSession): string {
     return theme.teal;
   }
   return theme.mauve;
-}
-
-function truncateText(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  return text.slice(0, Math.max(1, maxLen - 1)) + "…";
 }
 
 /** Agent dot/label color by agent type. A function (not a module const) so it
@@ -311,8 +307,8 @@ const FieldCell: Component<{
       // when the budget changes, while collapsing the cell's several JSX reads
       // (prefix/dirname/branchLabel) into one fit per pass. `fitted` applies the
       // `…` truncation for the non-highlighted path; the search-highlight path
-      // stays untruncated (its markup can't be sliced by char count, same
-      // documented tradeoff as the prompt cell).
+      // stays untruncated and is clipped by flex instead (see
+      // `highlightUnbounded`), the same tradeoff the prompt cell makes.
       const fitted = createMemo(() =>
         fittedProjectCell(
           ctx.session,
@@ -321,6 +317,13 @@ const FieldCell: Component<{
           ctx.maxBranchLen,
         ),
       );
+      // A search highlight renders the FULL matched path/branch untruncated
+      // (its markup is clipped by flex rather than char-sliced), so
+      // `fitProjectCell` never bounds it. Both fields matter: a project match
+      // overflows directly, and a branch match can exceed the cell's width
+      // budget even while fitting `maxBranchLen`.
+      const highlightUnbounded = () =>
+        !!(ctx.highlights?.project || ctx.highlights?.gitBranch);
       const dirnameColor = () =>
         ctx.isActiveSession && !ctx.selected
           ? dimColor(ctx, theme.text)
@@ -331,10 +334,12 @@ const FieldCell: Component<{
         // width, else flex squeezes the path into a mid-word clip (the `…`
         // and gap artifacts). The prompt (flexShrink=1) absorbs the squeeze
         // instead. When the project is the filler (no prompt), keep
-        // flexShrink=1 as the backstop behind `fitProjectCell`.
+        // flexShrink=1 as the backstop behind `fitProjectCell`. An unbounded
+        // highlight also needs that backstop, else the overflowing string
+        // shoves the row's other columns off the edge.
         <box
           flexGrow={props.promptOnRow ? 0 : 1}
-          flexShrink={props.promptOnRow ? 0 : 1}
+          flexShrink={props.promptOnRow && !highlightUnbounded() ? 0 : 1}
           flexDirection="row"
         >
           <Show
@@ -430,7 +435,7 @@ const FieldCell: Component<{
       // markup can't be sliced by char count.
       const text = () =>
         ctx.session.lastPrompt
-          ? truncateText(
+          ? sliceEllipsis(
               normalizePrompt(ctx.session.lastPrompt),
               ctx.maxPromptLen,
             )
@@ -557,7 +562,7 @@ const RowRender: Component<{
               <text fg={props.ctx.attentionColor}>
                 {props.ctx.sidebar
                   ? "!"
-                  : truncateText(label(), ATTENTION_LABEL_MAX)}
+                  : sliceEllipsis(label(), ATTENTION_LABEL_MAX)}
               </text>
             )}
           </Show>

--- a/src/tui/components/SessionList.test.tsx
+++ b/src/tui/components/SessionList.test.tsx
@@ -44,6 +44,7 @@ async function renderList(
   items: FlatItem[],
   selectedIndex = 0,
   columns?: import("../../lib/preferences").ColumnsConfig,
+  width = 80,
 ) {
   const [tick] = createSignal(0);
   setup = await testRender(
@@ -57,7 +58,7 @@ async function renderList(
         />
       </TickContext.Provider>
     ),
-    { width: 80, height: 20 },
+    { width, height: 20 },
   );
   await setup.renderOnce();
   return setup.captureCharFrame();
@@ -67,6 +68,76 @@ describe("SessionList", () => {
   it("renders empty state message", async () => {
     const frame = await renderList([]);
     expect(frame).toContain("No sessions found");
+  });
+
+  it("aligns the agent column across waiting and idle rows", async () => {
+    // The waiting row carries an attention label the idle row does not. The
+    // right-side metadata (agent) is fixed-width at the row end, so it stays
+    // aligned regardless: the label eats into the flexible middle, not the
+    // right columns.
+    const items: FlatItem[] = [
+      makeSessionItem("s1", "proj", {
+        cwd: "/code/app-one",
+        gitBranch: "main",
+        status: "waiting",
+        attentionType: "permission",
+        pendingTool: "Bash(git status)",
+      }),
+      makeSessionItem("s2", "proj", {
+        cwd: "/code/app-two",
+        gitBranch: "main",
+      }),
+    ];
+    // Wide enough that both paths fit with room to spare, so the label eats
+    // slack, not the path.
+    const frame = await renderList(items, 0, undefined, 120);
+    const agentLines = frame.split("\n").filter((l) => l.includes("Claude"));
+    expect(agentLines.length).toBe(2);
+    const cols = agentLines.map((l) => l.indexOf("Claude"));
+    expect(cols[0]).toBe(cols[1]);
+    // Both rows keep their full path:branch (no clipped mid-word).
+    expect(frame).toContain("app-one:main");
+    expect(frame).toContain("app-two:main");
+  });
+
+  it("lets an unlabeled row's prompt extend into the label's space", async () => {
+    // Per-row label width (not a list-wide reservation): the idle row has no
+    // trailing label, so its inline prompt runs further right than the waiting
+    // sibling's, whose prompt truncates earlier to leave room for the label.
+    const prompt =
+      "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda";
+    const items: FlatItem[] = [
+      makeSessionItem("s1", "proj", {
+        cwd: "/code/app",
+        gitBranch: "main",
+        status: "waiting",
+        attentionType: "permission",
+        pendingTool: "Bash(git status)",
+        lastPrompt: prompt,
+      }),
+      makeSessionItem("s2", "proj", {
+        cwd: "/code/app",
+        gitBranch: "main",
+        lastPrompt: prompt,
+      }),
+    ];
+    // Default prompt display is inline, so the prompt rides row 1.
+    const frame = await renderList(items, 0, undefined, 90);
+    const lines = frame.split("\n");
+    const waitingLine = lines.find((l) => l.includes("Bash(git"))!;
+    const idleLine = lines.find(
+      (l) => l.includes("alpha") && !l.includes("Bash(git"),
+    )!;
+    expect(waitingLine).toBeDefined();
+    expect(idleLine).toBeDefined();
+    // Count how many prompt words survive on each row. The idle row has no
+    // trailing label, so more of the prompt fits before it truncates.
+    const words = prompt.split(" ");
+    const shown = (l: string) => words.filter((w) => l.includes(w)).length;
+    expect(shown(idleLine)).toBeGreaterThan(shown(waitingLine));
+    // Concretely: the idle row reaches "gamma"; the waiting row stops before it.
+    expect(idleLine).toContain("gamma");
+    expect(waitingLine).not.toContain("gamma");
   });
 
   it("renders group header", async () => {

--- a/src/tui/components/session-columns.test.ts
+++ b/src/tui/components/session-columns.test.ts
@@ -1021,4 +1021,30 @@ describe("fitProjectCell", () => {
     );
     expect(out.branchLabel).toBe("");
   });
+
+  it("shortens the branch as a last resort with a ~ marker", () => {
+    // Tight budget: even after dropping the prefix and flooring the dirname to
+    // its 5-char minimum, the branch still overflows, so step 3 truncates it
+    // with `~` rather than dropping it to "". Exercises the positive
+    // shortenBranchLabel path (avail >= 3), not the zero-budget drop.
+    const out = fitProjectCell(
+      {
+        prefix: "epilande/",
+        dirname: "claude-toolkit",
+        branch: "feature-x",
+        isWorktree: false,
+      },
+      12,
+      24,
+    );
+    expect(out.prefix).toBe("");
+    expect(out.dirname.endsWith("…")).toBe(true);
+    // Branch truncated with the `~` marker: neither dropped to "" nor left whole.
+    expect(out.branchLabel).toBe(":featu~");
+    expect(out.branchLabel.endsWith("~")).toBe(true);
+    // The cascade never overshoots its budget.
+    expect(
+      out.prefix.length + out.dirname.length + out.branchLabel.length,
+    ).toBeLessThanOrEqual(12);
+  });
 });

--- a/src/tui/components/session-columns.test.ts
+++ b/src/tui/components/session-columns.test.ts
@@ -15,7 +15,13 @@ import {
   rowHasContent,
   rowHasPrompt,
   SIDEBAR_DEFAULT_COLUMNS,
+  trailingLabelsWidth,
+  fitProjectCell,
+  getAttentionLabel,
+  subagentCountLabel,
+  ATTENTION_LABEL_MAX,
 } from "./session-columns";
+import type { SubagentState } from "../../types";
 import { DEFAULT_BREAKPOINTS, type Responsive } from "../../lib/preferences";
 import { mockEnrichedSession } from "./test-helpers";
 
@@ -798,5 +804,221 @@ describe("prColorState", () => {
     expect(
       prColorState(mockEnrichedSession({ branchPRs: [approved, approved] })),
     ).toBe("green");
+  });
+});
+
+const mockSubagent = (
+  overrides: Partial<SubagentState> = {},
+): SubagentState => ({
+  agentId: "sub",
+  status: "working",
+  attentionType: null,
+  pendingTool: null,
+  lastActivityAt: null,
+  ...overrides,
+});
+
+describe("getAttentionLabel", () => {
+  it("returns the pending tool name when present", () => {
+    expect(
+      getAttentionLabel(
+        mockEnrichedSession({ pendingTool: "Bash(git status)" }),
+      ),
+    ).toBe("Bash(git status)");
+  });
+
+  it("returns Plan in plan mode", () => {
+    expect(getAttentionLabel(mockEnrichedSession({ inPlanMode: true }))).toBe(
+      "Plan",
+    );
+  });
+
+  it("returns Permission / Question by attention type when waiting", () => {
+    expect(
+      getAttentionLabel(
+        mockEnrichedSession({ status: "waiting", attentionType: "permission" }),
+      ),
+    ).toBe("Permission");
+    expect(
+      getAttentionLabel(
+        mockEnrichedSession({ status: "waiting", attentionType: "question" }),
+      ),
+    ).toBe("Question");
+  });
+
+  it("returns null for an idle session with no signal", () => {
+    expect(getAttentionLabel(mockEnrichedSession())).toBeNull();
+  });
+});
+
+describe("subagentCountLabel", () => {
+  it("counts live subagents when no tool/plan marker is up", () => {
+    expect(
+      subagentCountLabel(
+        mockEnrichedSession({ subagents: [mockSubagent(), mockSubagent()] }),
+      ),
+    ).toBe("2 Agent");
+  });
+
+  it("is hidden while a pending tool or plan takes the slot", () => {
+    expect(
+      subagentCountLabel(
+        mockEnrichedSession({
+          pendingTool: "Edit",
+          subagents: [mockSubagent()],
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      subagentCountLabel(
+        mockEnrichedSession({ inPlanMode: true, subagents: [mockSubagent()] }),
+      ),
+    ).toBeNull();
+  });
+
+  it("is null with no subagents", () => {
+    expect(subagentCountLabel(mockEnrichedSession())).toBeNull();
+  });
+});
+
+describe("trailingLabelsWidth", () => {
+  it("is 0 for an idle, label-less session", () => {
+    expect(trailingLabelsWidth(mockEnrichedSession(), false)).toBe(0);
+  });
+
+  it("is the attention label width (capped) in the picker", () => {
+    expect(
+      trailingLabelsWidth(
+        mockEnrichedSession({ status: "waiting", attentionType: "permission" }),
+        false,
+      ),
+    ).toBe("Permission".length);
+  });
+
+  it("caps a long attention label at ATTENTION_LABEL_MAX", () => {
+    const long = "Bash(git status --porcelain --untracked)";
+    expect(
+      trailingLabelsWidth(mockEnrichedSession({ pendingTool: long }), false),
+    ).toBe(ATTENTION_LABEL_MAX);
+  });
+
+  it("sums attention + subagent + the inter-label gap", () => {
+    // pendingTool suppresses the subagent count, so use a waiting session with
+    // subagents but no pending tool.
+    const s = mockEnrichedSession({
+      status: "waiting",
+      attentionType: "question",
+      subagents: [mockSubagent(), mockSubagent()],
+    });
+    // "Question"(8) + gap(1) + "2 Agent"(7) = 16
+    expect(trailingLabelsWidth(s, false)).toBe(8 + 1 + 7);
+  });
+
+  it("collapses to a single '!' in the sidebar and hides the subagent count", () => {
+    const s = mockEnrichedSession({
+      status: "waiting",
+      attentionType: "question",
+      subagents: [mockSubagent()],
+    });
+    expect(trailingLabelsWidth(s, true)).toBe(1);
+    expect(trailingLabelsWidth(mockEnrichedSession(), true)).toBe(0);
+  });
+});
+
+describe("fitProjectCell", () => {
+  const base = {
+    prefix: "epilande/",
+    dirname: "ccmux",
+    branch: "main" as string | null,
+    isWorktree: false,
+  };
+
+  it("renders everything unchanged when it fits", () => {
+    const out = fitProjectCell(base, 40, 24);
+    expect(out).toEqual({
+      prefix: "epilande/",
+      dirname: "ccmux",
+      branchLabel: ":main",
+    });
+  });
+
+  it("appends the worktree marker and caps the branch with ~", () => {
+    const out = fitProjectCell(
+      { ...base, branch: "feature/really-long-branch", isWorktree: true },
+      60,
+      8,
+    );
+    // 8-char cap: 7 chars + "~", then "+"
+    expect(out.branchLabel).toBe(":feature~+");
+  });
+
+  it("shrinks the prefix with an ellipsis before touching the dirname", () => {
+    // budget forces the prefix to give up chars; dirname + branch stay whole
+    const out = fitProjectCell(base, 12, 24);
+    expect(out.dirname).toBe("ccmux");
+    expect(out.branchLabel).toBe(":main");
+    expect(out.prefix.endsWith("…")).toBe(true);
+    expect(
+      out.prefix.length + out.dirname.length + out.branchLabel.length,
+    ).toBe(12);
+  });
+
+  it("drops the prefix entirely when under 2 usable chars remain", () => {
+    // dirname(5) + branch(5) = 10 already fills the budget, no prefix room
+    const out = fitProjectCell(base, 10, 24);
+    expect(out.prefix).toBe("");
+    expect(out.dirname).toBe("ccmux");
+    expect(out.branchLabel).toBe(":main");
+  });
+
+  it("truncates the dirname with an ellipsis, keeping a floor", () => {
+    const out = fitProjectCell(
+      {
+        prefix: "",
+        dirname: "claude-toolkit",
+        branch: null,
+        isWorktree: false,
+      },
+      8,
+      24,
+    );
+    expect(out.dirname.endsWith("…")).toBe(true);
+    expect(out.dirname).not.toBe("claude-toolkit");
+    // floor keeps it identifiable, never a negative slice
+    expect(out.dirname.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("never produces negative slices on a zero/negative budget", () => {
+    const out = fitProjectCell(
+      {
+        prefix: "a/b/c/",
+        dirname: "very-long-dirname",
+        branch: "main",
+        isWorktree: false,
+      },
+      0,
+      24,
+    );
+    // Prefix collapses, dirname holds at its floor with an ellipsis (not a
+    // raw mid-word clip), and no slice went negative.
+    expect(out.prefix).toBe("");
+    expect(out.dirname.endsWith("…")).toBe(true);
+    expect(out.dirname.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("keeps a short dirname whole even when the budget is exhausted", () => {
+    const out = fitProjectCell(base, 0, 24);
+    // "ccmux" already sits at the floor, so it is shown in full (no fake `…`).
+    expect(out.dirname).toBe("ccmux");
+    expect(out.prefix).toBe("");
+  });
+
+  it("leaves a branch-less cell without a stray colon", () => {
+    const out = fitProjectCell(
+      { prefix: "", dirname: "app", branch: null, isWorktree: false },
+      20,
+      24,
+    );
+    expect(out.branchLabel).toBe("");
   });
 });

--- a/src/tui/components/session-columns.ts
+++ b/src/tui/components/session-columns.ts
@@ -481,6 +481,171 @@ export function rowHasPrompt(row: ResolvedRow): boolean {
   );
 }
 
+/** Max rendered width of an attention label before it is ellipsized. */
+export const ATTENTION_LABEL_MAX = 12;
+
+/**
+ * The row-1 attention label for a session (pending tool name, "Plan",
+ * "Permission", "Question"), or null when the row needs no attention marker.
+ * Pure and layout-owned so the shared column budget can reserve its width;
+ * the theme-dependent color stays in SessionItem (`getAttentionColor`).
+ */
+export function getAttentionLabel(session: EnrichedSession): string | null {
+  if (session.pendingTool) return session.pendingTool;
+  if (session.inPlanMode || session.attentionType === "plan_approval") {
+    return "Plan";
+  }
+  if (session.status !== "waiting") return null;
+  if (session.attentionType === "permission") return "Permission";
+  if (session.attentionType === "question") return "Question";
+  return null;
+}
+
+/**
+ * The row-1 "N Agent" subagent-count label, or null when it should not show.
+ * Hidden while a tool/plan attention marker is up (that takes the slot), and
+ * only present when the session has live subagents.
+ */
+export function subagentCountLabel(session: EnrichedSession): string | null {
+  if (
+    !session.pendingTool &&
+    !session.inPlanMode &&
+    session.subagents &&
+    session.subagents.length > 0
+  ) {
+    return `${session.subagents.length} Agent`;
+  }
+  return null;
+}
+
+/**
+ * Rendered width of row 1's trailing labels (attention + subagent count) for
+ * a session. SessionList folds this to a list-wide max so every row reserves
+ * an identical fixed-width cell and the path column can't misalign on waiting
+ * rows. Sidebar collapses the attention label to a single "!" and hides the
+ * subagent count.
+ */
+export function trailingLabelsWidth(
+  session: EnrichedSession,
+  sidebar: boolean,
+): number {
+  const attn = getAttentionLabel(session);
+  if (sidebar) return attn ? 1 : 0;
+  const sub = subagentCountLabel(session);
+  const attnW = attn ? Math.min(attn.length, ATTENTION_LABEL_MAX) : 0;
+  const subW = sub ? sub.length : 0;
+  const gap = attn && sub ? 1 : 0; // the space between the two labels
+  return attnW + subW + gap;
+}
+
+/** Split cwd parts plus branch state, fed to {@link fitProjectCell}. */
+export interface ProjectCellInput {
+  /** Path prefix (e.g. "epilande/"); pass "" in compact/dirname mode. */
+  prefix: string;
+  dirname: string;
+  branch: string | null;
+  isWorktree: boolean;
+}
+
+/** Display strings for the project cell after fitting to a width budget. */
+export interface ProjectCellDisplay {
+  prefix: string;
+  dirname: string;
+  /** ":"-prefixed branch (with the `~`/`+` conventions), or "" when no branch. */
+  branchLabel: string;
+}
+
+/** Slice `text` to at most `maxLen` chars, marking any cut with a trailing "…". */
+function sliceEllipsis(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, Math.max(1, maxLen - 1)) + "…";
+}
+
+/**
+ * The `:branch` label with the existing conventions: capped at `maxBranchLen`
+ * with a trailing `~`, worktree `+` appended.
+ */
+function branchLabelFor(
+  branch: string,
+  isWorktree: boolean,
+  maxBranchLen: number,
+): string {
+  const shown =
+    branch.length > maxBranchLen
+      ? branch.slice(0, maxBranchLen - 1) + "~"
+      : branch;
+  return ":" + shown + (isWorktree ? "+" : "");
+}
+
+/** Shorten a branch label to `avail` chars using the `~` marker; "" if too tight. */
+function shortenBranchLabel(
+  branch: string,
+  isWorktree: boolean,
+  avail: number,
+): string {
+  if (avail < 3) return ""; // no room for ":" plus a usable char
+  const wt = isWorktree ? "+" : "";
+  const bodyLen = Math.max(1, avail - 1 /* colon */ - 1 /* ~ */ - wt.length);
+  if (branch.length <= bodyLen) return ":" + branch + wt;
+  return ":" + branch.slice(0, bodyLen) + "~" + wt;
+}
+
+/**
+ * Fit the project (path:branch) cell into `budget` chars, never silently
+ * clipping: any shortening shows `…` (or the existing `~` for the branch).
+ * Shrink order matches the design: prefix first (drop it under 2 usable
+ * chars), then the dirname (kept to a small floor), then the branch as a last
+ * resort. When everything already fits, the rendering is unchanged.
+ */
+export function fitProjectCell(
+  input: ProjectCellInput,
+  budget: number,
+  maxBranchLen: number,
+): ProjectCellDisplay {
+  const { prefix, dirname, branch, isWorktree } = input;
+  let branchLabel = branch
+    ? branchLabelFor(branch, isWorktree, maxBranchLen)
+    : "";
+  const branchWidth = branchLabel.length;
+
+  if (prefix.length + dirname.length + branchWidth <= budget) {
+    return { prefix, dirname, branchLabel };
+  }
+
+  // 1. Shrink the prefix first: give it whatever is left after dirname+branch.
+  const availForPrefix = budget - dirname.length - branchWidth;
+  let outPrefix: string;
+  if (availForPrefix < 2) {
+    outPrefix = "";
+  } else if (prefix.length > availForPrefix) {
+    outPrefix = sliceEllipsis(prefix, availForPrefix);
+  } else {
+    outPrefix = prefix;
+  }
+  if (outPrefix.length + dirname.length + branchWidth <= budget) {
+    return { prefix: outPrefix, dirname, branchLabel };
+  }
+
+  // 2. Prefix minimal but dirname+branch still overflow: truncate the dirname,
+  //    keeping a small floor so it stays identifiable.
+  const DIRNAME_FLOOR = 5;
+  const availForDirname = budget - outPrefix.length - branchWidth;
+  const outDirname =
+    dirname.length <= availForDirname
+      ? dirname
+      : sliceEllipsis(dirname, Math.max(DIRNAME_FLOOR, availForDirname));
+  if (outPrefix.length + outDirname.length + branchWidth <= budget) {
+    return { prefix: outPrefix, dirname: outDirname, branchLabel };
+  }
+
+  // 3. Last resort: shorten the branch further with the `~` marker.
+  if (branch) {
+    const availForBranch = budget - outPrefix.length - outDirname.length;
+    branchLabel = shortenBranchLabel(branch, isWorktree, availForBranch);
+  }
+  return { prefix: outPrefix, dirname: outDirname, branchLabel };
+}
+
 /** Width allocated to a resolved entry on a "right side" (right-aligned column). */
 export function entryRightWidth(entry: ResolvedEntry): number {
   switch (entry.field) {

--- a/src/tui/components/session-columns.ts
+++ b/src/tui/components/session-columns.ts
@@ -559,7 +559,7 @@ export interface ProjectCellDisplay {
 }
 
 /** Slice `text` to at most `maxLen` chars, marking any cut with a trailing "…". */
-function sliceEllipsis(text: string, maxLen: number): string {
+export function sliceEllipsis(text: string, maxLen: number): string {
   if (text.length <= maxLen) return text;
   return text.slice(0, Math.max(1, maxLen - 1)) + "…";
 }

--- a/src/tui/components/session-columns.ts
+++ b/src/tui/components/session-columns.ts
@@ -520,10 +520,13 @@ export function subagentCountLabel(session: EnrichedSession): string | null {
 
 /**
  * Rendered width of row 1's trailing labels (attention + subagent count) for
- * a session. SessionList folds this to a list-wide max so every row reserves
- * an identical fixed-width cell and the path column can't misalign on waiting
- * rows. Sidebar collapses the attention label to a single "!" and hides the
- * subagent count.
+ * a session. Consumed per-row (see `attentionWidth` in SessionItem): each row
+ * reserves a cell sized to exactly its own labels, so an unlabeled row reserves
+ * nothing and its prompt runs to the right-side metadata, while a labeled row's
+ * prompt/project budgets subtract this width so the `…` truncation lands just
+ * before the label. Right-side column alignment is preserved by those columns'
+ * fixed widths, not by a uniform trailing cell. Sidebar collapses the attention
+ * label to a single "!" and hides the subagent count.
  */
 export function trailingLabelsWidth(
   session: EnrichedSession,


### PR DESCRIPTION
## Overview

Makes the row 1 attention label (pending tool, `Permission`, `Plan`) a budgeted part of the row layout and adds honest ellipsis truncation to the path:branch cell, so waiting rows no longer break the picker's column grid.

## Motivation

A session entering `waiting` gained a trailing label that no other row had. The label was injected outside the shared column structure, so flexbox took its width from the only shrinkable cell: the path. Three visible artifacts followed: the waiting row's path stopped lining up with its siblings, paths hard-clipped mid-word with no truncation marker (`epilande/ccmux` rendered as `epilandccmu`), and a dead whitespace band sat between the prompt and the label because the prompt's width budget didn't know the label existed.

## Screenshots

**Before**

<img width="1760" height="304" alt="Before" src="https://github.com/user-attachments/assets/30330569-cee1-46da-bd0a-2659894896d6" />

**After**

<img width="1760" height="304" alt="After" src="https://github.com/user-attachments/assets/1f9d00e6-2b52-4ff1-9542-6b61030b2f29" />

## Changes



### Layout

- **SessionItem.tsx** - Renders the attention label and subagent count in a cell sized to exactly its own content; adds a `maxProjectLen` budget for the path cell; feeds the per-row label width into `maxPromptLen` so the prompt truncates right where the label begins and unlabeled rows keep the full width; the path cell gives its flex squeeze to the prompt in inline mode so identity survives at the message's expense

### Pure helpers

- **session-columns.ts** - Adds `getAttentionLabel` (moved from SessionItem), `subagentCountLabel`, `trailingLabelsWidth`, a 12-char label cap, and `fitProjectCell`, which fits prefix/dirname/branch to a width budget and marks every cut with `…` (or the existing `~` for branches) so the path can never silently drop characters

### Tests

- **SessionList.test.tsx** - Agent column alignment across waiting + idle rows; idle prompts extend into the space a sibling's label occupies
- **SessionItem.test.tsx** - Label ellipsis past the cap; long paths at narrow widths render `…` instead of mid-word clips
- **session-columns.test.ts** - Unit coverage for the shrink cascade's edge cases (exact fit, prefix drop, dirname floor, zero/negative budgets)

## Breaking Changes

None

## Testing

- [x] Unit tests pass (2232 tests, 110 files)
- [x] `bun run typecheck` clean
- [x] Live picker verified in a detached tmux session at 200/120/80 cols, both `inline` and `row2` prompt display modes
- [x] A real agent driven into `waiting [permission]` to exercise the label path end to end