### PR TITLE
refactor(claude): Rename config key to additionalClaudeConfigDirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,21 +258,21 @@ ccmux config get <key>
 ccmux config list
 ```
 
-| Key                 | Values                                                                       | Default            | Description                                                                                                                                      |
-| :------------------ | :--------------------------------------------------------------------------- | :----------------- | :----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `iconStyle`         | `dot`, `emoji`, `nerdfont`, `none`                                           | `dot`              | Status icon style                                                                                                                                |
-| `theme`             | `catppuccin-*`, `tokyo-night*`, `dracula`, `gruvbox-*`, `nord`, `rose-pine*` | `catppuccin-mocha` | TUI color theme (resolved at launch; see [Theme](#-theme))                                                                                       |
-| `showPreview`       | `true`, `false`                                                              | `false`            | Show preview panel on launch                                                                                                                     |
-| `previewWidth`      | `20`–`80`                                                                    | `40`               | Preview panel width (percentage)                                                                                                                 |
-| `command`           | any non-blank string                                                         | `claude`           | CLI command used for session restart                                                                                                             |
-| `groupBy`           | `project`, `cwd`, `session`, `window`, `none`                                | `project`          | How sessions are grouped in the TUI                                                                                                              |
-| `promptDisplay`     | `inline`, `row2`, `off`                                                      | `inline`           | Prompt display: inline on row 1, its own row, or hidden                                                                                          |
-| `backgroundAgents`  | `true`, `false`                                                              | `true`             | Show Claude background agents as rows (daemon restart required)                                                                                  |
-| `claudeConfigDirs`  | array of paths                                                               | `[]`               | Extra Claude config dirs to watch beyond `~/.claude` (daemon restart required; see [Multiple Claude Config Dirs](#-multiple-claude-config-dirs)) |
-| `searchPaneContent` | `true`, `false`                                                              | `true`             | Include captured pane content in TUI search                                                                                                      |
-| `persistent`        | `true`, `false`                                                              | `false`            | Keep picker open after switching sessions (dashboard mode)                                                                                       |
-| `sidebar.width`     | `10`–`80`                                                                    | `30`               | Sidebar pane width in columns                                                                                                                    |
-| `sidebar.position`  | `left`, `right`                                                              | `left`             | Which side of the window to place the sidebar                                                                                                    |
+| Key                          | Values                                                                       | Default            | Description                                                                                                                        |
+| :--------------------------- | :--------------------------------------------------------------------------- | :----------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
+| `iconStyle`                  | `dot`, `emoji`, `nerdfont`, `none`                                           | `dot`              | Status icon style                                                                                                                  |
+| `theme`                      | `catppuccin-*`, `tokyo-night*`, `dracula`, `gruvbox-*`, `nord`, `rose-pine*` | `catppuccin-mocha` | TUI color theme (resolved at launch; see [Theme](#-theme))                                                                         |
+| `showPreview`                | `true`, `false`                                                              | `false`            | Show preview panel on launch                                                                                                       |
+| `previewWidth`               | `20`–`80`                                                                    | `40`               | Preview panel width (percentage)                                                                                                   |
+| `command`                    | any non-blank string                                                         | `claude`           | CLI command used for session restart                                                                                               |
+| `groupBy`                    | `project`, `cwd`, `session`, `window`, `none`                                | `project`          | How sessions are grouped in the TUI                                                                                                |
+| `promptDisplay`              | `inline`, `row2`, `off`                                                      | `inline`           | Prompt display: inline on row 1, its own row, or hidden                                                                            |
+| `backgroundAgents`           | `true`, `false`                                                              | `true`             | Show Claude background agents as rows (daemon restart required)                                                                    |
+| `additionalClaudeConfigDirs` | array of paths                                                               | `[]`               | Additional Claude config dirs to watch (daemon restart required; see [Multiple Claude Config Dirs](#-multiple-claude-config-dirs)) |
+| `searchPaneContent`          | `true`, `false`                                                              | `true`             | Include captured pane content in TUI search                                                                                        |
+| `persistent`                 | `true`, `false`                                                              | `false`            | Keep picker open after switching sessions (dashboard mode)                                                                         |
+| `sidebar.width`              | `10`–`80`                                                                    | `30`               | Sidebar pane width in columns                                                                                                      |
+| `sidebar.position`           | `left`, `right`                                                              | `left`             | Which side of the window to place the sidebar                                                                                      |
 
 ### 📊 Column Configuration
 
@@ -368,27 +368,18 @@ An unknown base name falls back to the default theme; an invalid hex value or un
 
 ### 🗂️ Multiple Claude Config Dirs
 
-Claude Code writes its session transcripts to `$CLAUDE_CONFIG_DIR/projects` (default `~/.claude/projects`). If you run more than one Claude account — e.g. a work login in `~/.claude` and a personal one launched with `CLAUDE_CONFIG_DIR=~/.claude-personal` — sessions from the non-default account land in a separate `projects` tree that ccmux doesn't watch by default, so they never show up in the TUI even though their hooks fire correctly.
-
-Add the extra config dirs to `claudeConfigDirs` in `~/.config/ccmux/ccmux.json` and ccmux watches every `<dir>/projects` tree from a single daemon, the same way it fans out across agents:
-
-```json
-{ "claudeConfigDirs": ["~/.claude-personal"] }
-```
-
-Then install hooks into every configured dir so sessions from each account are matched authoritatively, and restart the daemon to pick up the new dirs:
+Claude Code writes session transcripts to `$CLAUDE_CONFIG_DIR/projects` (default `~/.claude/projects`), so sessions from a second account (e.g. a personal login launched with `CLAUDE_CONFIG_DIR=~/.claude-personal`) land in a tree ccmux doesn't watch by default. List those dirs in `additionalClaudeConfigDirs` and a single daemon watches every `<dir>/projects` tree:
 
 ```bash
