### PR TITLE
feat: watch multiple Claude config dirs (CLAUDE_CONFIG_DIR) in one instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ ccmux config list
 | `groupBy`           | `project`, `cwd`, `session`, `window`, `none`                                | `project`          | How sessions are grouped in the TUI                             |
 | `promptDisplay`     | `inline`, `row2`, `off`                                                      | `inline`           | Prompt display: inline on row 1, its own row, or hidden         |
 | `backgroundAgents`  | `true`, `false`                                                              | `true`             | Show Claude background agents as rows (daemon restart required) |
+| `claudeConfigDirs`  | array of paths                                                               | `[]`               | Extra Claude config dirs to watch beyond `~/.claude` (daemon restart required; see [Multiple Claude Config Dirs](#-multiple-claude-config-dirs)) |
 | `searchPaneContent` | `true`, `false`                                                              | `true`             | Include captured pane content in TUI search                     |
 | `persistent`        | `true`, `false`                                                              | `false`            | Keep picker open after switching sessions (dashboard mode)      |
 | `sidebar.width`     | `10`–`80`                                                                    | `30`               | Sidebar pane width in columns                                   |
@@ -364,6 +365,31 @@ An unknown base name falls back to the default theme; an invalid hex value or un
 
 > [!NOTE]
 > ccmux paints no background fill, so theme colors sit on your terminal's own background. The light palettes (`catppuccin-latte`, `tokyo-night-day`, `gruvbox-light`, `rose-pine-dawn`) assume a light terminal; pair them with a light background. Every other palette assumes a dark one.
+
+### 🗂️ Multiple Claude Config Dirs
+
+Claude Code writes its session transcripts to `$CLAUDE_CONFIG_DIR/projects` (default `~/.claude/projects`). If you run more than one Claude account — e.g. a work login in `~/.claude` and a personal one launched with `CLAUDE_CONFIG_DIR=~/.claude-personal` — sessions from the non-default account land in a separate `projects` tree that ccmux doesn't watch by default, so they never show up in the TUI even though their hooks fire correctly.
+
+Add the extra config dirs to `claudeConfigDirs` and ccmux watches every `<dir>/projects` tree from a single daemon, the same way it fans out across agents:
+
+```jsonc
+// ~/.config/ccmux/ccmux.json
+{
+  "claudeConfigDirs": ["~/.claude-personal"]
+}
+```
+
+```bash
+ccmux config set claudeConfigDirs '["~/.claude-personal"]'
+ccmux daemon restart
+```
+
+Notes:
+
+- `~/.claude` is always watched; entries here are **additional** Claude config dirs (their `projects` subdir is watched). Paths may start with `~`.
+- The `CLAUDE_CONFIG_DIR` environment variable, if set, is honored too and added automatically.
+- Sessions are keyed by their (globally unique) session ID, so the same project opened under two accounts coexists without collision.
+- Install the Claude hooks (`ccmux setup`) for each config dir you want authoritative session matching in — hooks are resolved per `CLAUDE_CONFIG_DIR`.
 
 ## 🔗 Session Matching with Hooks
 

--- a/README.md
+++ b/README.md
@@ -384,12 +384,18 @@ ccmux config set claudeConfigDirs '["~/.claude-personal"]'
 ccmux daemon restart
 ```
 
+Then install hooks into every configured dir so sessions from each account are matched authoritatively:
+
+```bash
+ccmux setup --agent claude   # fans out to ~/.claude and every claudeConfigDirs entry
+```
+
 Notes:
 
 - `~/.claude` is always watched; entries here are **additional** Claude config dirs (their `projects` subdir is watched). Paths may start with `~`.
 - The `CLAUDE_CONFIG_DIR` environment variable, if set, is honored too and added automatically.
 - Sessions are keyed by their (globally unique) session ID, so the same project opened under two accounts coexists without collision.
-- Install the Claude hooks (`ccmux setup`) for each config dir you want authoritative session matching in — hooks are resolved per `CLAUDE_CONFIG_DIR`.
+- `ccmux setup` installs the hook scripts and `settings.json` entries into **all** configured Claude dirs. Configure `claudeConfigDirs` first, then run setup. If you add a dir later, re-run setup — the daemon warns at startup about any configured dir still missing hooks.
 
 ## 🔗 Session Matching with Hooks
 

--- a/README.md
+++ b/README.md
@@ -258,21 +258,21 @@ ccmux config get <key>
 ccmux config list
 ```
 
-| Key                 | Values                                                                       | Default            | Description                                                     |
-| :------------------ | :--------------------------------------------------------------------------- | :----------------- | :-------------------------------------------------------------- |
-| `iconStyle`         | `dot`, `emoji`, `nerdfont`, `none`                                           | `dot`              | Status icon style                                               |
-| `theme`             | `catppuccin-*`, `tokyo-night*`, `dracula`, `gruvbox-*`, `nord`, `rose-pine*` | `catppuccin-mocha` | TUI color theme (resolved at launch; see [Theme](#-theme))      |
-| `showPreview`       | `true`, `false`                                                              | `false`            | Show preview panel on launch                                    |
-| `previewWidth`      | `20`–`80`                                                                    | `40`               | Preview panel width (percentage)                                |
-| `command`           | any non-blank string                                                         | `claude`           | CLI command used for session restart                            |
-| `groupBy`           | `project`, `cwd`, `session`, `window`, `none`                                | `project`          | How sessions are grouped in the TUI                             |
-| `promptDisplay`     | `inline`, `row2`, `off`                                                      | `inline`           | Prompt display: inline on row 1, its own row, or hidden         |
-| `backgroundAgents`  | `true`, `false`                                                              | `true`             | Show Claude background agents as rows (daemon restart required) |
+| Key                 | Values                                                                       | Default            | Description                                                                                                                                      |
+| :------------------ | :--------------------------------------------------------------------------- | :----------------- | :----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `iconStyle`         | `dot`, `emoji`, `nerdfont`, `none`                                           | `dot`              | Status icon style                                                                                                                                |
+| `theme`             | `catppuccin-*`, `tokyo-night*`, `dracula`, `gruvbox-*`, `nord`, `rose-pine*` | `catppuccin-mocha` | TUI color theme (resolved at launch; see [Theme](#-theme))                                                                                       |
+| `showPreview`       | `true`, `false`                                                              | `false`            | Show preview panel on launch                                                                                                                     |
+| `previewWidth`      | `20`–`80`                                                                    | `40`               | Preview panel width (percentage)                                                                                                                 |
+| `command`           | any non-blank string                                                         | `claude`           | CLI command used for session restart                                                                                                             |
+| `groupBy`           | `project`, `cwd`, `session`, `window`, `none`                                | `project`          | How sessions are grouped in the TUI                                                                                                              |
+| `promptDisplay`     | `inline`, `row2`, `off`                                                      | `inline`           | Prompt display: inline on row 1, its own row, or hidden                                                                                          |
+| `backgroundAgents`  | `true`, `false`                                                              | `true`             | Show Claude background agents as rows (daemon restart required)                                                                                  |
 | `claudeConfigDirs`  | array of paths                                                               | `[]`               | Extra Claude config dirs to watch beyond `~/.claude` (daemon restart required; see [Multiple Claude Config Dirs](#-multiple-claude-config-dirs)) |
-| `searchPaneContent` | `true`, `false`                                                              | `true`             | Include captured pane content in TUI search                     |
-| `persistent`        | `true`, `false`                                                              | `false`            | Keep picker open after switching sessions (dashboard mode)      |
-| `sidebar.width`     | `10`–`80`                                                                    | `30`               | Sidebar pane width in columns                                   |
-| `sidebar.position`  | `left`, `right`                                                              | `left`             | Which side of the window to place the sidebar                   |
+| `searchPaneContent` | `true`, `false`                                                              | `true`             | Include captured pane content in TUI search                                                                                                      |
+| `persistent`        | `true`, `false`                                                              | `false`            | Keep picker open after switching sessions (dashboard mode)                                                                                       |
+| `sidebar.width`     | `10`–`80`                                                                    | `30`               | Sidebar pane width in columns                                                                                                                    |
+| `sidebar.position`  | `left`, `right`                                                              | `left`             | Which side of the window to place the sidebar                                                                                                    |
 
 ### 📊 Column Configuration
 
@@ -370,24 +370,17 @@ An unknown base name falls back to the default theme; an invalid hex value or un
 
 Claude Code writes its session transcripts to `$CLAUDE_CONFIG_DIR/projects` (default `~/.claude/projects`). If you run more than one Claude account — e.g. a work login in `~/.claude` and a personal one launched with `CLAUDE_CONFIG_DIR=~/.claude-personal` — sessions from the non-default account land in a separate `projects` tree that ccmux doesn't watch by default, so they never show up in the TUI even though their hooks fire correctly.
 
-Add the extra config dirs to `claudeConfigDirs` and ccmux watches every `<dir>/projects` tree from a single daemon, the same way it fans out across agents:
+Add the extra config dirs to `claudeConfigDirs` in `~/.config/ccmux/ccmux.json` and ccmux watches every `<dir>/projects` tree from a single daemon, the same way it fans out across agents:
 
-```jsonc
-// ~/.config/ccmux/ccmux.json
-{
-  "claudeConfigDirs": ["~/.claude-personal"]
-}
+```json
+{ "claudeConfigDirs": ["~/.claude-personal"] }
 ```
 
-```bash
-ccmux config set claudeConfigDirs '["~/.claude-personal"]'
-ccmux daemon restart
-```
-
-Then install hooks into every configured dir so sessions from each account are matched authoritatively:
+Then install hooks into every configured dir so sessions from each account are matched authoritatively, and restart the daemon to pick up the new dirs:
 
 ```bash
 ccmux setup --agent claude   # fans out to ~/.claude and every claudeConfigDirs entry
+ccmux daemon restart
 ```
 
 Notes:

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -56,7 +56,7 @@ The startup-race closer for markers written before the first scan created the pa
 
 ### Agent-owned (read-only except during `ccmux setup`)
 
-- Claude Code logs: `~/.claude/projects/<encoded-path>/<sessionId>.jsonl`
+- Claude Code logs: `~/.claude/projects/<encoded-path>/<sessionId>.jsonl` (plus any extra config dirs from the `claudeConfigDirs` preference / `CLAUDE_CONFIG_DIR`, each watched at `<dir>/projects`)
 - Claude Code history: `~/.claude/history.jsonl`
 - Claude Code settings: `~/.claude/settings.json` (written by `ccmux setup --agent claude`)
 - Claude Code hooks: `~/.claude/hooks/ccmux-session-start.sh`, `ccmux-session-end.sh`, `ccmux-state-notify.sh`

--- a/src/daemon/adapters/claude/hook-adapter.test.ts
+++ b/src/daemon/adapters/claude/hook-adapter.test.ts
@@ -266,6 +266,53 @@ describe("ClaudeHookAdapter", () => {
     });
   });
 
+  describe("marker routing across watchers", () => {
+    function fakeWatcher(ownedId: string | null) {
+      return {
+        ownsSession: (id: string) => id === ownedId,
+        added: [] as string[],
+        removed: [] as string[],
+        handleMarkerAdded(m: { session_id: string }) {
+          this.added.push(m.session_id);
+        },
+        handleMarkerRemoved(m: { session_id: string }) {
+          this.removed.push(m.session_id);
+        },
+      };
+    }
+    function ctxWith(watchers: unknown[]) {
+      return { getLogWatchers: () => watchers } as never;
+    }
+    const marker = { session_id: "sess-personal" } as never;
+
+    it("routes to the watcher whose tree owns the session", async () => {
+      const primary = fakeWatcher(null);
+      const secondary = fakeWatcher("sess-personal");
+      const ctx = ctxWith([primary, secondary]);
+
+      await adapter.onMarkerAdded(marker, ctx);
+      await adapter.onMarkerRemoved(marker, ctx);
+
+      expect(secondary.added).toEqual(["sess-personal"]);
+      expect(secondary.removed).toEqual(["sess-personal"]);
+      expect(primary.added).toEqual([]);
+      expect(primary.removed).toEqual([]);
+    });
+
+    it("falls back to the primary watcher when no tree owns the session yet", async () => {
+      const primary = fakeWatcher(null);
+      const secondary = fakeWatcher(null);
+      const ctx = ctxWith([primary, secondary]);
+
+      await adapter.onMarkerAdded(marker, ctx);
+      await adapter.onMarkerRemoved(marker, ctx);
+
+      expect(primary.added).toEqual(["sess-personal"]);
+      expect(primary.removed).toEqual(["sess-personal"]);
+      expect(secondary.added).toEqual([]);
+    });
+  });
+
   describe("uninstall preserves user-owned hooks", () => {
     it("removes ccmux entries but leaves user-authored entries in the same slot", async () => {
       await adapter.install();

--- a/src/daemon/adapters/claude/hook-adapter.test.ts
+++ b/src/daemon/adapters/claude/hook-adapter.test.ts
@@ -20,6 +20,13 @@ const projectsDir = join(claudeDir, "projects");
 const settingsFile = join(claudeDir, "settings.json");
 const markersDir = join(tempRoot, "markers");
 
+// A second configured Claude config dir (e.g. ~/.claude-personal), used by the
+// fan-out tests. `mockedConfigDirs` is what the adapter sees; tests mutate it
+// and beforeEach resets it to just the primary dir.
+const claudeDir2 = join(tempRoot, ".claude-personal");
+const settingsFile2 = join(claudeDir2, "settings.json");
+let mockedConfigDirs = [claudeDir];
+
 const actualConfig = await import("../../../lib/config");
 mock.module("../../../lib/config", () => ({
   ...actualConfig,
@@ -28,6 +35,13 @@ mock.module("../../../lib/config", () => ({
   PROJECTS_DIR: projectsDir,
   SETTINGS_FILE: settingsFile,
   MARKERS_DIR: markersDir,
+  // The adapter resolves its target dirs through these helpers, whose real
+  // implementations close over the real CLAUDE_DIR (unaffected by the
+  // constant overrides above). Pin them to temp dirs so install/uninstall
+  // never touch the real ~/.claude (or configured extra dirs).
+  resolveClaudeConfigDirs: () => mockedConfigDirs,
+  resolveClaudeProjectDirs: () =>
+    mockedConfigDirs.map((d) => join(d, "projects")),
 }));
 
 import { ClaudeHookAdapter } from "./hook-adapter";
@@ -43,6 +57,7 @@ describe("ClaudeHookAdapter", () => {
   beforeEach(() => {
     rmSync(tempRoot, { recursive: true, force: true });
     mkdirSync(tempRoot, { recursive: true });
+    mockedConfigDirs = [claudeDir];
     adapter = new ClaudeHookAdapter();
   });
 
@@ -207,6 +222,47 @@ describe("ClaudeHookAdapter", () => {
       mkdirSync(claudeDir, { recursive: true });
       writeFileSync(settingsFile, "{ not valid json");
       expect(adapter.isInstalled()).toBe(false);
+    });
+  });
+
+  describe("multiple config dirs", () => {
+    function ccmuxInstalledIn(file: string): boolean {
+      if (!existsSync(file)) return false;
+      const settings = JSON.parse(readFileSync(file, "utf-8"));
+      const start = settings?.hooks?.SessionStart ?? [];
+      return start.some((g: { hooks?: { command?: string }[] }) =>
+        g.hooks?.some((h) => h.command?.includes("ccmux-session-start.sh")),
+      );
+    }
+
+    it("install fans out hooks to every configured config dir", async () => {
+      mockedConfigDirs = [claudeDir, claudeDir2];
+      await adapter.install();
+      expect(ccmuxInstalledIn(settingsFile)).toBe(true);
+      expect(ccmuxInstalledIn(settingsFile2)).toBe(true);
+      expect(
+        existsSync(join(claudeDir2, "hooks", "ccmux-session-start.sh")),
+      ).toBe(true);
+    });
+
+    it("uninstall removes hooks from every configured config dir", async () => {
+      mockedConfigDirs = [claudeDir, claudeDir2];
+      await adapter.install();
+      await adapter.uninstall();
+      expect(ccmuxInstalledIn(settingsFile)).toBe(false);
+      expect(ccmuxInstalledIn(settingsFile2)).toBe(false);
+    });
+
+    it("isInstalled tracks only the primary dir; extras surface as anomalies", async () => {
+      // Only the primary dir has hooks installed.
+      mockedConfigDirs = [claudeDir];
+      await adapter.install();
+      // Now a second dir is configured but not yet set up.
+      mockedConfigDirs = [claudeDir, claudeDir2];
+      expect(adapter.isInstalled()).toBe(true);
+      const anomalies = adapter.describeInstallAnomalies?.() ?? [];
+      expect(anomalies.length).toBe(1);
+      expect(anomalies[0]).toContain(claudeDir2);
     });
   });
 

--- a/src/daemon/adapters/claude/hook-adapter.ts
+++ b/src/daemon/adapters/claude/hook-adapter.ts
@@ -9,11 +9,8 @@ import {
   writeFileSync,
 } from "fs";
 import { join } from "path";
-import {
-  CLAUDE_HOOKS_DIR as HOOKS_DIR,
-  MARKERS_DIR,
-  SETTINGS_FILE,
-} from "../../../lib/config";
+import { MARKERS_DIR, resolveClaudeConfigDirs } from "../../../lib/config";
+import { getPreferences, getPreferencesSync } from "../../../lib/preferences";
 import {
   SESSION_END_HOOK_SCRIPT,
   SESSION_START_HOOK_SCRIPT,
@@ -25,6 +22,14 @@ import type {
   HookManagerContext,
 } from "../../hook-adapter";
 import type { SessionPidMarker } from "../../session-markers";
+
+/** Per-config-dir paths ccmux reads/writes for Claude hook integration. */
+function hooksDirFor(configDir: string): string {
+  return join(configDir, "hooks");
+}
+function settingsFileFor(configDir: string): string {
+  return join(configDir, "settings.json");
+}
 
 const SESSION_START_SCRIPT = "ccmux-session-start.sh";
 const SESSION_END_SCRIPT = "ccmux-session-end.sh";
@@ -62,8 +67,27 @@ export class ClaudeHookAdapter implements HookAdapter {
     const lines: string[] = [];
     let changed = false;
 
-    mkdirSync(HOOKS_DIR, { recursive: true });
     mkdirSync(MARKERS_DIR, { recursive: true });
+
+    // Fan out across every configured Claude config dir so a second account
+    // (via CLAUDE_CONFIG_DIR / the `claudeConfigDirs` preference) gets hooks
+    // too, not just the default ~/.claude.
+    const configDirs = resolveClaudeConfigDirs(
+      (await getPreferences()).claudeConfigDirs,
+    );
+    for (const dir of configDirs) {
+      changed = this.installIntoDir(dir, lines) || changed;
+    }
+
+    return { lines, changed };
+  }
+
+  private installIntoDir(configDir: string, lines: string[]): boolean {
+    let changed = false;
+    const hooksDir = hooksDirFor(configDir);
+    const settingsFile = settingsFileFor(configDir);
+
+    mkdirSync(hooksDir, { recursive: true });
 
     const scripts = [
       { name: SESSION_START_SCRIPT, content: SESSION_START_HOOK_SCRIPT },
@@ -71,7 +95,7 @@ export class ClaudeHookAdapter implements HookAdapter {
       { name: STATE_NOTIFY_SCRIPT, content: STATE_NOTIFY_HOOK_SCRIPT },
     ] as const;
     for (const { name, content } of scripts) {
-      const path = join(HOOKS_DIR, name);
+      const path = join(hooksDir, name);
       const existed = existsSync(path);
       const current = existed ? readFileSync(path, "utf-8") : null;
       if (current === content) {
@@ -85,9 +109,9 @@ export class ClaudeHookAdapter implements HookAdapter {
     }
 
     let settings: ClaudeSettings = {};
-    const settingsExisted = existsSync(SETTINGS_FILE);
+    const settingsExisted = existsSync(settingsFile);
     if (settingsExisted) {
-      settings = JSON.parse(readFileSync(SETTINGS_FILE, "utf-8"));
+      settings = JSON.parse(readFileSync(settingsFile, "utf-8"));
     }
 
     const hookSlots: Array<{
@@ -110,7 +134,7 @@ export class ClaudeHookAdapter implements HookAdapter {
         settings,
         slot,
         matcher,
-        join(HOOKS_DIR, script),
+        join(hooksDir, script),
         lines,
       );
       settingsChanged ||= added;
@@ -118,62 +142,27 @@ export class ClaudeHookAdapter implements HookAdapter {
 
     if (settingsChanged) {
       if (settingsExisted) {
-        const backupPath = `${SETTINGS_FILE}.backup`;
-        copyFileSync(SETTINGS_FILE, backupPath);
+        const backupPath = `${settingsFile}.backup`;
+        copyFileSync(settingsFile, backupPath);
         lines.push(`Backed up settings to ${backupPath}`);
       }
-      writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2) + "\n");
-      lines.push(`Updated ${SETTINGS_FILE}`);
+      writeFileSync(settingsFile, JSON.stringify(settings, null, 2) + "\n");
+      lines.push(`Updated ${settingsFile}`);
       changed = true;
     }
 
-    return { lines, changed };
+    return changed;
   }
 
   async uninstall(): Promise<HookAdapterOutcome> {
     const lines: string[] = [];
     let changed = false;
 
-    if (existsSync(SETTINGS_FILE)) {
-      const settings: ClaudeSettings = JSON.parse(
-        readFileSync(SETTINGS_FILE, "utf-8"),
-      );
-
-      const removedStart = removeHook(
-        settings,
-        "SessionStart",
-        SESSION_START_SCRIPT,
-      );
-      const removedEnd = removeHook(settings, "SessionEnd", SESSION_END_SCRIPT);
-      const removedNotify = removeHook(
-        settings,
-        "Notification",
-        STATE_NOTIFY_SCRIPT,
-      );
-      const removed = removedStart || removedEnd || removedNotify;
-
-      if (settings.hooks && Object.keys(settings.hooks).length === 0) {
-        delete settings.hooks;
-      }
-
-      if (removed) {
-        writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2) + "\n");
-        lines.push(`Removed hooks from ${SETTINGS_FILE}`);
-        changed = true;
-      }
-    }
-
-    for (const script of [
-      SESSION_START_SCRIPT,
-      SESSION_END_SCRIPT,
-      STATE_NOTIFY_SCRIPT,
-    ]) {
-      const scriptPath = join(HOOKS_DIR, script);
-      if (existsSync(scriptPath)) {
-        unlinkSync(scriptPath);
-        lines.push(`Removed ${scriptPath}`);
-        changed = true;
-      }
+    const configDirs = resolveClaudeConfigDirs(
+      (await getPreferences()).claudeConfigDirs,
+    );
+    for (const dir of configDirs) {
+      changed = this.uninstallFromDir(dir, lines) || changed;
     }
 
     if (existsSync(MARKERS_DIR)) {
@@ -196,18 +185,80 @@ export class ClaudeHookAdapter implements HookAdapter {
     return { lines, changed };
   }
 
-  isInstalled(): boolean {
-    if (!existsSync(SETTINGS_FILE)) return false;
-    try {
-      const settings = JSON.parse(readFileSync(SETTINGS_FILE, "utf-8"));
-      const startHooks = settings?.hooks?.SessionStart;
-      if (!Array.isArray(startHooks)) return false;
-      return startHooks.some((h: { hooks?: { command?: string }[] }) =>
-        h.hooks?.some((hook) => hook.command?.includes(SESSION_START_SCRIPT)),
+  private uninstallFromDir(configDir: string, lines: string[]): boolean {
+    let changed = false;
+    const settingsFile = settingsFileFor(configDir);
+    const hooksDir = hooksDirFor(configDir);
+
+    if (existsSync(settingsFile)) {
+      const settings: ClaudeSettings = JSON.parse(
+        readFileSync(settingsFile, "utf-8"),
       );
-    } catch {
-      return false;
+
+      const removedStart = removeHook(
+        settings,
+        "SessionStart",
+        SESSION_START_SCRIPT,
+      );
+      const removedEnd = removeHook(settings, "SessionEnd", SESSION_END_SCRIPT);
+      const removedNotify = removeHook(
+        settings,
+        "Notification",
+        STATE_NOTIFY_SCRIPT,
+      );
+      const removed = removedStart || removedEnd || removedNotify;
+
+      if (settings.hooks && Object.keys(settings.hooks).length === 0) {
+        delete settings.hooks;
+      }
+
+      if (removed) {
+        writeFileSync(settingsFile, JSON.stringify(settings, null, 2) + "\n");
+        lines.push(`Removed hooks from ${settingsFile}`);
+        changed = true;
+      }
     }
+
+    for (const script of [
+      SESSION_START_SCRIPT,
+      SESSION_END_SCRIPT,
+      STATE_NOTIFY_SCRIPT,
+    ]) {
+      const scriptPath = join(hooksDir, script);
+      if (existsSync(scriptPath)) {
+        unlinkSync(scriptPath);
+        lines.push(`Removed ${scriptPath}`);
+        changed = true;
+      }
+    }
+
+    return changed;
+  }
+
+  // Installed status tracks the primary `~/.claude` dir, which drives the
+  // daemon's single global runtime mode; keying it off an unconfigured extra
+  // dir could flip the whole daemon to no-hooks. Coverage gaps in extra
+  // configured dirs surface via `describeInstallAnomalies` instead.
+  isInstalled(): boolean {
+    const [primary] = resolveClaudeConfigDirs(
+      getPreferencesSync().claudeConfigDirs,
+    );
+    return isInstalledInDir(primary);
+  }
+
+  // Warn (at daemon startup and in `ccmux setup` status) when a configured
+  // Claude dir beyond the primary is missing hooks — those sessions won't be
+  // tracked authoritatively until `ccmux setup` is re-run.
+  describeInstallAnomalies(): string[] {
+    const [, ...extra] = resolveClaudeConfigDirs(
+      getPreferencesSync().claudeConfigDirs,
+    );
+    return extra
+      .filter((dir) => !isInstalledInDir(dir))
+      .map(
+        (dir) =>
+          `configured Claude dir missing hooks: ${dir} — run \`ccmux setup --agent claude\``,
+      );
   }
 
   // Claude does not write the per-session JSONL until the user submits the
@@ -230,6 +281,21 @@ export class ClaudeHookAdapter implements HookAdapter {
     ctx: HookManagerContext,
   ): Promise<void> {
     ctx.getLogWatcher(this.agentType)?.handleMarkerRemoved(marker);
+  }
+}
+
+function isInstalledInDir(configDir: string): boolean {
+  const settingsFile = settingsFileFor(configDir);
+  if (!existsSync(settingsFile)) return false;
+  try {
+    const settings = JSON.parse(readFileSync(settingsFile, "utf-8"));
+    const startHooks = settings?.hooks?.SessionStart;
+    if (!Array.isArray(startHooks)) return false;
+    return startHooks.some((h: { hooks?: { command?: string }[] }) =>
+      h.hooks?.some((hook) => hook.command?.includes(SESSION_START_SCRIPT)),
+    );
+  } catch {
+    return false;
   }
 }
 

--- a/src/daemon/adapters/claude/hook-adapter.ts
+++ b/src/daemon/adapters/claude/hook-adapter.ts
@@ -22,6 +22,7 @@ import type {
   HookManagerContext,
 } from "../../hook-adapter";
 import type { SessionPidMarker } from "../../session-markers";
+import type { LogWatcher } from "../../watcher";
 
 /** Per-config-dir paths ccmux reads/writes for Claude hook integration. */
 function hooksDirFor(configDir: string): string {
@@ -76,7 +77,13 @@ export class ClaudeHookAdapter implements HookAdapter {
       (await getPreferences()).claudeConfigDirs,
     );
     for (const dir of configDirs) {
-      changed = this.installIntoDir(dir, lines) || changed;
+      // Isolate each dir: a malformed settings.json in one must not abort the
+      // fan-out (which would leave orphan scripts and skip later dirs).
+      try {
+        changed = this.installIntoDir(dir, lines) || changed;
+      } catch (error) {
+        lines.push(`Failed to install hooks in ${dir}: ${errorMessage(error)}`);
+      }
     }
 
     return { lines, changed };
@@ -162,7 +169,13 @@ export class ClaudeHookAdapter implements HookAdapter {
       (await getPreferences()).claudeConfigDirs,
     );
     for (const dir of configDirs) {
-      changed = this.uninstallFromDir(dir, lines) || changed;
+      // Isolate each dir so one malformed settings.json can't skip the others
+      // or the marker cleanup below.
+      try {
+        changed = this.uninstallFromDir(dir, lines) || changed;
+      } catch (error) {
+        lines.push(`Failed to remove hooks in ${dir}: ${errorMessage(error)}`);
+      }
     }
 
     if (existsSync(MARKERS_DIR)) {
@@ -273,15 +286,34 @@ export class ClaudeHookAdapter implements HookAdapter {
     marker: SessionPidMarker,
     ctx: HookManagerContext,
   ): Promise<void> {
-    ctx.getLogWatcher(this.agentType)?.handleMarkerAdded(marker);
+    this.ownerFor(marker, ctx)?.handleMarkerAdded(marker);
   }
 
   async onMarkerRemoved(
     marker: SessionPidMarker,
     ctx: HookManagerContext,
   ): Promise<void> {
-    ctx.getLogWatcher(this.agentType)?.handleMarkerRemoved(marker);
+    this.ownerFor(marker, ctx)?.handleMarkerRemoved(marker);
   }
+
+  // Route a marker to the Claude watcher whose log tree owns the session, so
+  // a second-account session (in an extra config dir) re-arms / tears down on
+  // its own watcher instead of no-oping against the primary. Falls back to the
+  // primary watcher for sessions no tree has discovered yet (e.g. pane-migrated
+  // with no transcript on disk), preserving single-dir behavior.
+  private ownerFor(
+    marker: SessionPidMarker,
+    ctx: HookManagerContext,
+  ): LogWatcher | undefined {
+    const watchers = ctx.getLogWatchers(this.agentType);
+    return (
+      watchers.find((w) => w.ownsSession(marker.session_id)) ?? watchers[0]
+    );
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isInstalledInDir(configDir: string): boolean {

--- a/src/daemon/adapters/claude/log-adapter.ts
+++ b/src/daemon/adapters/claude/log-adapter.ts
@@ -52,7 +52,7 @@ function capStaleWorking(state: SessionState): SessionState {
  */
 export class ClaudeLogAdapter implements LogAdapter {
   readonly agentType = "claude";
-  readonly logDirGlob = PROJECTS_DIR;
+  readonly logDirGlob: string;
   readonly watchDepth = 1;
 
   private sessionManager: SessionManager;
@@ -61,8 +61,16 @@ export class ClaudeLogAdapter implements LogAdapter {
   private watchedSubagentDirs = new Set<string>();
   private subagentFileOffsets = new Map<string, number>();
 
-  constructor(sessionManager: SessionManager) {
+  // `projectsDir` defaults to the primary `~/.claude/projects`. A second
+  // instance pointed at another Claude config dir's `projects` tree (e.g.
+  // `~/.claude-personal/projects`) lets one daemon watch multiple accounts;
+  // see `resolveClaudeProjectDirs`.
+  constructor(
+    sessionManager: SessionManager,
+    projectsDir: string = PROJECTS_DIR,
+  ) {
     this.sessionManager = sessionManager;
+    this.logDirGlob = projectsDir;
   }
 
   resolveSessionIdFromPath(path: string): string | null {

--- a/src/daemon/adapters/codex/hook-adapter.test.ts
+++ b/src/daemon/adapters/codex/hook-adapter.test.ts
@@ -424,6 +424,8 @@ describe("CodexHookAdapter", () => {
         } as never,
         getLogWatcher: (agentType: string) =>
           agentType === "codex" ? (logWatcherSpy as never) : undefined,
+        getLogWatchers: (agentType: string) =>
+          agentType === "codex" ? [logWatcherSpy as never] : [],
         listProcesses: async () => [] as never,
         listPanes: async () => panes as never,
         getPaneHostingPid: async () => null,
@@ -608,6 +610,7 @@ describe("CodexHookAdapter", () => {
           ({
             processPath: async (p: string) => void processed.push(p),
           }) as never,
+        getLogWatchers: () => [] as never,
         listProcesses: async () => [] as never,
         listPanes: async () => {
           listPanesCalls++;

--- a/src/daemon/adapters/cursor/hook-adapter.test.ts
+++ b/src/daemon/adapters/cursor/hook-adapter.test.ts
@@ -378,6 +378,7 @@ describe("CursorHookAdapter", () => {
           },
         } as never,
         getLogWatcher: () => undefined,
+        getLogWatchers: () => [],
         listProcesses: async () => [] as never,
         listPanes: async () => [] as never,
         getPaneHostingPid: async (pid: number) =>

--- a/src/daemon/adapters/opencode/integration.test.ts
+++ b/src/daemon/adapters/opencode/integration.test.ts
@@ -140,6 +140,7 @@ describe("OpenCode plugin → HookManager → adapter pipeline", () => {
     ctx = {
       sessionManager,
       getLogWatcher: () => undefined,
+      getLogWatchers: () => [],
       listProcesses: async () => [],
       listPanes: async () => [pane],
       getPaneHostingPid: async (pid: number) =>

--- a/src/daemon/adapters/opencode/link.test.ts
+++ b/src/daemon/adapters/opencode/link.test.ts
@@ -65,6 +65,7 @@ function makeCtx(sessions: Session[], panes: TmuxPane[]): HookManagerContext {
       getSessions: () => sessions,
     } as unknown as HookManagerContext["sessionManager"],
     getLogWatcher: () => undefined,
+    getLogWatchers: () => [],
     listProcesses: async () => [],
     listPanes: async () => panes,
     getPaneHostingPid: async (pid: number) => {

--- a/src/daemon/adapters/opencode/plugin-adapter.test.ts
+++ b/src/daemon/adapters/opencode/plugin-adapter.test.ts
@@ -97,6 +97,7 @@ function makeCtx(
       },
     } as unknown as HookManagerContext["sessionManager"],
     getLogWatcher: () => undefined,
+    getLogWatchers: () => [],
     listProcesses: async () => [],
     listPanes: async () => panes,
     getPaneHostingPid: async (pid: number) => {

--- a/src/daemon/adapters/pi/hook-adapter.test.ts
+++ b/src/daemon/adapters/pi/hook-adapter.test.ts
@@ -86,6 +86,7 @@ function makeCtx(
       },
     } as unknown as HookManagerContext["sessionManager"],
     getLogWatcher: () => undefined,
+    getLogWatchers: () => [],
     listProcesses: async () => [],
     listPanes: async () => panes,
     getPaneHostingPid: async (pid: number) => {

--- a/src/daemon/binder/primitives.test.ts
+++ b/src/daemon/binder/primitives.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "bun:test";
+import { resolveExistingLogPath } from "./primitives";
+
+describe("resolveExistingLogPath", () => {
+  const cwd = "/Users/bob/proj";
+  const sid = "11111111-2222-3333-4444-555555555555";
+  const primary = "/Users/bob/.claude/projects";
+  const personal = "/Users/bob/.claude-personal/projects";
+  const rel = `-Users-bob-proj/${sid}.jsonl`;
+
+  it("returns the first dir whose transcript exists", () => {
+    const exists = (p: string) => p === `${personal}/${rel}`;
+    expect(resolveExistingLogPath([primary, personal], cwd, sid, exists)).toBe(
+      `${personal}/${rel}`,
+    );
+  });
+
+  it("prefers the earlier dir when multiple exist", () => {
+    const exists = () => true;
+    expect(resolveExistingLogPath([primary, personal], cwd, sid, exists)).toBe(
+      `${primary}/${rel}`,
+    );
+  });
+
+  it("falls back to the primary dir's path when none exists", () => {
+    const exists = () => false;
+    expect(resolveExistingLogPath([primary, personal], cwd, sid, exists)).toBe(
+      `${primary}/${rel}`,
+    );
+  });
+
+  it("encodes the cwd the same way Claude names project dirs", () => {
+    const exists = () => false;
+    const path = resolveExistingLogPath(
+      ["/root/projects"],
+      "/Users/bob/.dotfiles",
+      sid,
+      exists,
+    );
+    expect(path).toBe(`/root/projects/-Users-bob--dotfiles/${sid}.jsonl`);
+  });
+});

--- a/src/daemon/binder/primitives.ts
+++ b/src/daemon/binder/primitives.ts
@@ -1,3 +1,4 @@
+import { join } from "path";
 import type { ProcessInfo, TmuxPane } from "../../types/session";
 import { normalizeTty } from "../pane-discovery";
 import type { ProcPaneMatch } from "./types";
@@ -18,6 +19,31 @@ import type { ProcPaneMatch } from "./types";
  */
 export function encodeProjectPath(path: string): string {
   return path.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+/**
+ * Locate a Claude session's transcript across one or more `projects` trees.
+ *
+ * A session started under a non-default `CLAUDE_CONFIG_DIR` writes its
+ * transcript to that account's `projects` tree, so probe each dir in order and
+ * return the first whose `<encoded-cwd>/<sessionId>.jsonl` exists. Falls back to
+ * the first (primary) dir's path when none exists yet — the transcript may not
+ * be written until the first turn — preserving single-dir behavior.
+ *
+ * Pure: `fileExists` is injected so it can be unit-tested without a filesystem.
+ */
+export function resolveExistingLogPath(
+  projectDirs: string[],
+  cwd: string,
+  sessionId: string,
+  fileExists: (path: string) => boolean,
+): string {
+  const rel = join(encodeProjectPath(cwd), `${sessionId}.jsonl`);
+  for (const dir of projectDirs) {
+    const candidate = join(dir, rel);
+    if (fileExists(candidate)) return candidate;
+  }
+  return join(projectDirs[0] ?? "", rel);
 }
 
 /**

--- a/src/daemon/hook-adapter.ts
+++ b/src/daemon/hook-adapter.ts
@@ -12,6 +12,12 @@ import type { SessionPidMarker } from "./session-markers";
 export interface HookManagerContext {
   sessionManager: SessionManager;
   getLogWatcher(agentType: string): LogWatcher | undefined;
+  /**
+   * All log watchers for `agentType`. Claude may run several (one per
+   * configured config dir); every other agent has exactly one. Adapters use
+   * this to route marker events to the watcher that owns the session.
+   */
+  getLogWatchers(agentType: string): LogWatcher[];
   listProcesses(): Promise<ProcessInfo[]>;
   listPanes(): Promise<TmuxPane[]>;
 

--- a/src/daemon/hook-manager.test.ts
+++ b/src/daemon/hook-manager.test.ts
@@ -26,6 +26,7 @@ function trivialContext() {
   return {
     sessionManager: {} as never,
     getLogWatcher: () => undefined,
+    getLogWatchers: () => [],
     listProcesses: async () => [],
     listPanes: async () => [],
     getPaneHostingPid: async () => null,
@@ -94,6 +95,7 @@ describe("HookManager", () => {
       const ctx = {
         sessionManager: {} as never,
         getLogWatcher: () => undefined,
+        getLogWatchers: () => [],
         listProcesses: async () => [],
         listPanes: async () => [],
         getPaneHostingPid: async () => null,
@@ -429,6 +431,7 @@ describe("HookManager", () => {
       manager.setContext({
         sessionManager: {} as never,
         getLogWatcher: () => undefined,
+        getLogWatchers: () => [],
         listProcesses: async () => [],
         listPanes: async () => [],
         getPaneHostingPid: async () => null,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -11,6 +11,7 @@ import {
   SCAN_INTERVAL_MS,
   PROJECTS_DIR,
   CCMUX_DIR,
+  resolveClaudeProjectDirs,
 } from "../lib/config";
 import { readFirstLine } from "./parser";
 import { reconcileSessionMarkerLinks } from "./adapters/link";
@@ -31,7 +32,7 @@ import { DaemonServer } from "./server";
 import { HookManager } from "./hook-manager";
 import type { AgentDef } from "../lib/agents";
 import { getAgents } from "../lib/agents";
-import { getPreferences } from "../lib/preferences";
+import { getPreferences, type Preferences } from "../lib/preferences";
 import { VersionResolver, parseShellTokens } from "./version-resolver";
 import { readClaudeHistory } from "./adapters/claude/history";
 import {
@@ -94,6 +95,15 @@ type ClaudeRuntimeMode = "claude-with-hooks" | "claude-no-hooks";
 export class Daemon {
   private sessionManager: SessionManager;
   private watcher: LogWatcher;
+  /** Extra Claude watchers for additional config dirs (`claudeConfigDirs` /
+   * `CLAUDE_CONFIG_DIR`), one per non-default `projects` tree. Empty unless
+   * configured. The primary `watcher` above stays authoritative for
+   * marker-driven, path-agnostic `processPath` routing; these add file
+   * discovery for their own trees, all feeding the shared SessionManager. */
+  private extraClaudeWatchers: LogWatcher[] = [];
+  /** All Claude `projects` dirs watched this run (primary first). Used by
+   * `buildLogPath` to locate a session's transcript across accounts. */
+  private claudeProjectDirs: string[] = [PROJECTS_DIR];
   private codexWatcher: LogWatcher;
   private codexAdapter: CodexLogAdapter;
   private logAdapters: Map<string, LogAdapter> = new Map();
@@ -204,8 +214,13 @@ export class Daemon {
     // Load supported agents (builtins + user overrides/custom agents)
     const preferences = await getPreferences();
     this.agents = getAgents(preferences);
+    // Build extra Claude watchers for any additional config dirs before
+    // runtime-mode propagation and session migration so every tree is live
+    // from boot.
+    this.setupExtraClaudeWatchers(preferences);
     this.claudeRuntimeMode = this.resolveClaudeRuntimeMode();
-    this.watcher.setRuntimeMode(this.claudeRuntimeMode);
+    for (const w of this.claudeWatchers())
+      w.setRuntimeMode(this.claudeRuntimeMode);
     this.checkHooksInstalled();
 
     // Reap detached `ccmux-invoke-*` tmux sessions from a previous
@@ -253,10 +268,13 @@ export class Daemon {
       this.backgroundSource = new ClaudeBackgroundSource(this.sessionManager);
       await this.backgroundSource.start();
     }
-    this.watcher.start();
+    for (const w of this.claudeWatchers()) w.start();
     this.codexWatcher.start();
 
-    await Promise.all([this.watcher.ready, this.codexWatcher.ready]);
+    await Promise.all([
+      ...this.claudeWatchers().map((w) => w.ready),
+      this.codexWatcher.ready,
+    ]);
 
     // Initial scan - also matches existing sessions to panes
     DaemonPerf.startReporter(5);
@@ -291,7 +309,7 @@ export class Daemon {
       this.scanInterval = null;
     }
 
-    await this.watcher.stop();
+    await Promise.all(this.claudeWatchers().map((w) => w.stop()));
     await this.codexWatcher.stop();
     await this.hookManager.stop();
     await this.backgroundSource?.stop();
@@ -587,7 +605,7 @@ export class Daemon {
   private async migrateExistingSessions(): Promise<void> {
     try {
       if (this.claudeRuntimeMode === "claude-no-hooks") return;
-      if (!existsSync(PROJECTS_DIR)) return;
+      if (!this.claudeProjectDirs.some((dir) => existsSync(dir))) return;
 
       const claudeProcs = await discoverAgentProcesses(
         this.agents.filter((a) => a.name === "claude"),
@@ -624,8 +642,46 @@ export class Daemon {
     }
   }
 
+  // A session's transcript may live under any watched Claude config dir
+  // (e.g. a `~/.claude-personal` account), so probe each `projects` tree and
+  // return the first that exists. Falls back to the primary tree's path when
+  // none is found yet (the file may not have been written), preserving the
+  // original single-root behavior.
   private buildLogPath(cwd: string, sessionId: string): string {
-    return join(PROJECTS_DIR, encodeProjectPath(cwd), `${sessionId}.jsonl`);
+    const rel = join(encodeProjectPath(cwd), `${sessionId}.jsonl`);
+    for (const dir of this.claudeProjectDirs) {
+      const candidate = join(dir, rel);
+      if (existsSync(candidate)) return candidate;
+    }
+    return join(PROJECTS_DIR, rel);
+  }
+
+  /** Primary Claude watcher plus any extra config-dir watchers. */
+  private claudeWatchers(): LogWatcher[] {
+    return [this.watcher, ...this.extraClaudeWatchers];
+  }
+
+  // Resolve the configured Claude `projects` dirs and stand up one extra
+  // adapter+watcher per non-default tree, all feeding the shared
+  // SessionManager — mirroring how each agent is a separate adapter+watcher.
+  // The primary `~/.claude/projects` watcher is built in the constructor;
+  // this only adds the extras.
+  private setupExtraClaudeWatchers(preferences: Preferences): void {
+    this.claudeProjectDirs = resolveClaudeProjectDirs(
+      preferences.claudeConfigDirs,
+    );
+    for (const dir of this.claudeProjectDirs) {
+      if (dir === PROJECTS_DIR) continue;
+      const adapter = new ClaudeLogAdapter(this.sessionManager, dir);
+      this.extraClaudeWatchers.push(
+        new LogWatcher(adapter, this.sessionManager),
+      );
+    }
+    if (this.extraClaudeWatchers.length > 0) {
+      console.log(
+        `Watching ${this.claudeProjectDirs.length} Claude projects dirs: ${this.claudeProjectDirs.join(", ")}`,
+      );
+    }
   }
 
   /**

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -5,7 +5,6 @@ import {
   readFileSync,
   mkdirSync,
 } from "fs";
-import { join } from "path";
 import {
   PID_FILE,
   SCAN_INTERVAL_MS,
@@ -19,6 +18,7 @@ import {
   decideMigrationBindings,
   decideCodexRolloutLinks,
   decideMarkerLinks,
+  resolveExistingLogPath,
   type CodexLinkCandidate,
 } from "./binder";
 import { SessionManager } from "./sessions";
@@ -62,7 +62,6 @@ import {
 import {
   matchSessionsToPanes,
   cleanupStaleSessions,
-  encodeProjectPath,
 } from "./session-pane-match";
 import { sweepOrphanInvokeSessions } from "./detached-session";
 import { ProcessTree } from "./process-tree";
@@ -173,6 +172,11 @@ export class Daemon {
     this.hookManager.setContext({
       sessionManager: this.sessionManager,
       getLogWatcher: (agentType) => this.logWatchers.get(agentType),
+      getLogWatchers: (agentType) => {
+        if (agentType === "claude") return this.claudeWatchers();
+        const single = this.logWatchers.get(agentType);
+        return single ? [single] : [];
+      },
       listProcesses: () => discoverAgentProcesses(this.agents),
       listPanes: () => listTmuxPanes(),
       getPaneHostingPid: (pid) => this.resolvePaneHostingPid(pid),
@@ -642,18 +646,15 @@ export class Daemon {
     }
   }
 
-  // A session's transcript may live under any watched Claude config dir
-  // (e.g. a `~/.claude-personal` account), so probe each `projects` tree and
-  // return the first that exists. Falls back to the primary tree's path when
-  // none is found yet (the file may not have been written), preserving the
-  // original single-root behavior.
+  // Locate a session's transcript across every watched Claude config dir
+  // (e.g. a `~/.claude-personal` account). See `resolveExistingLogPath`.
   private buildLogPath(cwd: string, sessionId: string): string {
-    const rel = join(encodeProjectPath(cwd), `${sessionId}.jsonl`);
-    for (const dir of this.claudeProjectDirs) {
-      const candidate = join(dir, rel);
-      if (existsSync(candidate)) return candidate;
-    }
-    return join(PROJECTS_DIR, rel);
+    return resolveExistingLogPath(
+      this.claudeProjectDirs,
+      cwd,
+      sessionId,
+      existsSync,
+    );
   }
 
   /** Primary Claude watcher plus any extra config-dir watchers. */

--- a/src/daemon/watcher.ts
+++ b/src/daemon/watcher.ts
@@ -164,6 +164,16 @@ export class LogWatcher {
    * next jsonl write is picked up immediately. No-op for non-Claude
    * adapters and for the Claude no-hooks runtime mode.
    */
+  /**
+   * Whether this watcher's log tree is the one that discovered `sessionId`
+   * (its transcript lives under this watcher's `logDirGlob`). With multiple
+   * Claude config dirs, marker events route to the owning watcher so the
+   * tree holding the transcript is the one that re-arms / tears down.
+   */
+  ownsSession(sessionId: string): boolean {
+    return this.knownLogPaths.has(sessionId);
+  }
+
   handleMarkerAdded(marker: SessionPidMarker): void {
     if (this.adapter.agentType !== "claude") return;
     if (this.runtimeMode === "claude-no-hooks") return;

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { homedir } from "os";
+import { join } from "path";
+import { PROJECTS_DIR, resolveClaudeProjectDirs } from "./config";
+
+describe("resolveClaudeProjectDirs", () => {
+  const savedConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+  beforeEach(() => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+  });
+
+  afterEach(() => {
+    if (savedConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = savedConfigDir;
+  });
+
+  it("defaults to the primary projects dir when nothing is configured", () => {
+    expect(resolveClaudeProjectDirs()).toEqual([PROJECTS_DIR]);
+    expect(resolveClaudeProjectDirs([])).toEqual([PROJECTS_DIR]);
+  });
+
+  it("appends `projects` to each configured config dir, primary first", () => {
+    expect(resolveClaudeProjectDirs(["/home/bob/.claude-personal"])).toEqual([
+      PROJECTS_DIR,
+      "/home/bob/.claude-personal/projects",
+    ]);
+  });
+
+  it("expands a leading ~ to the home directory", () => {
+    expect(resolveClaudeProjectDirs(["~/.claude-work"])).toEqual([
+      PROJECTS_DIR,
+      join(homedir(), ".claude-work", "projects"),
+    ]);
+  });
+
+  it("includes CLAUDE_CONFIG_DIR before preference-configured dirs", () => {
+    process.env.CLAUDE_CONFIG_DIR = "/env/.claude-alt";
+    expect(resolveClaudeProjectDirs(["/pref/.claude-extra"])).toEqual([
+      PROJECTS_DIR,
+      "/env/.claude-alt/projects",
+      "/pref/.claude-extra/projects",
+    ]);
+  });
+
+  it("de-duplicates while preserving order (default tree is never doubled)", () => {
+    process.env.CLAUDE_CONFIG_DIR = join(homedir(), ".claude");
+    expect(
+      resolveClaudeProjectDirs([
+        "~/.claude-personal",
+        "/home/bob/.claude-personal",
+        "~/.claude-personal",
+      ]),
+    ).toEqual([
+      PROJECTS_DIR,
+      join(homedir(), ".claude-personal", "projects"),
+      "/home/bob/.claude-personal/projects",
+    ]);
+  });
+
+  it("ignores empty entries", () => {
+    expect(resolveClaudeProjectDirs(["", "/a/.claude"])).toEqual([
+      PROJECTS_DIR,
+      "/a/.claude/projects",
+    ]);
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join, resolve } from "path";
 import { homedir } from "os";
 
 /**
@@ -8,6 +8,44 @@ export const CLAUDE_DIR = join(homedir(), ".claude");
 export const PROJECTS_DIR = join(CLAUDE_DIR, "projects");
 export const SETTINGS_FILE = join(CLAUDE_DIR, "settings.json");
 export const CLAUDE_HOOKS_DIR = join(CLAUDE_DIR, "hooks");
+
+/** Expand a leading `~` / `~/` to the user's home directory. */
+function expandHome(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+/**
+ * Resolve the set of Claude `projects` directories ccmux should watch.
+ *
+ * Claude Code writes session transcripts to `$CLAUDE_CONFIG_DIR/projects`
+ * (default `~/.claude/projects`). A user running a second account via
+ * `CLAUDE_CONFIG_DIR=~/.claude-personal claude` produces sessions under a
+ * *different* projects tree that the default single-root watcher never
+ * sees. This returns every tree to watch so one ccmux instance can surface
+ * sessions from multiple Claude config dirs — the same way it already fans
+ * out across multiple agents.
+ *
+ * Sources, in order: the default `~/.claude/projects` (always first), the
+ * `CLAUDE_CONFIG_DIR` env var (matches Claude's own resolution), then the
+ * `claudeConfigDirs` preference. Each extra entry is a Claude *config* dir
+ * whose `projects` subdir is watched. Paths may start with `~`. The result
+ * is absolute and de-duplicated, order-preserving, so the default behavior
+ * is unchanged when nothing extra is configured.
+ */
+export function resolveClaudeProjectDirs(configDirs?: string[]): string[] {
+  const dirs = [PROJECTS_DIR];
+  const extraConfigDirs = [
+    ...(process.env.CLAUDE_CONFIG_DIR ? [process.env.CLAUDE_CONFIG_DIR] : []),
+    ...(configDirs ?? []),
+  ];
+  for (const dir of extraConfigDirs) {
+    if (!dir) continue;
+    dirs.push(join(resolve(expandHome(dir)), "projects"));
+  }
+  return [...new Set(dirs)];
+}
 
 /**
  * Claude Code's background/background-agent state, written by Claude's own

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,34 +17,45 @@ function expandHome(p: string): string {
 }
 
 /**
- * Resolve the set of Claude `projects` directories ccmux should watch.
+ * Resolve the set of Claude *config* directories ccmux should treat as
+ * active (the dirs that hold `settings.json`, `hooks/`, and `projects/`).
  *
- * Claude Code writes session transcripts to `$CLAUDE_CONFIG_DIR/projects`
- * (default `~/.claude/projects`). A user running a second account via
- * `CLAUDE_CONFIG_DIR=~/.claude-personal claude` produces sessions under a
- * *different* projects tree that the default single-root watcher never
- * sees. This returns every tree to watch so one ccmux instance can surface
- * sessions from multiple Claude config dirs — the same way it already fans
- * out across multiple agents.
+ * A user running a second account via `CLAUDE_CONFIG_DIR=~/.claude-personal
+ * claude` keeps its state under a *different* config dir that the default
+ * single-root code never touches. This returns every config dir so one
+ * ccmux instance can watch — and install hooks into — them all, the same
+ * way it already fans out across multiple agents.
  *
- * Sources, in order: the default `~/.claude/projects` (always first), the
+ * Sources, in order: the default `~/.claude` (always first), the
  * `CLAUDE_CONFIG_DIR` env var (matches Claude's own resolution), then the
- * `claudeConfigDirs` preference. Each extra entry is a Claude *config* dir
- * whose `projects` subdir is watched. Paths may start with `~`. The result
- * is absolute and de-duplicated, order-preserving, so the default behavior
- * is unchanged when nothing extra is configured.
+ * `claudeConfigDirs` preference. Paths may start with `~`. The result is
+ * absolute and de-duplicated, order-preserving, so the default behavior is
+ * unchanged when nothing extra is configured.
  */
-export function resolveClaudeProjectDirs(configDirs?: string[]): string[] {
-  const dirs = [PROJECTS_DIR];
+export function resolveClaudeConfigDirs(configDirs?: string[]): string[] {
+  const dirs = [CLAUDE_DIR];
   const extraConfigDirs = [
     ...(process.env.CLAUDE_CONFIG_DIR ? [process.env.CLAUDE_CONFIG_DIR] : []),
     ...(configDirs ?? []),
   ];
   for (const dir of extraConfigDirs) {
     if (!dir) continue;
-    dirs.push(join(resolve(expandHome(dir)), "projects"));
+    dirs.push(resolve(expandHome(dir)));
   }
   return [...new Set(dirs)];
+}
+
+/**
+ * Resolve the set of Claude `projects` directories ccmux should watch — the
+ * `projects` subdir of every configured Claude config dir. Claude Code
+ * writes session transcripts to `$CLAUDE_CONFIG_DIR/projects`; watching all
+ * of them lets one ccmux instance surface sessions from multiple accounts.
+ * See {@link resolveClaudeConfigDirs}.
+ */
+export function resolveClaudeProjectDirs(configDirs?: string[]): string[] {
+  return resolveClaudeConfigDirs(configDirs).map((dir) =>
+    join(dir, "projects"),
+  );
 }
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,8 +6,6 @@ import { homedir } from "os";
  */
 export const CLAUDE_DIR = join(homedir(), ".claude");
 export const PROJECTS_DIR = join(CLAUDE_DIR, "projects");
-export const SETTINGS_FILE = join(CLAUDE_DIR, "settings.json");
-export const CLAUDE_HOOKS_DIR = join(CLAUDE_DIR, "hooks");
 
 /** Expand a leading `~` / `~/` to the user's home directory. */
 function expandHome(p: string): string {
@@ -36,7 +34,13 @@ export function resolveClaudeConfigDirs(configDirs?: string[]): string[] {
   const dirs = [CLAUDE_DIR];
   const extraConfigDirs = [
     ...(process.env.CLAUDE_CONFIG_DIR ? [process.env.CLAUDE_CONFIG_DIR] : []),
-    ...(configDirs ?? []),
+    // `configDirs` comes from unvalidated ccmux.json; a bare string (e.g.
+    // `"claudeConfigDirs": "~/.claude-personal"`) would otherwise spread into
+    // single characters and have hooks written into `~`, `/`, and cwd. Only
+    // accept an array of strings.
+    ...(Array.isArray(configDirs)
+      ? configDirs.filter((d) => typeof d === "string")
+      : []),
   ];
   for (const dir of extraConfigDirs) {
     if (!dir) continue;

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -210,6 +210,15 @@ export interface Preferences {
   previewWidth?: number;
   command?: string;
   agents?: Record<string, AgentConfig>;
+  /**
+   * Additional Claude Code config directories to watch beyond the default
+   * `~/.claude`. Each entry contributes its `<dir>/projects` session tree,
+   * letting a single ccmux instance surface sessions from multiple Claude
+   * accounts started via `CLAUDE_CONFIG_DIR` (e.g. `~/.claude` +
+   * `~/.claude-personal`). The default `~/.claude` is always watched. Paths
+   * may start with `~`. See `resolveClaudeProjectDirs`.
+   */
+  claudeConfigDirs?: string[];
   columns?: ColumnsConfig;
   breakpoints?: BreakpointConfig;
   /** Default prompt display mode (default "inline"). The runtime `p`-key

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "fs";
+import { mkdirSync, readFileSync } from "fs";
 import { dirname } from "path";
 import { PREFS_FILE } from "./config";
 import type { IconStyle } from "./icons";
@@ -263,6 +263,19 @@ export async function getPreferences(): Promise<Preferences> {
     // Ignore malformed file
   }
   return {};
+}
+
+/**
+ * Synchronous preferences read for the few callers that can't be async
+ * (e.g. `HookAdapter.isInstalled`). Returns an empty object if the file is
+ * missing or malformed, matching {@link getPreferences}.
+ */
+export function getPreferencesSync(): Preferences {
+  try {
+    return JSON.parse(readFileSync(PREFS_FILE, "utf-8"));
+  } catch {
+    return {};
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #6.

Lets one ccmux instance track Claude sessions from **multiple config dirs** — e.g. a work account in `~/.claude` and a personal one launched with `CLAUDE_CONFIG_DIR=~/.claude-personal`. Today ccmux only watches `~/.claude/projects`, so the second account's sessions never surface even though their hooks fire and markers are written.

## Approach

A second config dir isn't a new *agent* — it's the same adapter pointed at a second log root. So this fans out Claude log roots the way ccmux already fans out agents:

- `resolveClaudeConfigDirs()` / `resolveClaudeProjectDirs()` gather `~/.claude` plus any dirs from the new **`claudeConfigDirs`** preference and the `CLAUDE_CONFIG_DIR` env var (deduped, order-preserving).
- The daemon stands up one `ClaudeLogAdapter` + `LogWatcher` per projects tree, all feeding the shared `SessionManager`. The primary watcher stays authoritative for marker-driven, path-agnostic `processPath` routing; `buildLogPath` probes every tree.
- Default behavior is unchanged when nothing extra is configured.

## Hook install fan-out (per your review note)

`ccmux setup` hardcoded `~/.claude` for hooks. Now `install()`/`uninstall()` fan out across every configured config dir, each writing its own `hooks/` scripts and `settings.json` entries. `isInstalled()` still reflects the primary `~/.claude` (it drives the daemon's single global runtime mode — keying it off an unconfigured extra dir could flip the whole daemon to no-hooks), and a new `describeInstallAnomalies()` warns at startup / in `ccmux setup` status when a configured dir is still missing hooks.

## Config

```jsonc
// ~/.config/ccmux/ccmux.json
{ "claudeConfigDirs": ["~/.claude-personal"] }
```
```bash
ccmux config set claudeConfigDirs '["~/.claude-personal"]'
ccmux setup --agent claude   # installs hooks into every configured dir
ccmux daemon restart
```

## Tests

`bun run typecheck` clean. New unit tests for `resolveClaudeProjectDirs` and for hook install/uninstall/`isInstalled` fan-out across dirs. Full suite green except the same pre-existing env-only failures on `main` (native chokidar watch timing + missing generated plugin bundles). Verified end-to-end: a daemon with `claudeConfigDirs` set watches both trees and tracks a live `claudep` session whose `logPath` resolves under `~/.claude-personal/projects`.

Note: builds on the same base as #8 (the `lsof -Ffn` cwd fix); they're independent and can merge in either order.
