### PR TITLE
fix(daemon): Ensure config dir exists before opening daemon log

### DIFF
--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -1,4 +1,12 @@
-import { readFileSync, unlinkSync, existsSync, openSync, closeSync } from "fs";
+import {
+  readFileSync,
+  unlinkSync,
+  existsSync,
+  openSync,
+  closeSync,
+  mkdirSync,
+} from "fs";
+import { dirname } from "path";
 import { spawn } from "child_process";
 import {
   LOG_FILE,
@@ -201,6 +209,7 @@ export function isStandaloneBinary(
  * Spawn daemon process in background (detached)
  */
 export function spawnDaemonBackground(): void {
+  mkdirSync(dirname(LOG_FILE), { recursive: true });
   const logFd = openSync(LOG_FILE, "a");
   const daemonArgs = isStandaloneBinary(process.argv[1])
     ? ["daemon", "start"]


### PR DESCRIPTION
Saw your post on reddit, seems like your tool is exactly what i need.  But it crashes on a fresh install (no `~/.config/ccmux/` yet), `spawnDaemonBackground` crashed with `ENOENT` when opening `ccmux.log`:

```
Starting daemon...
ENOENT: no such file or directory, open '/Users/eric/.config/ccmux/ccmux.log'
```

Create the log file's directory (recursive) before `openSync`, mirroring what `redirectStdioToLogFile` in `log-redirect.ts` already does.