-ccmux setup --agent claude   # fans out to ~/.claude and every claudeConfigDirs entry
+ccmux config set additionalClaudeConfigDirs '["~/.claude-personal"]'
+ccmux setup --agent claude   # installs hooks into every configured dir
 ccmux daemon restart
 ```
 
-Notes:
+`~/.claude` is always watched; entries are additional config dirs (`~` paths supported), and a set `CLAUDE_CONFIG_DIR` environment variable is picked up automatically. Sessions are keyed by their globally unique session ID, so the same project opened under two accounts coexists without collision.
 
-- `~/.claude` is always watched; entries here are **additional** Claude config dirs (their `projects` subdir is watched). Paths may start with `~`.
-- The `CLAUDE_CONFIG_DIR` environment variable, if set, is honored too and added automatically.
-- Sessions are keyed by their (globally unique) session ID, so the same project opened under two accounts coexists without collision.
-- `ccmux setup` installs the hook scripts and `settings.json` entries into **all** configured Claude dirs. Configure `claudeConfigDirs` first, then run setup. If you add a dir later, re-run setup — the daemon warns at startup about any configured dir still missing hooks.
+> [!NOTE]
+> If you add a dir later, re-run `ccmux setup --agent claude`. The daemon warns at startup about any configured dir still missing hooks.
 
 ## 🔗 Session Matching with Hooks
 

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -56,7 +56,7 @@ The startup-race closer for markers written before the first scan created the pa
 
 ### Agent-owned (read-only except during `ccmux setup`)
 
-- Claude Code logs: `~/.claude/projects/<encoded-path>/<sessionId>.jsonl` (plus any extra config dirs from the `claudeConfigDirs` preference / `CLAUDE_CONFIG_DIR`, each watched at `<dir>/projects`)
+- Claude Code logs: `~/.claude/projects/<encoded-path>/<sessionId>.jsonl` (plus any extra config dirs from the `additionalClaudeConfigDirs` preference / `CLAUDE_CONFIG_DIR`, each watched at `<dir>/projects`)
 - Claude Code history: `~/.claude/history.jsonl`
 - Claude Code settings: `~/.claude/settings.json` (written by `ccmux setup --agent claude`)
 - Claude Code hooks: `~/.claude/hooks/ccmux-session-start.sh`, `ccmux-session-end.sh`, `ccmux-state-notify.sh`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,6 +63,12 @@ For panes no marker claims, each same-cwd group of sessions and candidate panes 
 
 Platform event names are unreliable and FSEvents coalescing is stream-local, so events are classified by `stat` + a known-files set, and every event reconciles a subtree (walk for new files, sweep for gone ones). `ready` is deferred ~50ms to cover the stream's arming window. It falls back to chokidar when the root is missing or recursive watching is unsupported.
 
+### Multiple Claude config dirs
+
+Claude Code writes transcripts to `$CLAUDE_CONFIG_DIR/projects`, so a second account (a work login in `~/.claude` plus a personal one under `CLAUDE_CONFIG_DIR=~/.claude-personal`) lands in a separate tree. `resolveClaudeProjectDirs` (`lib/config.ts`) collects `~/.claude` plus every dir from the `additionalClaudeConfigDirs` preference and `CLAUDE_CONFIG_DIR` (deduped, primary first). The daemon stands up one `ClaudeLogAdapter` + `LogWatcher` per tree — the same fan-out shape as one-adapter-per-agent — all feeding the shared `SessionManager`. Empty unless configured, so default single-dir behavior is unchanged. Only extra trees add watchers; the primary `~/.claude/projects` watcher stays authoritative for marker-driven, path-agnostic `processPath` routing, and `buildLogPath` probes every tree to locate a session's transcript.
+
+Because a transcript lives in exactly one tree, marker events route to the watcher that owns the session: `LogWatcher.ownsSession(id)` reports whether that tree has discovered the session's log, and the Claude adapter's `ownerFor` (`getLogWatchers("claude")` → `find(ownsSession) ?? watchers[0]`) picks the owning watcher, falling back to the primary for sessions no tree has discovered yet (e.g. a marker written before the first turn). For the same reason, per-watcher freshness state (`isRecentlyProcessed`) is folded across all Claude watchers in the reconciler, so a second-account session isn't invisible to the just-processed debounce guard.
+
 ## Hook lifecycle
 
 <picture>

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { getNestedValue, flattenObject } from "./config";
+import { getNestedValue, flattenObject, KNOWN_KEYS } from "./config";
 import type { Preferences } from "../lib/preferences";
 
 describe("getNestedValue", () => {
@@ -126,5 +126,31 @@ describe("flattenObject", () => {
 
   it("skips arrays without recursing into elements", () => {
     expect(flattenObject({ items: [1, 2, 3] })).toEqual([["items", "[1,2,3]"]]);
+  });
+});
+
+describe("KNOWN_KEYS.additionalClaudeConfigDirs", () => {
+  const spec = KNOWN_KEYS.additionalClaudeConfigDirs!;
+
+  it("validate accepts absolute and ~/-prefixed path arrays", () => {
+    expect(spec.validate('["~/.claude-personal"]')).toBe(true);
+    expect(spec.validate('["/abs/path"]')).toBe(true);
+    expect(spec.validate('["~/a","/b"]')).toBe(true);
+    expect(spec.validate("[]")).toBe(true);
+  });
+
+  it("validate rejects non-JSON, non-array, and non-conforming entries", () => {
+    expect(spec.validate("~/.claude-personal")).toBe(false);
+    expect(spec.validate('"~/.claude-personal"')).toBe(false);
+    expect(spec.validate("5")).toBe(false);
+    expect(spec.validate('{"a":1}')).toBe(false);
+    expect(spec.validate('["personal"]')).toBe(false);
+    expect(spec.validate('["~"]')).toBe(false);
+    expect(spec.validate('[""]')).toBe(false);
+    expect(spec.validate('["~/x", 5]')).toBe(false);
+  });
+
+  it("parse returns the parsed array", () => {
+    expect(spec.parse('["~/a","~/b"]')).toEqual(["~/a", "~/b"]);
   });
 });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { isAbsolute } from "node:path";
 import {
   getPreferences,
   setPreferences,
@@ -16,7 +17,7 @@ import { VALID_ICON_STYLES, type IconStyle } from "../lib/icons";
 import { BUILTIN_THEME_NAMES, DEFAULT_THEME_NAME } from "../tui/themes";
 import { resolveThemeVerbose } from "../tui/theme";
 
-const KNOWN_KEYS: Record<
+export const KNOWN_KEYS: Record<
   string,
   {
     validate: (v: string) => boolean;
@@ -71,7 +72,11 @@ const KNOWN_KEYS: Record<
       try {
         const parsed = JSON.parse(v);
         return (
-          Array.isArray(parsed) && parsed.every((d) => typeof d === "string")
+          Array.isArray(parsed) &&
+          parsed.every(
+            (d) =>
+              typeof d === "string" && (isAbsolute(d) || d.startsWith("~/")),
+          )
         );
       } catch {
         return false;
@@ -79,7 +84,7 @@ const KNOWN_KEYS: Record<
     },
     parse: (v) => JSON.parse(v) as string[],
     description:
-      "Additional Claude config dirs to watch, as a JSON array of paths (e.g. '[\"~/.claude-personal\"]')",
+      "Additional Claude config dirs to watch, as a JSON array of absolute or ~/-prefixed paths (e.g. '[\"~/.claude-personal\"]')",
     note: "Run `ccmux setup --agent claude` to install hooks into the new dirs, then restart the daemon (ccmux daemon restart)",
   },
   searchPaneContent: {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -66,6 +66,22 @@ const KNOWN_KEYS: Record<
       "Show Claude background agents as rows (true, false; default true, daemon restart required)",
     note: "Takes effect after a daemon restart (ccmux daemon restart)",
   },
+  additionalClaudeConfigDirs: {
+    validate: (v) => {
+      try {
+        const parsed = JSON.parse(v);
+        return (
+          Array.isArray(parsed) && parsed.every((d) => typeof d === "string")
+        );
+      } catch {
+        return false;
+      }
+    },
+    parse: (v) => JSON.parse(v) as string[],
+    description:
+      "Additional Claude config dirs to watch, as a JSON array of paths (e.g. '[\"~/.claude-personal\"]')",
+    note: "Run `ccmux setup --agent claude` to install hooks into the new dirs, then restart the daemon (ccmux daemon restart)",
+  },
   searchPaneContent: {
     validate: (v) => v === "true" || v === "false",
     parse: (v) => v === "true",

--- a/src/daemon/adapters/claude/hook-adapter.ts
+++ b/src/daemon/adapters/claude/hook-adapter.ts
@@ -71,10 +71,10 @@ export class ClaudeHookAdapter implements HookAdapter {
     mkdirSync(MARKERS_DIR, { recursive: true });
 
     // Fan out across every configured Claude config dir so a second account
-    // (via CLAUDE_CONFIG_DIR / the `claudeConfigDirs` preference) gets hooks
-    // too, not just the default ~/.claude.
+    // (via CLAUDE_CONFIG_DIR / the `additionalClaudeConfigDirs` preference)
+    // gets hooks too, not just the default ~/.claude.
     const configDirs = resolveClaudeConfigDirs(
-      (await getPreferences()).claudeConfigDirs,
+      (await getPreferences()).additionalClaudeConfigDirs,
     );
     for (const dir of configDirs) {
       // Isolate each dir: a malformed settings.json in one must not abort the
@@ -166,7 +166,7 @@ export class ClaudeHookAdapter implements HookAdapter {
     let changed = false;
 
     const configDirs = resolveClaudeConfigDirs(
-      (await getPreferences()).claudeConfigDirs,
+      (await getPreferences()).additionalClaudeConfigDirs,
     );
     for (const dir of configDirs) {
       // Isolate each dir so one malformed settings.json can't skip the others
@@ -254,7 +254,7 @@ export class ClaudeHookAdapter implements HookAdapter {
   // configured dirs surface via `describeInstallAnomalies` instead.
   isInstalled(): boolean {
     const [primary] = resolveClaudeConfigDirs(
-      getPreferencesSync().claudeConfigDirs,
+      getPreferencesSync().additionalClaudeConfigDirs,
     );
     return isInstalledInDir(primary);
   }
@@ -264,7 +264,7 @@ export class ClaudeHookAdapter implements HookAdapter {
   // tracked authoritatively until `ccmux setup` is re-run.
   describeInstallAnomalies(): string[] {
     const [, ...extra] = resolveClaudeConfigDirs(
-      getPreferencesSync().claudeConfigDirs,
+      getPreferencesSync().additionalClaudeConfigDirs,
     );
     return extra
       .filter((dir) => !isInstalledInDir(dir))

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -89,6 +89,19 @@ import {
 type ClaudeRuntimeMode = "claude-with-hooks" | "claude-no-hooks";
 
 /**
+ * Fold the debounce check across every Claude watcher: an extra config-dir
+ * watcher records freshness on its own `lastProcessedAt`, so consulting only
+ * the primary would let second-account sessions bypass the reconciler's
+ * just-processed guard.
+ */
+export function isRecentlyProcessedByAny(
+  watchers: ReadonlyArray<{ isRecentlyProcessed: (id: string) => boolean }>,
+  sessionId: string,
+): boolean {
+  return watchers.some((w) => w.isRecentlyProcessed(sessionId));
+}
+
+/**
  * Main daemon class
  */
 export class Daemon {
@@ -902,7 +915,7 @@ export class Daemon {
       // the reconciler's just-processed guard.
       watcher: {
         isRecentlyProcessed: (id) =>
-          this.claudeWatchers().some((w) => w.isRecentlyProcessed(id)),
+          isRecentlyProcessedByAny(this.claudeWatchers(), id),
       },
       hookManager: this.hookManager,
       attentionTracker: this.attentionTracker,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -94,8 +94,9 @@ type ClaudeRuntimeMode = "claude-with-hooks" | "claude-no-hooks";
 export class Daemon {
   private sessionManager: SessionManager;
   private watcher: LogWatcher;
-  /** Extra Claude watchers for additional config dirs (`claudeConfigDirs` /
-   * `CLAUDE_CONFIG_DIR`), one per non-default `projects` tree. Empty unless
+  /** Extra Claude watchers for additional config dirs
+   * (`additionalClaudeConfigDirs` / `CLAUDE_CONFIG_DIR`), one per non-default
+   * `projects` tree. Empty unless
    * configured. The primary `watcher` above stays authoritative for
    * marker-driven, path-agnostic `processPath` routing; these add file
    * discovery for their own trees, all feeding the shared SessionManager. */
@@ -669,7 +670,7 @@ export class Daemon {
   // this only adds the extras.
   private setupExtraClaudeWatchers(preferences: Preferences): void {
     this.claudeProjectDirs = resolveClaudeProjectDirs(
-      preferences.claudeConfigDirs,
+      preferences.additionalClaudeConfigDirs,
     );
     for (const dir of this.claudeProjectDirs) {
       if (dir === PROJECTS_DIR) continue;
@@ -895,7 +896,14 @@ export class Daemon {
   private buildReconcilerDeps(): ReconcilerDeps {
     return {
       sessionManager: this.sessionManager,
-      watcher: this.watcher,
+      // Fold the debounce check across every Claude watcher: an extra
+      // config-dir watcher records freshness on its own `lastProcessedAt`, so
+      // consulting only the primary would let second-account sessions bypass
+      // the reconciler's just-processed guard.
+      watcher: {
+        isRecentlyProcessed: (id) =>
+          this.claudeWatchers().some((w) => w.isRecentlyProcessed(id)),
+      },
       hookManager: this.hookManager,
       attentionTracker: this.attentionTracker,
       agents: this.agents,

--- a/src/daemon/reconciler-deps.test.ts
+++ b/src/daemon/reconciler-deps.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { isRecentlyProcessedByAny } from "./index";
+
+describe("isRecentlyProcessedByAny", () => {
+  it("returns false for an empty watcher array", () => {
+    expect(isRecentlyProcessedByAny([], "s1")).toBe(false);
+  });
+
+  it("returns true when the single watcher reports true", () => {
+    const watchers = [{ isRecentlyProcessed: (id: string) => id === "s1" }];
+    expect(isRecentlyProcessedByAny(watchers, "s1")).toBe(true);
+  });
+
+  it("returns false when the single watcher reports false", () => {
+    const watchers = [{ isRecentlyProcessed: (id: string) => id === "s1" }];
+    expect(isRecentlyProcessedByAny(watchers, "s2")).toBe(false);
+  });
+
+  it("returns true when only the non-primary watcher reports true (the regression case)", () => {
+    const watchers = [
+      { isRecentlyProcessed: (id: string) => id === "primary-only" },
+      { isRecentlyProcessed: (id: string) => id === "s1" },
+    ];
+    expect(isRecentlyProcessedByAny(watchers, "s1")).toBe(true);
+  });
+
+  it("returns false when neither watcher reports true for a different id", () => {
+    const watchers = [
+      { isRecentlyProcessed: (id: string) => id === "primary-only" },
+      { isRecentlyProcessed: (id: string) => id === "s1" },
+    ];
+    expect(isRecentlyProcessedByAny(watchers, "s2")).toBe(false);
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -26,7 +26,7 @@ function expandHome(p: string): string {
  *
  * Sources, in order: the default `~/.claude` (always first), the
  * `CLAUDE_CONFIG_DIR` env var (matches Claude's own resolution), then the
- * `claudeConfigDirs` preference. Paths may start with `~`. The result is
+ * `additionalClaudeConfigDirs` preference. Paths may start with `~`. The result is
  * absolute and de-duplicated, order-preserving, so the default behavior is
  * unchanged when nothing extra is configured.
  */
@@ -35,7 +35,7 @@ export function resolveClaudeConfigDirs(configDirs?: string[]): string[] {
   const extraConfigDirs = [
     ...(process.env.CLAUDE_CONFIG_DIR ? [process.env.CLAUDE_CONFIG_DIR] : []),
     // `configDirs` comes from unvalidated ccmux.json; a bare string (e.g.
-    // `"claudeConfigDirs": "~/.claude-personal"`) would otherwise spread into
+    // `"additionalClaudeConfigDirs": "~/.claude-personal"`) would otherwise spread into
     // single characters and have hooks written into `~`, `/`, and cwd. Only
     // accept an array of strings.
     ...(Array.isArray(configDirs)

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -218,7 +218,7 @@ export interface Preferences {
    * `~/.claude-personal`). The default `~/.claude` is always watched. Paths
    * may start with `~`. See `resolveClaudeProjectDirs`.
    */
-  claudeConfigDirs?: string[];
+  additionalClaudeConfigDirs?: string[];
   columns?: ColumnsConfig;
   breakpoints?: BreakpointConfig;
   /** Default prompt display mode (default "inline"). The runtime `p`-key


### PR DESCRIPTION
## Summary

Renames the `claudeConfigDirs` preference (merged in #9) to `additionalClaudeConfigDirs`, and bundles the follow-ups from the #9 review. The old name read like the full list of Claude config dirs, inviting the wrong assumption that `~/.claude` must be listed or gets replaced; the semantics are strictly additive (the default dir is always watched), so the key now says so. Since the feature hasn't shipped in a tagged release, this is a clean rename with no back-compat alias.

Follow-ups included:

- **Register the key in `ccmux config set`.** It was documented but never added to `KNOWN_KEYS`, so the CLI rejected it as an unknown key and the only way to configure it was editing `ccmux.json` by hand. Validates a JSON array of strings (a bare string is rejected at the CLI layer too) and prints the `ccmux setup --agent claude` + `ccmux daemon restart` follow-up on success.
- **Fold the reconciler's `isRecentlyProcessed` guard across all Claude watchers.** An extra config-dir watcher records freshness on its own `lastProcessedAt`, so consulting only the primary let second-account sessions bypass the just-processed debounce guard (a narrow, self-healing race, but a real inconsistency introduced by the fan-out).
- **Document the multi-watcher design in `docs/architecture.md`** (per AGENTS.md's delegation of daemon internals there): the per-config-dir watcher fan-out and the `ownsSession`/`ownerFor` marker routing.

## Related issue

Follow-up to #9 (refs #6).

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (config, hook-adapter, binder, and state-reconciler suites; same pre-existing env-only failures as `main` excluded)
- [ ] Verified the affected TUI surface (picker / sidebar) in a detached tmux session (if this touches the TUI, columns, layout, theming, or the daemon → TUI data path) — N/A, no TUI surface touched
- [x] Verified end to end with a real agent session (if this touches detection, state, the daemon, or the CLI) — exercised the new `config set` key against the real CLI: invalid JSON and a bare string are rejected with the key's usage hint, a valid array round-trips through `config set`/`config get`, and the success note prints (prefs file backed up and restored)

## Notes for reviewers

- `grep claudeConfigDirs` across `src/`, `README.md`, and `docs/` returns nothing; the `Preferences` type change makes the compiler enforce the rename at every read site.
- The `resolveClaudeConfigDirs`/`resolveClaudeProjectDirs` function names are intentionally unchanged: they resolve the full set including the always-present `~/.claude`, so "additional" would be wrong there. Internal `extraClaudeWatchers` identifiers are also left as-is (mechanism naming, not user-facing).
- The reconciler fix is contained: `ReconcilerDeps.watcher` is typed as the minimal `{ isRecentlyProcessed }` interface, so the fold touches no other consumer.