### PR TITLE
fix(daemon): use `lsof -Ffn` so cwd resolution works on lsof 4.99+

### DIFF
--- a/src/daemon/processes.ts
+++ b/src/daemon/processes.ts
@@ -197,7 +197,13 @@ export async function discoverAgentProcesses(
 
 /**
  * Batch get working directories for multiple processes in a single lsof call
- * Parses lsof -Fn output format: p<pid>, fcwd, n<path>
+ * Parses lsof -Ffn output format: p<pid>, fcwd, n<path>
+ *
+ * The `f` field selector is required: lsof 4.99+ (e.g. the Nix build) emits no
+ * fd-type lines for a bare `-Fn`, so `fcwd` never appears and every cwd lookup
+ * silently fails (0 sessions ever get a cwd → nothing binds to a pane). Older
+ * builds (macOS system lsof) include `f` even with `-Fn`, which is why this
+ * only bites on some setups. `-Ffn` is correct on both.
  */
 async function batchGetProcessCwds(
   pids: number[],
@@ -208,7 +214,7 @@ async function batchGetProcessCwds(
   try {
     const pidList = pids.join(",");
     DaemonPerf.incSubprocessSpawn("lsof-cwds");
-    const proc = Bun.spawn(["lsof", "-p", pidList, "-Fn"], {
+    const proc = Bun.spawn(["lsof", "-p", pidList, "-Ffn"], {
       stdout: "pipe",
       stderr: "pipe",
     });


### PR DESCRIPTION
Fixes #7.

## Problem

`batchGetProcessCwds` runs `lsof -p <pids> -Fn` and keys the working dir off an `fcwd` fd-type line. **lsof 4.99+** (e.g. the Nix build, or any setup where a newer lsof is first on `PATH`) emits *no* fd-type lines for a bare `-Fn`, so `fcwd` never appears, every process cwd resolves to `undefined`, and no session ever binds to a tmux pane — `ccmux debug` shows `Tracked Sessions (0 from daemon)` with every process under `CWD lookup failed (lsof returned no result)`. Older builds (macOS system lsof) include the `f` field even with `-Fn`, which is why it only bites some setups.

```console
$ /nix/store/…/lsof-4.99.6/bin/lsof -p <pid> -Fn  | grep -c '^fcwd'   # 0
$ /nix/store/…/lsof-4.99.6/bin/lsof -p <pid> -Ffn | grep -c '^fcwd'   # 1
$ /usr/sbin/lsof            -p <pid> -Fn  | grep -c '^fcwd'           # 1
```

## Fix

Select the fd field explicitly with `-Ffn` — correct on both old and new lsof. The `.jsonl`-matching call in `getLsofLines` only reads `n` lines and is unaffected.

Verified locally: took the daemon from 0 tracked sessions to all live sessions correctly bound to their panes.
