### PR TITLE
feat(review): Send hunk review notes back to the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ ccmux setup
 | `ccmux review [id]`                         | Review a session's diff with [hunk](https://github.com/modem-dev/hunk) (defaults to cwd)        |
 | `ccmux kill <id>`                           | Kill a session's process                                                                        |
 | `ccmux restart <id>`                        | Kill and resume a session                                                                       |
-| `ccmux send <id> <text>`                    | Send text to a session's tmux pane                                                              |
+| `ccmux send <id> <text>`                    | Send text to a session's tmux pane (multiline pastes as one message; `--no-enter` skips submit) |
 | `ccmux screen [id]`                         | Capture pane content                                                                            |
 | `ccmux screen --grep <pattern>`             | Search across all session panes                                                                 |
 | `ccmux dismiss <id>`                        | Remove a session from tracking                                                                  |
@@ -138,6 +138,8 @@ To send review feedback back to the agent:
 1. Press <kbd>c</kbd> in hunk to annotate a line, then <kbd>Ctrl+S</kbd> to save the note.
 2. Add any other review notes and quit hunk.
 3. Confirm **Send review comments** when the picker resumes. ccmux sends all captured notes, including short source snippets, to the agent as one prompt and stays in the picker so you can watch its status.
+
+The offer relies on hunk's session JSON commands (`hunk session list` / `session comment list`, verified against hunk 0.17.0). With an older hunk the review itself still works; the offer just doesn't appear.
 
 The `reviewHandback` preference controls what happens when hunk exits:
 
@@ -236,31 +238,31 @@ Other skills-capable agents (Codex, Cursor, OpenCode, and others) can use the sa
 
 ## ⌨️ Keyboard Controls
 
-| Action                | Key                                                                                | Description                                                                                        |
-| :-------------------- | :--------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------- |
-| Navigate              | <kbd>j</kbd> / <kbd>k</kbd> or <kbd>↑</kbd> / <kbd>↓</kbd>                         | Move through session list                                                                          |
-| Jump to first/last    | <kbd>g</kbd><kbd>g</kbd> / <kbd>G</kbd>                                            | Go to top / bottom                                                                                 |
-| Jump to session       | <kbd>1</kbd>–<kbd>9</kbd>                                                          | Switch directly to session N                                                                       |
-| Switch to session     | <kbd>Enter</kbd>                                                                   | Switch tmux to the selected pane                                                                   |
-| Search                | <kbd>/</kbd>                                                                       | Enter fuzzy search mode                                                                            |
-| Toggle preview        | <kbd>P</kbd>                                                                       | Show/hide the preview panel                                                                        |
-| Scroll preview        | <kbd>Ctrl+D</kbd> / <kbd>Ctrl+U</kbd>                                              | Half-page scroll in preview                                                                        |
-| Resize preview        | <kbd>Alt+H</kbd> / <kbd>Alt+L</kbd>                                                | Increase/decrease preview width                                                                    |
-| Focus preview         | <kbd>Tab</kbd>                                                                     | Send keys directly to tmux pane                                                                    |
-| Restart session       | <kbd>r</kbd>                                                                       | Kill and resume the selected session                                                               |
-| Reconnect             | <kbd>R</kbd>                                                                       | Reconnect to the daemon SSE stream                                                                 |
-| Kill session          | <kbd>x</kbd>                                                                       | Kill the selected session's process                                                                |
-| Kill all              | <kbd>X</kbd>                                                                       | Kill all tracked sessions                                                                          |
+| Action                | Key                                                                                | Description                                                                                                            |
+| :-------------------- | :--------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- |
+| Navigate              | <kbd>j</kbd> / <kbd>k</kbd> or <kbd>↑</kbd> / <kbd>↓</kbd>                         | Move through session list                                                                                              |
+| Jump to first/last    | <kbd>g</kbd><kbd>g</kbd> / <kbd>G</kbd>                                            | Go to top / bottom                                                                                                     |
+| Jump to session       | <kbd>1</kbd>–<kbd>9</kbd>                                                          | Switch directly to session N                                                                                           |
+| Switch to session     | <kbd>Enter</kbd>                                                                   | Switch tmux to the selected pane                                                                                       |
+| Search                | <kbd>/</kbd>                                                                       | Enter fuzzy search mode                                                                                                |
+| Toggle preview        | <kbd>P</kbd>                                                                       | Show/hide the preview panel                                                                                            |
+| Scroll preview        | <kbd>Ctrl+D</kbd> / <kbd>Ctrl+U</kbd>                                              | Half-page scroll in preview                                                                                            |
+| Resize preview        | <kbd>Alt+H</kbd> / <kbd>Alt+L</kbd>                                                | Increase/decrease preview width                                                                                        |
+| Focus preview         | <kbd>Tab</kbd>                                                                     | Send keys directly to tmux pane                                                                                        |
+| Restart session       | <kbd>r</kbd>                                                                       | Kill and resume the selected session                                                                                   |
+| Reconnect             | <kbd>R</kbd>                                                                       | Reconnect to the daemon SSE stream                                                                                     |
+| Kill session          | <kbd>x</kbd>                                                                       | Kill the selected session's process                                                                                    |
+| Kill all              | <kbd>X</kbd>                                                                       | Kill all tracked sessions                                                                                              |
 | Review and hand back  | <kbd>d</kbd>                                                                       | Review with [hunk](https://github.com/modem-dev/hunk), then offer to send notes to the agent (requires `hunk` on PATH) |
-| Collapse/expand       | <kbd>h</kbd> / <kbd>l</kbd> or <kbd>Space</kbd>                                    | Toggle group collapsed state                                                                       |
-| Move group            | <kbd>J</kbd> / <kbd>K</kbd>                                                        | Reorder group down / up (persisted)                                                                |
-| Move group top/bottom | <kbd><</kbd> / <kbd>></kbd>                                                        | Pin group to top / bottom                                                                          |
-| Collapse/expand all   | <kbd>z</kbd><kbd>M</kbd> / <kbd>z</kbd><kbd>R</kbd> or <kbd>-</kbd> / <kbd>=</kbd> | Collapse or expand all groups                                                                      |
-| Hide idle             | <kbd>f</kbd>                                                                       | Toggle hiding idle sessions                                                                        |
-| Cycle prompt          | <kbd>p</kbd>                                                                       | Prompt display: inline → own row → off                                                             |
-| Cycle group-by        | <kbd>b</kbd>                                                                       | Cycle through group-by modes                                                                       |
-| Help                  | <kbd>?</kbd>                                                                       | Show keyboard shortcuts overlay                                                                    |
-| Quit                  | <kbd>q</kbd> / <kbd>Esc</kbd>                                                      | Exit the picker                                                                                    |
+| Collapse/expand       | <kbd>h</kbd> / <kbd>l</kbd> or <kbd>Space</kbd>                                    | Toggle group collapsed state                                                                                           |
+| Move group            | <kbd>J</kbd> / <kbd>K</kbd>                                                        | Reorder group down / up (persisted)                                                                                    |
+| Move group top/bottom | <kbd><</kbd> / <kbd>></kbd>                                                        | Pin group to top / bottom                                                                                              |
+| Collapse/expand all   | <kbd>z</kbd><kbd>M</kbd> / <kbd>z</kbd><kbd>R</kbd> or <kbd>-</kbd> / <kbd>=</kbd> | Collapse or expand all groups                                                                                          |
+| Hide idle             | <kbd>f</kbd>                                                                       | Toggle hiding idle sessions                                                                                            |
+| Cycle prompt          | <kbd>p</kbd>                                                                       | Prompt display: inline → own row → off                                                                                 |
+| Cycle group-by        | <kbd>b</kbd>                                                                       | Cycle through group-by modes                                                                                           |
+| Help                  | <kbd>?</kbd>                                                                       | Show keyboard shortcuts overlay                                                                                        |
+| Quit                  | <kbd>q</kbd> / <kbd>Esc</kbd>                                                      | Exit the picker                                                                                                        |
 
 <details>
 <summary><strong>Search mode keys</strong></summary>
@@ -312,7 +314,7 @@ ccmux config list
 | `searchPaneLines`            | `10`–`500`                                                                   | `100`              | Lines of pane content scanned in TUI search                                                                                        |
 | `searchTranscript`           | `true`, `false`                                                              | `true`             | Search live Claude/Codex transcripts (full history + assistant text) via the daemon                                                |
 | `persistent`                 | `true`, `false`                                                              | `false`            | Keep picker open after switching sessions (dashboard mode)                                                                         |
-| `reviewHandback`             | `confirm`, `auto`, `fill`                                                     | `confirm`          | After a hunk review, confirm delivery, send immediately, or fill the agent composer without submitting                             |
+| `reviewHandback`             | `confirm`, `auto`, `fill`                                                    | `confirm`          | After a hunk review, confirm delivery, send immediately, or fill the agent composer without submitting                             |
 | `sidebar.width`              | `10`–`80`                                                                    | `30`               | Sidebar pane width in columns                                                                                                      |
 | `sidebar.position`           | `left`, `right`                                                              | `left`             | Which side of the window to place the sidebar                                                                                      |
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,19 @@ https://github.com/user-attachments/assets/7e0d42b3-4e7b-43b8-8d06-72a2d69dd694
 
 ### Diff Review with Hunk
 
-[hunk](https://github.com/modem-dev/hunk) is a terminal diff reviewer. With `hunk` on your `PATH`, press <kbd>d</kbd> in the picker to review the selected session's working-tree diff without leaving ccmux: the picker suspends, `hunk diff --watch` takes over the pane in the session's repository root, and the picker resumes when hunk exits. The same action is available from the right-click context menu.
+[hunk](https://github.com/modem-dev/hunk) is a terminal diff reviewer. With `hunk` on your `PATH`, press <kbd>d</kbd> in the picker to review the selected session's working-tree diff without leaving ccmux: the picker suspends, `hunk diff --watch` takes over the pane in the session's repository root, and the picker resumes when hunk exits. The same action is available from the right-click context menu. If the working tree has no changes, ccmux reports that instead of opening an empty review.
+
+To send review feedback back to the agent:
+
+1. Press <kbd>c</kbd> in hunk to annotate a line, then <kbd>Ctrl+S</kbd> to save the note.
+2. Add any other review notes and quit hunk.
+3. Confirm **Send review comments** when the picker resumes. ccmux sends all captured notes, including short source snippets, to the agent as one prompt and stays in the picker so you can watch its status.
+
+The `reviewHandback` preference controls what happens when hunk exits:
+
+- `confirm` (default) asks before sending the prompt.
+- `auto` sends and submits the prompt immediately without a dialog.
+- `fill` pastes the prompt into the agent's composer without submitting it. The text remains there until you jump to the session and submit or edit it; a later send or invoke may find it prepended.
 
 The review also runs from the CLI:
 
@@ -239,7 +251,7 @@ Other skills-capable agents (Codex, Cursor, OpenCode, and others) can use the sa
 | Reconnect             | <kbd>R</kbd>                                                                       | Reconnect to the daemon SSE stream                                                                 |
 | Kill session          | <kbd>x</kbd>                                                                       | Kill the selected session's process                                                                |
 | Kill all              | <kbd>X</kbd>                                                                       | Kill all tracked sessions                                                                          |
-| Review diff           | <kbd>d</kbd>                                                                       | Review the session's diff with [hunk](https://github.com/modem-dev/hunk) (requires `hunk` on PATH) |
+| Review and hand back  | <kbd>d</kbd>                                                                       | Review with [hunk](https://github.com/modem-dev/hunk), then offer to send notes to the agent (requires `hunk` on PATH) |
 | Collapse/expand       | <kbd>h</kbd> / <kbd>l</kbd> or <kbd>Space</kbd>                                    | Toggle group collapsed state                                                                       |
 | Move group            | <kbd>J</kbd> / <kbd>K</kbd>                                                        | Reorder group down / up (persisted)                                                                |
 | Move group top/bottom | <kbd><</kbd> / <kbd>></kbd>                                                        | Pin group to top / bottom                                                                          |
@@ -300,6 +312,7 @@ ccmux config list
 | `searchPaneLines`            | `10`–`500`                                                                   | `100`              | Lines of pane content scanned in TUI search                                                                                        |
 | `searchTranscript`           | `true`, `false`                                                              | `true`             | Search live Claude/Codex transcripts (full history + assistant text) via the daemon                                                |
 | `persistent`                 | `true`, `false`                                                              | `false`            | Keep picker open after switching sessions (dashboard mode)                                                                         |
+| `reviewHandback`             | `confirm`, `auto`, `fill`                                                     | `confirm`          | After a hunk review, confirm delivery, send immediately, or fill the agent composer without submitting                             |
 | `sidebar.width`              | `10`–`80`                                                                    | `30`               | Sidebar pane width in columns                                                                                                      |
 | `sidebar.position`           | `left`, `right`                                                              | `left`             | Which side of the window to place the sidebar                                                                                      |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,6 +173,8 @@ Constructed in `Daemon.start()` only when `backgroundAgents !== false` (opt-out 
 
 The Server (`server.ts`) starts at the top of `Daemon.start()`, before session migration, marker replay, and the initial scan: auto-start callers poll `/health` on a short budget, and a session-heavy boot would otherwise outlast it. Early SSE clients get a sparse `init` and hydrate live via `session_created` / `session_updated`. `GET /server-info` returns `{ socketPath: string | null }`, the tmux socket the daemon scans, so consumers can refuse cross-server pane targeting.
 
+`POST /sessions/:id/send` routes single-line text through `sendLiteralToPane` and multiline text through `sendPromptToPane` in `pane-io.ts`; the latter uses tmux bracketed paste so embedded newlines remain one prompt, and both paths honor requests that paste without pressing Enter.
+
 `lifecycle.ts` owns process management: PID-file read/write, HTTP `/health` liveness (used instead of the PID file alone, because a dead daemon's PID can be recycled by an unrelated process — a false positive would suppress auto-start), detached background spawn, and PID-reuse-safe zombie-port recovery. `stopDaemonByPort` signals only the confirmed port LISTENer found via `findDaemonPidByPort` (`lsof -sTCP:LISTEN`), never the PID-file PID, and spares a foreign squatter whose `ps` command line isn't `daemon start` (fail-open on an unreadable cmd to preserve recovery). The auto-start/recovery flow that composes these lives in `src/commands/shared.ts` (`ensureDaemon` → `launchDaemon`: evict the zombie holding the port, spawn fresh, wait for health, surface the blocker's PID/cmd on failure), shared by every CLI entrypoint.
 
 ## Where to look in the code

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -154,3 +154,22 @@ describe("KNOWN_KEYS.additionalClaudeConfigDirs", () => {
     expect(spec.parse('["~/a","~/b"]')).toEqual(["~/a", "~/b"]);
   });
 });
+
+describe("KNOWN_KEYS.reviewHandback", () => {
+  const spec = KNOWN_KEYS.reviewHandback!;
+
+  it("validate accepts the known delivery modes", () => {
+    expect(spec.validate("auto")).toBe(true);
+    expect(spec.validate("confirm")).toBe(true);
+    expect(spec.validate("fill")).toBe(true);
+  });
+
+  it("validate rejects unknown values", () => {
+    expect(spec.validate("bogus")).toBe(false);
+    expect(spec.validate("")).toBe(false);
+  });
+
+  it("parse returns the value unchanged", () => {
+    expect(spec.parse("auto")).toBe("auto");
+  });
+});

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -5,6 +5,7 @@ import {
   setPreferences,
   VALID_GROUP_BY,
   VALID_PROMPT_DISPLAYS,
+  VALID_REVIEW_HANDBACK,
   BREAKPOINT_NAMES,
   COLUMN_FIELDS,
   type BreakpointConfig,
@@ -113,6 +114,11 @@ export const KNOWN_KEYS: Record<
     parse: (v) => v === "true",
     description:
       "Keep picker open after switching sessions (true, false; default false)",
+  },
+  reviewHandback: {
+    validate: (v) => (VALID_REVIEW_HANDBACK as readonly string[]).includes(v),
+    parse: (v) => v,
+    description: `Hunk review note delivery (${VALID_REVIEW_HANDBACK.join(", ")}; default confirm)`,
   },
   theme: {
     validate: (v) => BUILTIN_THEME_NAMES.includes(v),

--- a/src/commands/picker.ts
+++ b/src/commands/picker.ts
@@ -100,6 +100,7 @@ export function createPickerCommand(): Command {
           hideIdle: uiState.hideIdle,
           promptDisplay: resolvePromptDisplay(uiState, prefs.promptDisplay),
           persistent,
+          reviewHandback: prefs.reviewHandback,
           theme: prefs.theme,
         });
       },

--- a/src/commands/sidebar.ts
+++ b/src/commands/sidebar.ts
@@ -169,6 +169,7 @@ export function createSidebarCommand(): Command {
           hideIdle: uiState.hideIdle,
           promptDisplay: resolvePromptDisplay(uiState, prefs.promptDisplay),
           sidebar: true,
+          reviewHandback: prefs.reviewHandback,
           theme: prefs.theme,
         });
       },

--- a/src/daemon/invokers/claude-invoker.ts
+++ b/src/daemon/invokers/claude-invoker.ts
@@ -226,6 +226,7 @@ export class ClaudeInvoker implements Invoker {
         const sentPrompt = await this.deps.tmux.sendPromptToPane(
           paneId,
           input.prompt,
+          true,
         );
         if (!sentPrompt) {
           if (signal.aborted) {
@@ -264,6 +265,7 @@ export class ClaudeInvoker implements Invoker {
         const sentPrompt = await this.deps.tmux.sendPromptToPane(
           paneId,
           input.prompt,
+          true,
         );
         if (!sentPrompt) {
           if (signal.aborted) {

--- a/src/daemon/pane-io.ts
+++ b/src/daemon/pane-io.ts
@@ -102,7 +102,7 @@ export async function sendLiteralToPane(
  * input box instead of being interpreted as separate Enter presses
  * (which is what `send-keys -l` does for any string containing `\n`).
  *
- * After pasting, sends an explicit Enter to submit.
+ * After pasting, optionally sends an explicit Enter to submit.
  *
  * Do NOT use this for shell commands (the buffer's bracketed-paste
  * sequence is meaningless to a non-readline shell); use sendLiteralToPane
@@ -111,6 +111,7 @@ export async function sendLiteralToPane(
 export async function sendPromptToPane(
   paneId: string,
   text: string,
+  pressEnter: boolean,
 ): Promise<boolean> {
   // Per-pane buffer name keeps concurrent invocations from clobbering
   // each other's buffer if tmux ever schedules paste-buffer out of order.
@@ -134,15 +135,19 @@ export async function sendPromptToPane(
     const pasteExit = await paste.exited;
     if (pasteExit !== 0) return false;
 
-    // Same 150ms gap as sendLiteralToPane: gives the TUI a tick to
-    // commit the paste before we send the submit.
-    await new Promise((resolve) => setTimeout(resolve, 150));
-    const enter = Bun.spawn(["tmux", "send-keys", "-t", paneId, "Enter"], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const enterExit = await enter.exited;
-    return enterExit === 0;
+    if (pressEnter) {
+      // Same 150ms gap as sendLiteralToPane: gives the TUI a tick to
+      // commit the paste before we send the submit.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      const enter = Bun.spawn(["tmux", "send-keys", "-t", paneId, "Enter"], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const enterExit = await enter.exited;
+      if (enterExit !== 0) return false;
+    }
+
+    return true;
   } catch {
     return false;
   }

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, spyOn, afterAll } from "bun:test";
+import { describe, it, expect, spyOn, afterAll, mock } from "bun:test";
 import {
   DaemonServer,
   rejectCrossOriginBrowser,
@@ -19,6 +19,7 @@ import type { HookAdapter } from "./hook-adapter";
 import { mkdtempSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import type { sendLiteralToPane, sendPromptToPane } from "./pane-io";
 
 /**
  * Access private methods/fields on DaemonServer for unit testing.
@@ -94,6 +95,13 @@ function createServer(
   tracker?: AttentionTracker,
   getHookAdapter?: (name: string) => HookAdapter | null,
   agentLookup?: (name: string) => AgentDef | undefined,
+  paneSendDeps: {
+    sendLiteralToPane: typeof sendLiteralToPane;
+    sendPromptToPane: typeof sendPromptToPane;
+  } = {
+    sendLiteralToPane: mock(async () => true),
+    sendPromptToPane: mock(async () => true),
+  },
 ) {
   const mgr = manager ?? new SessionManager();
   const cache = paneCache ?? new Map<string, TmuxPane>();
@@ -116,6 +124,7 @@ function createServer(
     attn,
     invocationManager,
     resolveHookAdapter,
+    paneSendDeps,
   );
   return {
     manager: mgr,
@@ -910,6 +919,114 @@ describe("DaemonServer", () => {
       expect(data.error).toBe(
         "Text exceeds maximum length of 10,000 characters",
       );
+    });
+
+    it("routes single-line text through literal delivery with enter threading", async () => {
+      const paneSendDeps = {
+        sendLiteralToPane: mock(async () => true),
+        sendPromptToPane: mock(async () => true),
+      };
+      const { manager, internals } = createServer(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        paneSendDeps,
+      );
+      manager.createSession(
+        "s1",
+        "/Users/test/.claude/projects/-Users-test-proj/s1.jsonl",
+      );
+      manager.setTmuxPane("s1", "%1");
+
+      const response = await internals.handleSendToSession(
+        "s1",
+        new Request("http://localhost/sessions/s1/send", {
+          method: "POST",
+          body: JSON.stringify({ text: "hello", enter: false }),
+        }),
+        {},
+      );
+
+      expect(response.status).toBe(200);
+      expect(paneSendDeps.sendLiteralToPane).toHaveBeenCalledWith(
+        "%1",
+        "hello",
+        false,
+      );
+      expect(paneSendDeps.sendPromptToPane).not.toHaveBeenCalled();
+    });
+
+    it("routes multiline text through bracketed-paste delivery with enter threading", async () => {
+      const paneSendDeps = {
+        sendLiteralToPane: mock(async () => true),
+        sendPromptToPane: mock(async () => true),
+      };
+      const { manager, internals } = createServer(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        paneSendDeps,
+      );
+      manager.createSession(
+        "s1",
+        "/Users/test/.claude/projects/-Users-test-proj/s1.jsonl",
+      );
+      manager.setTmuxPane("s1", "%1");
+
+      const response = await internals.handleSendToSession(
+        "s1",
+        new Request("http://localhost/sessions/s1/send", {
+          method: "POST",
+          body: JSON.stringify({ text: "line one\nline two", enter: false }),
+        }),
+        {},
+      );
+
+      expect(response.status).toBe(200);
+      expect(paneSendDeps.sendPromptToPane).toHaveBeenCalledWith(
+        "%1",
+        "line one\nline two",
+        false,
+      );
+      expect(paneSendDeps.sendLiteralToPane).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 when pane delivery fails", async () => {
+      const paneSendDeps = {
+        sendLiteralToPane: mock(async () => false),
+        sendPromptToPane: mock(async () => true),
+      };
+      const { manager, internals } = createServer(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        paneSendDeps,
+      );
+      manager.createSession(
+        "s1",
+        "/Users/test/.claude/projects/-Users-test-proj/s1.jsonl",
+      );
+      manager.setTmuxPane("s1", "%1");
+
+      const response = await internals.handleSendToSession(
+        "s1",
+        new Request("http://localhost/sessions/s1/send", {
+          method: "POST",
+          body: JSON.stringify({ text: "hello" }),
+        }),
+        {},
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "Failed to send to session",
+      });
     });
   });
 

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -3,14 +3,11 @@ import {
   DAEMON_PORT,
   DAEMON_HOST,
   HEARTBEAT_INTERVAL_MS,
+  MAX_SEND_TEXT_CHARS,
   isCcmuxPane,
 } from "../lib/config";
 import { getPreferences } from "../lib/preferences";
-import {
-  capturePane,
-  sendLiteralToPane,
-  sendPromptToPane,
-} from "./pane-io";
+import { capturePane, sendLiteralToPane, sendPromptToPane } from "./pane-io";
 import type { AgentDef } from "../lib/agents";
 import {
   getMarkerKey,
@@ -1170,9 +1167,11 @@ export class DaemonServer {
       );
     }
 
-    if (text.length > 10_000) {
+    if (text.length > MAX_SEND_TEXT_CHARS) {
       return Response.json(
-        { error: "Text exceeds maximum length of 10,000 characters" },
+        {
+          error: `Text exceeds maximum length of ${MAX_SEND_TEXT_CHARS.toLocaleString("en-US")} characters`,
+        },
         { status: 400, headers },
       );
     }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -6,7 +6,11 @@ import {
   isCcmuxPane,
 } from "../lib/config";
 import { getPreferences } from "../lib/preferences";
-import { capturePane } from "./pane-io";
+import {
+  capturePane,
+  sendLiteralToPane,
+  sendPromptToPane,
+} from "./pane-io";
 import type { AgentDef } from "../lib/agents";
 import {
   getMarkerKey,
@@ -51,6 +55,10 @@ interface SSEClient {
 /** Function to get the current pane cache from the daemon */
 type PaneCacheGetter = () => Map<string, TmuxPane>;
 type AgentLookup = (agentType: string) => AgentDef | undefined;
+interface PaneSendDeps {
+  sendLiteralToPane: typeof sendLiteralToPane;
+  sendPromptToPane: typeof sendPromptToPane;
+}
 
 /** Cached git branch result */
 interface BranchCacheEntry {
@@ -226,6 +234,7 @@ export class DaemonServer {
   private attentionTracker: AttentionTracker;
   private invocationManager: InvocationManager;
   private getHookAdapter: (agentName: string) => HookAdapter | null;
+  private paneSendDeps: PaneSendDeps;
 
   constructor(
     sessionManager: SessionManager,
@@ -234,6 +243,7 @@ export class DaemonServer {
     attentionTracker: AttentionTracker,
     invocationManager: InvocationManager,
     getHookAdapter: (agentName: string) => HookAdapter | null,
+    paneSendDeps: PaneSendDeps = { sendLiteralToPane, sendPromptToPane },
   ) {
     this.sessionManager = sessionManager;
     this.getPaneCache = getPaneCache;
@@ -241,6 +251,7 @@ export class DaemonServer {
     this.attentionTracker = attentionTracker;
     this.invocationManager = invocationManager;
     this.getHookAdapter = getHookAdapter;
+    this.paneSendDeps = paneSendDeps;
 
     // Listen for session changes
     this.sessionManager.on("change", async (event: SessionEvent) => {
@@ -1172,31 +1183,12 @@ export class DaemonServer {
     // wrong pane. `%N` is immutable for the pane's life.
     const target = session.tmuxPane;
 
-    try {
-      // Send text literally (no key-name interpretation)
-      const proc = Bun.spawn(
-        ["tmux", "send-keys", "-t", target, "-l", "--", text],
-        { stdout: "pipe", stderr: "pipe" },
-      );
-      const exitCode = await proc.exited;
-      if (exitCode !== 0) {
-        const stderr = await new Response(proc.stderr).text();
-        return Response.json(
-          { error: `tmux send-keys failed: ${stderr.trim()}` },
-          { status: 500, headers },
-        );
-      }
-
-      if (enter) {
-        const enterProc = Bun.spawn(
-          ["tmux", "send-keys", "-t", target, "Enter"],
-          { stdout: "pipe", stderr: "pipe" },
-        );
-        await enterProc.exited;
-      }
-    } catch (err: unknown) {
+    const sent = text.includes("\n")
+      ? await this.paneSendDeps.sendPromptToPane(target, text, enter)
+      : await this.paneSendDeps.sendLiteralToPane(target, text, enter);
+    if (!sent) {
       return Response.json(
-        { error: `Failed to send to session: ${errorMessage(err)}` },
+        { error: "Failed to send to session" },
         { status: 500, headers },
       );
     }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -202,6 +202,13 @@ export const ZOMBIE_STALE_MS = 5 * 60 * 1000;
 export const BACKGROUND_FRESH_THRESHOLD_MS = 10_000;
 
 /**
+ * Maximum text length accepted by the daemon's `POST /sessions/:id/send`
+ * endpoint. The review hand-back prompt cap (`MAX_REVIEW_PROMPT_CHARS`)
+ * derives from this so the client never builds a prompt the daemon rejects.
+ */
+export const MAX_SEND_TEXT_CHARS = 10_000;
+
+/**
  * Log parsing configuration
  */
 export const MAX_LOG_ENTRIES = 100;

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -84,6 +84,15 @@ export type PromptDisplay = (typeof VALID_PROMPT_DISPLAYS)[number];
 /** Prompt display mode applied when neither config nor runtime state sets one. */
 export const DEFAULT_PROMPT_DISPLAY: PromptDisplay = "inline";
 
+/**
+ * How harvested hunk review comments are delivered back to the agent.
+ * - `confirm`: show a confirmation dialog before sending (default).
+ * - `auto`: send immediately with no dialog.
+ * - `fill`: fill the composer without submitting.
+ */
+export const VALID_REVIEW_HANDBACK = ["auto", "confirm", "fill"] as const;
+export type ReviewHandback = (typeof VALID_REVIEW_HANDBACK)[number];
+
 /** All field identifiers placeable in a row's left or right side */
 export const COLUMN_FIELDS = [
   "index",
@@ -235,7 +244,7 @@ export interface Preferences {
   /** Keep picker open after switching sessions (default false) */
   persistent?: boolean;
   /** Hunk review note delivery: confirm first (default), send automatically, or fill without submitting. */
-  reviewHandback?: "auto" | "confirm" | "fill";
+  reviewHandback?: ReviewHandback;
   /**
    * Surface Claude Code background agents (`claude --bg` / the agent view)
    * as rows (default true; only an explicit `false` disables). Gated

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -234,6 +234,8 @@ export interface Preferences {
   groupBy?: GroupBy;
   /** Keep picker open after switching sessions (default false) */
   persistent?: boolean;
+  /** Hunk review note delivery: confirm first (default), send automatically, or fill without submitting. */
+  reviewHandback?: "auto" | "confirm" | "fill";
   /**
    * Surface Claude Code background agents (`claude --bg` / the agent view)
    * as rows (default true; only an explicit `false` disables). Gated

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -1557,9 +1557,7 @@ describe("App review (d)", () => {
     // second press. A rapid double-d must not race two suspend/spawn/resume
     // cycles against the same renderer.
     let resolveReview!: (
-      r:
-        | { ok: true; notes: typeof reviewNotes }
-        | { ok: false; error: string },
+      r: { ok: true; notes: typeof reviewNotes } | { ok: false; error: string },
     ) => void;
     runHunkReviewSpy.mockImplementation(
       () =>
@@ -1638,6 +1636,24 @@ describe("App review (d)", () => {
     expect(setup.captureCharFrame()).toContain("Review failed: boom");
   });
 
+  it("recovers when runHunkReview rejects unexpectedly", async () => {
+    runHunkReviewSpy.mockImplementation(() =>
+      Promise.reject(new Error("resume blew up")),
+    );
+    await renderWithSession();
+    setup.mockInput.pressKey("d");
+    await setup.renderOnce();
+    await new Promise((r) => setTimeout(r, 0));
+    await setup.renderOnce();
+    expect(setup.captureCharFrame()).toContain("Review failed");
+    // reviewInFlight was reset by the catch handler, so `d` still works.
+    runHunkReviewSpy.mockClear();
+    runHunkReviewSpy.mockImplementation(async () => ({ ok: true, notes: [] }));
+    setup.mockInput.pressKey("d");
+    await setup.renderOnce();
+    expect(runHunkReviewSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("defaults to a confirmation dialog with the note count and agent label", async () => {
     runHunkReviewSpy.mockImplementation(async () => ({
       ok: true,
@@ -1687,6 +1703,31 @@ describe("App review (d)", () => {
     }
   });
 
+  it("shows a failure toast when review delivery returns a non-ok status", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      return new Response(null, { status: 500 });
+    }) as unknown as typeof fetch;
+    try {
+      runHunkReviewSpy.mockImplementation(async () => ({
+        ok: true,
+        notes: reviewNotes,
+      }));
+      await renderWithSession({}, { agentType: "claude", tmuxPane: "%1" });
+      setup.mockInput.pressKey("d");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await setup.renderOnce();
+      setup.mockInput.pressKey("y");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await setup.renderOnce();
+      expect(setup.captureCharFrame()).toContain(
+        "Failed to send review comments to claude",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("drops pending notes when confirmation is cancelled", async () => {
     const originalFetch = globalThis.fetch;
     const urls: string[] = [];
@@ -1718,15 +1759,12 @@ describe("App review (d)", () => {
       ok: true,
       notes: reviewNotes,
     }));
-    await renderWithSession(
-      {},
-      { trackingMode: "background", tmuxPane: null },
-    );
+    await renderWithSession({}, { trackingMode: "background", tmuxPane: null });
     setup.mockInput.pressKey("d");
     await new Promise((resolve) => setTimeout(resolve, 0));
     await setup.renderOnce();
     const frame = setup.captureCharFrame();
-    expect(frame).toContain("1 review notes captured (no pane to send to)");
+    expect(frame).toContain("1 review note captured (no pane to send to)");
     expect(frame).not.toContain("Send review comments");
   });
 
@@ -1746,7 +1784,10 @@ describe("App review (d)", () => {
       return new Response(null, { status: 200 });
     }) as unknown as typeof fetch;
     try {
-      runHunkReviewSpy.mockImplementation(async () => ({ ok: true, notes: reviewNotes }));
+      runHunkReviewSpy.mockImplementation(async () => ({
+        ok: true,
+        notes: reviewNotes,
+      }));
       await renderWithSession({ reviewHandback: "auto" }, { tmuxPane: "%1" });
       setup.mockInput.pressKey("d");
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -1766,8 +1807,14 @@ describe("App review (d)", () => {
       return new Response(null, { status: 200 });
     }) as unknown as typeof fetch;
     try {
-      runHunkReviewSpy.mockImplementation(async () => ({ ok: true, notes: reviewNotes }));
-      await renderWithSession({ reviewHandback: "fill" }, { agentType: "codex", tmuxPane: "%1" });
+      runHunkReviewSpy.mockImplementation(async () => ({
+        ok: true,
+        notes: reviewNotes,
+      }));
+      await renderWithSession(
+        { reviewHandback: "fill" },
+        { agentType: "codex", tmuxPane: "%1" },
+      );
       setup.mockInput.pressKey("d");
       await new Promise((resolve) => setTimeout(resolve, 0));
       await setup.renderOnce();

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -1828,6 +1828,31 @@ describe("App review (d)", () => {
     }
   });
 
+  it("falls back to the confirm dialog for an unrecognized reviewHandback value", async () => {
+    // An unvalidated config typo (e.g. "Fill") must degrade to the confirm
+    // dialog, never silently auto-submit the review to the agent.
+    const originalFetch = globalThis.fetch;
+    const urls: string[] = [];
+    globalThis.fetch = mock(async (url: string | URL) => {
+      urls.push(String(url));
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+    try {
+      runHunkReviewSpy.mockImplementation(async () => ({
+        ok: true,
+        notes: reviewNotes,
+      }));
+      await renderWithSession({ reviewHandback: "Fill" }, { tmuxPane: "%1" });
+      setup.mockInput.pressKey("d");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await setup.renderOnce();
+      expect(setup.captureCharFrame()).toContain("Send review comments");
+      expect(urls.some((url) => url.endsWith("/sessions/s1/send"))).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("shows Review diff in the context menu when reviewable", async () => {
     await renderWithSession();
     await setup.mockMouse.click(5, 1, MouseButtons.RIGHT);

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -72,9 +72,21 @@ let hunkAvailable = true;
 const runHunkReviewSpy = mock(
   async (
     ..._args: unknown[]
-  ): Promise<{ ok: true } | { ok: false; error: string }> => ({ ok: true }),
+  ): Promise<
+    { ok: true; notes: typeof reviewNotes } | { ok: false; error: string }
+  > => ({ ok: true, notes: [] }),
 );
 const HUNK_INSTALL_HINT_TEST = realReview.HUNK_INSTALL_HINT;
+const reviewNotes = [
+  {
+    noteId: "n1",
+    filePath: "src/foo.ts",
+    hunkIndex: 0,
+    newRange: [12, 12] as [number, number],
+    body: "Handle the missing token.",
+    snippet: "const token = getToken();",
+  },
+];
 
 mock.module("./utils/review", () => ({
   ...realReview,
@@ -111,7 +123,7 @@ beforeEach(() => {
   openAgentsWindowSpy.mockImplementation(async () => ({ ok: true }));
   hunkAvailable = true;
   runHunkReviewSpy.mockClear();
-  runHunkReviewSpy.mockImplementation(async () => ({ ok: true }));
+  runHunkReviewSpy.mockImplementation(async () => ({ ok: true, notes: [] }));
 });
 
 afterEach(() => {
@@ -1545,11 +1557,15 @@ describe("App review (d)", () => {
     // second press. A rapid double-d must not race two suspend/spawn/resume
     // cycles against the same renderer.
     let resolveReview!: (
-      r: { ok: true } | { ok: false; error: string },
+      r:
+        | { ok: true; notes: typeof reviewNotes }
+        | { ok: false; error: string },
     ) => void;
     runHunkReviewSpy.mockImplementation(
       () =>
-        new Promise<{ ok: true } | { ok: false; error: string }>((resolve) => {
+        new Promise<
+          { ok: true; notes: typeof reviewNotes } | { ok: false; error: string }
+        >((resolve) => {
           resolveReview = resolve;
         }),
     );
@@ -1560,7 +1576,7 @@ describe("App review (d)", () => {
     await setup.renderOnce();
     expect(runHunkReviewSpy).toHaveBeenCalledTimes(1);
     // Release the in-flight review so the guard clears (and no dangling promise).
-    resolveReview({ ok: true });
+    resolveReview({ ok: true, notes: [] });
   });
 
   it("does not call runHunkReview when a group header is selected", async () => {
@@ -1620,6 +1636,149 @@ describe("App review (d)", () => {
     await new Promise((r) => setTimeout(r, 0));
     await setup.renderOnce();
     expect(setup.captureCharFrame()).toContain("Review failed: boom");
+  });
+
+  it("defaults to a confirmation dialog with the note count and agent label", async () => {
+    runHunkReviewSpy.mockImplementation(async () => ({
+      ok: true,
+      notes: reviewNotes,
+    }));
+    await renderWithSession({}, { agentType: "claude", tmuxPane: "%1" });
+    setup.mockInput.pressKey("d");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setup.renderOnce();
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("Send review comments");
+    expect(frame).toContain("Send 1 comment to claude?");
+  });
+
+  it("posts the formatted prompt when review delivery is confirmed", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = mock(async (url: string | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+    try {
+      runHunkReviewSpy.mockImplementation(async () => ({
+        ok: true,
+        notes: reviewNotes,
+      }));
+      await renderWithSession({}, { agentType: "claude", tmuxPane: "%1" });
+      setup.mockInput.pressKey("d");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await setup.renderOnce();
+      setup.mockInput.pressKey("y");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await setup.renderOnce();
+
+      const send = calls.find((call) => call.url.endsWith("/sessions/s1/send"));
+      expect(send?.init?.method).toBe("POST");
+      const body = JSON.parse(String(send?.init?.body)) as {
+        text: string;
+        enter: boolean;
+      };
+      expect(body.enter).toBe(true);
+      expect(body.text).toContain("src/foo.ts:12");
+      expect(body.text).toContain("Handle the missing token.");
+      expect(setup.captureCharFrame()).toContain("Sent 1 comment to claude");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("drops pending notes when confirmation is cancelled", async () => {
+    const originalFetch = globalThis.fetch;
+    const urls: string[] = [];
+    const fetchSpy = mock(async (url: string | URL) => {
+      urls.push(String(url));
+      return new Response(null, { status: 200 });
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      runHunkReviewSpy.mockImplementation(async () => ({
+        ok: true,
+        notes: reviewNotes,
+      }));
+      await renderWithSession({}, { tmuxPane: "%1" });
+      setup.mockInput.pressKey("d");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await setup.renderOnce();
+      setup.mockInput.pressKey("n");
+      await setup.renderOnce();
+      expect(setup.captureCharFrame()).not.toContain("Send review comments");
+      expect(urls.some((url) => url.endsWith("/sessions/s1/send"))).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("shows a paneless toast without offering delivery", async () => {
+    runHunkReviewSpy.mockImplementation(async () => ({
+      ok: true,
+      notes: reviewNotes,
+    }));
+    await renderWithSession(
+      {},
+      { trackingMode: "background", tmuxPane: null },
+    );
+    setup.mockInput.pressKey("d");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setup.renderOnce();
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("1 review notes captured (no pane to send to)");
+    expect(frame).not.toContain("Send review comments");
+  });
+
+  it("does nothing after a successful review with zero notes", async () => {
+    await renderWithSession({}, { tmuxPane: "%1" });
+    setup.mockInput.pressKey("d");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setup.renderOnce();
+    expect(setup.captureCharFrame()).not.toContain("Send review comments");
+  });
+
+  it("auto mode sends immediately with enter true and no dialog", async () => {
+    const originalFetch = globalThis.fetch;
+    let sentBody: unknown = null;
+    globalThis.fetch = mock(async (_url: string | URL, init?: RequestInit) => {
+      sentBody = JSON.parse(String(init?.body)) as { enter: boolean };
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+    try {
+      runHunkReviewSpy.mockImplementation(async () => ({ ok: true, notes: reviewNotes }));
+      await renderWithSession({ reviewHandback: "auto" }, { tmuxPane: "%1" });
+      setup.mockInput.pressKey("d");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await setup.renderOnce();
+      expect(sentBody).toMatchObject({ enter: true });
+      expect(setup.captureCharFrame()).not.toContain("Send review comments");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("fill mode pastes without enter and shows the composer toast", async () => {
+    const originalFetch = globalThis.fetch;
+    let sentBody: unknown = null;
+    globalThis.fetch = mock(async (_url: string | URL, init?: RequestInit) => {
+      sentBody = JSON.parse(String(init?.body)) as { enter: boolean };
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+    try {
+      runHunkReviewSpy.mockImplementation(async () => ({ ok: true, notes: reviewNotes }));
+      await renderWithSession({ reviewHandback: "fill" }, { agentType: "codex", tmuxPane: "%1" });
+      setup.mockInput.pressKey("d");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await setup.renderOnce();
+      expect(sentBody).toMatchObject({ enter: false });
+      expect(setup.captureCharFrame()).toContain(
+        "Prompt filled in codex's composer, press Enter to jump",
+      );
+      expect(setup.captureCharFrame()).not.toContain("Send review comments");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("shows Review diff in the context menu when reviewable", async () => {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -19,9 +19,11 @@ import type { EnrichedSession } from "../types/session";
 import { createTUIStore, TickContext } from "./store";
 import { killActionPath, restartActionPath } from "./utils/invoke-actions";
 import {
+  formatReviewPrompt,
   HUNK_INSTALL_HINT,
   isHunkAvailable,
   runHunkReview,
+  type HunkReviewNote,
 } from "./utils/review";
 import { SSEClient } from "./utils/sse";
 import {
@@ -61,6 +63,7 @@ import type {
   ColumnsConfig,
   BreakpointConfig,
   PromptDisplay,
+  Preferences,
 } from "../lib/preferences";
 import type { FlatItem, GroupBy } from "./utils/grouping";
 import {
@@ -85,6 +88,7 @@ interface AppProps {
   promptDisplay?: PromptDisplay;
   persistent?: boolean;
   sidebar?: boolean;
+  reviewHandback?: Preferences["reviewHandback"];
 }
 
 export function App(props: AppProps) {
@@ -211,6 +215,46 @@ export function App(props: AppProps) {
   /** Drops re-activations while a review is pending: a rapid double-`d` would
    * otherwise race two suspend/spawn/resume cycles against the same renderer. */
   let reviewInFlight = false;
+  let pendingReviewNotes: {
+    sessionId: string;
+    notes: HunkReviewNote[];
+  } | null = null;
+
+  const pendingReviewNoteCount = () => pendingReviewNotes?.notes.length ?? 0;
+
+  async function deliverReviewNotes(
+    sessionId: string,
+    notes: HunkReviewNote[],
+    mode: "auto" | "confirm" | "fill",
+  ) {
+    const session = store.state.sessions.find((item) => item.id === sessionId);
+    const agent = session?.agentType ?? "agent";
+    try {
+      const response = await fetch(
+        `${getDaemonUrl()}/sessions/${sessionId}/send`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            text: formatReviewPrompt(notes),
+            enter: mode !== "fill",
+          }),
+        },
+      );
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      if (mode === "fill") {
+        store.actions.showToast(
+          `Prompt filled in ${agent}'s composer, press Enter to jump`,
+        );
+      } else {
+        store.actions.showToast(
+          `Sent ${notes.length} comment${notes.length === 1 ? "" : "s"} to ${agent}`,
+        );
+      }
+    } catch {
+      store.actions.showToast(`Failed to send review comments to ${agent}`);
+    }
+  }
 
   function reviewSession(session: EnrichedSession) {
     if (reviewInFlight) return;
@@ -230,6 +274,21 @@ export function App(props: AppProps) {
       reviewInFlight = false;
       if (!result.ok) {
         store.actions.showToast(`Review failed: ${result.error}`);
+        return;
+      }
+      if (result.notes.length === 0) return;
+      if (session.trackingMode === "background" || session.tmuxPane == null) {
+        store.actions.showToast(
+          `${result.notes.length} review notes captured (no pane to send to)`,
+        );
+        return;
+      }
+      const mode = props.reviewHandback ?? "confirm";
+      if (mode === "confirm") {
+        pendingReviewNotes = { sessionId: session.id, notes: result.notes };
+        store.actions.showConfirmDialog(session.id, "send-review");
+      } else {
+        void deliverReviewNotes(session.id, result.notes, mode);
       }
     });
   }
@@ -448,7 +507,13 @@ export function App(props: AppProps) {
   function confirmDialogAction() {
     const action = store.state.confirmAction;
     const sessionId = store.state.confirmSessionId;
-    if (action === "kill-all") {
+    if (action === "send-review" && sessionId) {
+      const pending = pendingReviewNotes;
+      pendingReviewNotes = null;
+      if (pending?.sessionId === sessionId) {
+        void deliverReviewNotes(sessionId, pending.notes, "confirm");
+      }
+    } else if (action === "kill-all") {
       // The daemon reaps in-flight invoke workers itself (it owns the
       // authoritative in-flight set); the client only needs to ask once.
       fetch(`${getDaemonUrl()}/sessions/kill-all`, { method: "POST" });
@@ -725,6 +790,7 @@ export function App(props: AppProps) {
         return;
       }
       if (key === "n" || key === "N" || key === "escape") {
+        pendingReviewNotes = null;
         store.actions.hideConfirmDialog();
         event.preventDefault();
         return;
@@ -1194,13 +1260,18 @@ export function App(props: AppProps) {
             session={getSessionById(store.state.confirmSessionId || "")}
             action={store.state.confirmAction}
             sessionCount={
-              store.state.confirmAction === "kill-group"
+              store.state.confirmAction === "send-review"
+                ? pendingReviewNoteCount()
+                : store.state.confirmAction === "kill-group"
                 ? store.state.confirmSessionIds.length
                 : store.filteredSessions().length
             }
             groupLabel={store.selectedGroupHeader()?.label}
             onConfirm={confirmDialogAction}
-            onCancel={store.actions.hideConfirmDialog}
+            onCancel={() => {
+              pendingReviewNotes = null;
+              store.actions.hideConfirmDialog();
+            }}
           />
         </Show>
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -242,9 +242,18 @@ export function App(props: AppProps) {
         },
       );
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      // Re-capture the preview so the delivered prompt is visible in the
+      // agent's pane; an unfocused preview never polls, so without this the
+      // only feedback would be the transient toast. Bump twice: the paste has
+      // landed when /send resolves, but the agent's TUI paints it a beat
+      // later, so an immediate-only capture usually still shows the empty
+      // composer (observed live with Claude Code).
+      setPreviewRefreshKey((key) => key + 1);
+      setTimeout(() => setPreviewRefreshKey((key) => key + 1), 500);
       if (mode === "fill") {
         store.actions.showToast(
           `Prompt filled in ${agent}'s composer, press Enter to jump`,
+          3_000,
         );
       } else {
         store.actions.showToast(

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -270,27 +270,35 @@ export function App(props: AppProps) {
       return;
     }
     reviewInFlight = true;
-    runHunkReview(renderer, cwd).then((result) => {
-      reviewInFlight = false;
-      if (!result.ok) {
-        store.actions.showToast(`Review failed: ${result.error}`);
-        return;
-      }
-      if (result.notes.length === 0) return;
-      if (session.trackingMode === "background" || session.tmuxPane == null) {
-        store.actions.showToast(
-          `${result.notes.length} review notes captured (no pane to send to)`,
-        );
-        return;
-      }
-      const mode = props.reviewHandback ?? "confirm";
-      if (mode === "confirm") {
-        pendingReviewNotes = { sessionId: session.id, notes: result.notes };
-        store.actions.showConfirmDialog(session.id, "send-review");
-      } else {
-        void deliverReviewNotes(session.id, result.notes, mode);
-      }
-    });
+    runHunkReview(renderer, cwd)
+      .then((result) => {
+        reviewInFlight = false;
+        if (!result.ok) {
+          store.actions.showToast(`Review failed: ${result.error}`);
+          return;
+        }
+        if (result.notes.length === 0) return;
+        if (session.trackingMode === "background" || session.tmuxPane == null) {
+          store.actions.showToast(
+            `${result.notes.length} review note${result.notes.length === 1 ? "" : "s"} captured (no pane to send to)`,
+          );
+          return;
+        }
+        const mode = props.reviewHandback ?? "confirm";
+        if (mode === "confirm") {
+          pendingReviewNotes = { sessionId: session.id, notes: result.notes };
+          store.actions.showConfirmDialog(session.id, "send-review");
+        } else {
+          void deliverReviewNotes(session.id, result.notes, mode);
+        }
+      })
+      .catch(() => {
+        // runHunkReview resolves on every expected failure; this guards an
+        // unexpected reject (e.g. resume() throwing in its finally) so a stuck
+        // reviewInFlight flag can't disable `d` for the rest of the session.
+        reviewInFlight = false;
+        store.actions.showToast("Review failed");
+      });
   }
 
   function handleRowActivate(item: FlatItem, index: number) {
@@ -1263,8 +1271,8 @@ export function App(props: AppProps) {
               store.state.confirmAction === "send-review"
                 ? pendingReviewNoteCount()
                 : store.state.confirmAction === "kill-group"
-                ? store.state.confirmSessionIds.length
-                : store.filteredSessions().length
+                  ? store.state.confirmSessionIds.length
+                  : store.filteredSessions().length
             }
             groupLabel={store.selectedGroupHeader()?.label}
             onConfirm={confirmDialogAction}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -293,12 +293,21 @@ export function App(props: AppProps) {
           );
           return;
         }
-        const mode = props.reviewHandback ?? "confirm";
-        if (mode === "confirm") {
+        // Only an explicit auto/fill skips the dialog; every other value
+        // (undefined, or an unvalidated config typo like "Fill") falls through
+        // to confirm rather than silently auto-submitting to the agent.
+        if (
+          props.reviewHandback === "auto" ||
+          props.reviewHandback === "fill"
+        ) {
+          void deliverReviewNotes(
+            session.id,
+            result.notes,
+            props.reviewHandback,
+          );
+        } else {
           pendingReviewNotes = { sessionId: session.id, notes: result.notes };
           store.actions.showConfirmDialog(session.id, "send-review");
-        } else {
-          void deliverReviewNotes(session.id, result.notes, mode);
         }
       })
       .catch(() => {

--- a/src/tui/components/ConfirmationDialog.test.tsx
+++ b/src/tui/components/ConfirmationDialog.test.tsx
@@ -60,6 +60,16 @@ describe("ConfirmationDialog", () => {
     expect(frame).toContain("Restart Session?");
   });
 
+  it("shows review count and agent for send-review", async () => {
+    const frame = await renderDialog({
+      action: "send-review",
+      session: mockSession({ agentType: "codex" }),
+      sessionCount: 2,
+    });
+    expect(frame).toContain("Send review comments");
+    expect(frame).toContain("Send 2 comments to codex?");
+  });
+
   it("shows session project in kill subtitle", async () => {
     const frame = await renderDialog({
       action: "kill",

--- a/src/tui/components/ConfirmationDialog.tsx
+++ b/src/tui/components/ConfirmationDialog.tsx
@@ -25,12 +25,19 @@ export const ConfirmationDialog: Component<ConfirmationDialogProps> = (
         return "Kill Group?";
       case "restart":
         return "Restart Session?";
+      case "send-review":
+        return "Send review comments";
       default:
         return "Kill Session?";
     }
   });
 
   const subtitle = createMemo(() => {
+    if (props.action === "send-review") {
+      const n = props.sessionCount ?? 0;
+      const agent = props.session?.agentType ?? "agent";
+      return `Send ${n} comment${n === 1 ? "" : "s"} to ${agent}?`;
+    }
     if (props.action === "kill-group") {
       const n = props.sessionCount ?? 0;
       const label = props.groupLabel || "group";

--- a/src/tui/components/Preview.test.tsx
+++ b/src/tui/components/Preview.test.tsx
@@ -163,6 +163,39 @@ describe("Preview pane capture", () => {
     expect(frame).not.toContain("AAA_STALE_CONTENT");
   });
 
+  it("re-captures on a refreshKey bump even when unfocused", async () => {
+    // An unfocused preview is a single snapshot: it must NOT pick up pane
+    // changes on its own, but a refreshKey bump (e.g. after review notes are
+    // delivered to the agent's composer) forces one re-capture.
+    let content = "BEFORE_FILL";
+    captureImpl = async () => content;
+    const [refreshKey, setRefreshKey] = createSignal(0);
+    setup = await testRender(
+      () => (
+        <TickContext.Provider value={{ tick: () => 0 }}>
+          <Preview
+            session={mockEnrichedSession({ tmuxPane: "%1" })}
+            width={40}
+            focused={false}
+            refreshKey={refreshKey()}
+          />
+        </TickContext.Provider>
+      ),
+      { width: 100, height: 15 },
+    );
+    await setup.renderOnce();
+    expect(await pollFrame(5)).toContain("BEFORE_FILL");
+
+    content = "AFTER_FILL";
+    // Unfocused and un-bumped: the stale snapshot stays.
+    expect(await pollFrame(5)).toContain("BEFORE_FILL");
+
+    setRefreshKey(1);
+    const frame = await pollFrame(5);
+    expect(frame).toContain("AFTER_FILL");
+    expect(frame).not.toContain("BEFORE_FILL");
+  });
+
   it("renders the failure state when a capture throws (dead pane)", async () => {
     captureImpl = async () => {
       throw new Error("pane gone");

--- a/src/tui/components/Preview.tsx
+++ b/src/tui/components/Preview.tsx
@@ -4,6 +4,7 @@ import {
   createEffect,
   createMemo,
   For,
+  on,
   Show,
   onCleanup,
 } from "solid-js";
@@ -249,11 +250,21 @@ export const Preview: Component<PreviewProps> = (props) => {
     await refreshPane();
   });
 
-  createEffect(() => {
-    void props.refreshKey; // track reactive dependency
-    if (!props.focused || !props.session?.tmuxPane) return;
-    refreshPane();
-  });
+  // Forced re-capture: the parent bumps refreshKey when it knows the pane
+  // just changed underneath us (e.g. review notes delivered to the agent's
+  // composer), so the user sees the outcome without focusing the preview.
+  // `on(..., {defer})` tracks only the key: mount and selection changes are
+  // already captured by the effects above, and an unfocused preview stays a
+  // single snapshot otherwise.
+  createEffect(
+    on(
+      () => props.refreshKey,
+      () => {
+        if (props.session?.tmuxPane) refreshPane();
+      },
+      { defer: true },
+    ),
+  );
 
   // Background refresh while focused (catches external output). Polls at
   // 500ms while the pane is changing, doubling up to 2s while it is quiet

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -12,6 +12,7 @@ import type {
   BreakpointConfig,
   PromptDisplay,
   ThemeConfig,
+  Preferences,
 } from "../lib/preferences";
 import { applyTheme } from "./theme";
 import type { GroupBy } from "./utils/grouping";
@@ -36,6 +37,7 @@ interface TUIOptions {
   persistent?: boolean;
   sidebar?: boolean;
   theme?: ThemeConfig;
+  reviewHandback?: Preferences["reviewHandback"];
 }
 
 /** Quiet-period after the last CAPABILITIES event before we restore focus.
@@ -127,6 +129,7 @@ export async function launchTUI(options: TUIOptions = {}): Promise<void> {
         promptDisplay={options.promptDisplay}
         persistent={options.persistent}
         sidebar={options.sidebar}
+        reviewHandback={options.reviewHandback}
       />
     ),
     rendererOrConfig,

--- a/src/tui/store.ts
+++ b/src/tui/store.ts
@@ -1087,13 +1087,13 @@ export function createTUIStore(options: TUIStoreOptions = {}) {
       });
     },
 
-    showToast(message: string) {
+    showToast(message: string, durationMs = 1500) {
       setState("toastMessage", message);
       if (toastTimer) clearTimeout(toastTimer);
       toastTimer = setTimeout(() => {
         setState("toastMessage", null);
         toastTimer = null;
-      }, 1500);
+      }, durationMs);
     },
 
     reloadUIState(freshState: UIState) {

--- a/src/tui/store.ts
+++ b/src/tui/store.ts
@@ -47,7 +47,12 @@ import {
   type FilteredSession,
 } from "./utils/grouping";
 
-export type ConfirmAction = "kill" | "kill-all" | "kill-group" | "restart";
+export type ConfirmAction =
+  | "kill"
+  | "kill-all"
+  | "kill-group"
+  | "restart"
+  | "send-review";
 
 interface TUIState {
   sessions: EnrichedSession[];

--- a/src/tui/utils/review.test.ts
+++ b/src/tui/utils/review.test.ts
@@ -257,6 +257,95 @@ describe("runHunkReview", () => {
     expect(readFileLines).toHaveBeenCalledTimes(1);
   });
 
+  it("discovers by tty when there is no paneId (display-popup)", async () => {
+    const { renderer } = fakeRenderer();
+    let resolveExit!: (code: number) => void;
+    const runHunkJson = mock(async (args: string[]) => {
+      if (args[1] === "list") {
+        return {
+          sessions: [
+            {
+              sessionId: "other",
+              terminal: { locations: [{ source: "tty", tty: "/dev/ttys1" }] },
+            },
+            {
+              // Popup session: hunk records a tty location but no tmux paneId.
+              sessionId: "popup",
+              terminal: { locations: [{ source: "tty", tty: "/dev/ttys9" }] },
+            },
+          ],
+        };
+      }
+      return {
+        comments: [
+          { noteId: "n1", filePath: "src/foo.ts", hunkIndex: 0, body: "Fix." },
+        ],
+      };
+    });
+    const result = await runHunkReview(renderer, "/repo", {
+      which: () => "hunk",
+      resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: undefined,
+      readTty: async () => "/dev/ttys9",
+      spawn: () => ({
+        exited: new Promise<number>((resolve) => (resolveExit = resolve)),
+      }),
+      runHunkJson,
+      sleep: async (ms: number) => {
+        if (ms === 1_000) resolveExit(0);
+      },
+    });
+    expect(result).toEqual({
+      ok: true,
+      notes: [
+        { noteId: "n1", filePath: "src/foo.ts", hunkIndex: 0, body: "Fix." },
+      ],
+    });
+  });
+
+  it("prefers the freshest session when multiple match the same tty", async () => {
+    const { renderer } = fakeRenderer();
+    let resolveExit!: (code: number) => void;
+    let queriedSessionId: string | undefined;
+    const runHunkJson = mock(async (args: string[]) => {
+      if (args[1] === "list") {
+        return {
+          sessions: [
+            {
+              sessionId: "stale",
+              launchedAt: "2026-07-10T00:00:00Z",
+              terminal: { locations: [{ source: "tty", tty: "/dev/ttys9" }] },
+            },
+            {
+              sessionId: "fresh",
+              launchedAt: "2026-07-11T00:00:00Z",
+              terminal: { locations: [{ source: "tty", tty: "/dev/ttys9" }] },
+            },
+          ],
+        };
+      }
+      queriedSessionId = args[3];
+      return { comments: [] };
+    });
+    const result = await runHunkReview(renderer, "/repo", {
+      which: () => "hunk",
+      resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: undefined,
+      readTty: async () => "/dev/ttys9",
+      spawn: () => ({
+        exited: new Promise<number>((resolve) => (resolveExit = resolve)),
+      }),
+      runHunkJson,
+      sleep: async (ms: number) => {
+        if (ms === 1_000) resolveExit(0);
+      },
+    });
+    expect(result).toEqual({ ok: true, notes: [] });
+    expect(queriedSessionId).toBe("fresh");
+  });
+
   it("falls back to the last snapshot when every final read fails", async () => {
     const { renderer } = fakeRenderer();
     let resolveExit!: (code: number) => void;

--- a/src/tui/utils/review.test.ts
+++ b/src/tui/utils/review.test.ts
@@ -6,8 +6,14 @@ import { describe, it, expect, mock } from "bun:test";
 // that mock instead of this real implementation. Non-literal so tsc doesn't
 // attempt (and fail) to resolve the suffixed specifier on disk.
 const REAL_REVIEW_SPECIFIER = "./review" + "?real";
-const { HUNK_DIFF_ARGS, HUNK_INSTALL_HINT, isHunkAvailable, runHunkReview } =
-  (await import(REAL_REVIEW_SPECIFIER)) as typeof import("./review");
+const {
+  HUNK_DIFF_ARGS,
+  HUNK_INSTALL_HINT,
+  MAX_REVIEW_PROMPT_CHARS,
+  formatReviewPrompt,
+  isHunkAvailable,
+  runHunkReview,
+} = (await import(REAL_REVIEW_SPECIFIER)) as typeof import("./review");
 
 function fakeRenderer() {
   const calls: string[] = [];
@@ -33,6 +39,8 @@ function fakeSpawn(exitCode: number) {
   return { spawn, calls };
 }
 
+const dirtyGitStatus = async () => " M file\n";
+
 describe("isHunkAvailable", () => {
   it("is true when which resolves the binary", () => {
     expect(isHunkAvailable(() => "/opt/homebrew/bin/hunk")).toBe(true);
@@ -48,6 +56,8 @@ describe("runHunkReview", () => {
     const { renderer } = fakeRenderer();
     const result = await runHunkReview(renderer, "/repo", {
       which: () => null,
+      gitStatus: dirtyGitStatus,
+      paneId: "",
     });
     expect(result).toEqual({ ok: false, error: HUNK_INSTALL_HINT });
     expect(renderer.suspend).not.toHaveBeenCalled();
@@ -58,6 +68,8 @@ describe("runHunkReview", () => {
     const result = await runHunkReview(renderer, "/repo", {
       which: () => "/opt/homebrew/bin/hunk",
       resolveRoot: async () => null,
+      gitStatus: dirtyGitStatus,
+      paneId: "",
     });
     expect(result).toEqual({ ok: false, error: "not a git repository" });
     expect(renderer.suspend).not.toHaveBeenCalled();
@@ -69,9 +81,11 @@ describe("runHunkReview", () => {
     const result = await runHunkReview(renderer, "/repo/sub", {
       which: () => "/opt/homebrew/bin/hunk",
       resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: "",
       spawn,
     });
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({ ok: true, notes: [] });
     expect(calls).toEqual(["suspend", "resume"]);
     expect(spawnCalls).toEqual([
       [
@@ -92,6 +106,8 @@ describe("runHunkReview", () => {
     const result = await runHunkReview(renderer, "/repo", {
       which: () => "/opt/homebrew/bin/hunk",
       resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: "",
       spawn,
     });
     expect(result.ok).toBe(false);
@@ -107,6 +123,8 @@ describe("runHunkReview", () => {
     const result = await runHunkReview(renderer, "/repo", {
       which: () => "/opt/homebrew/bin/hunk",
       resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: "",
       spawn: spawn as never,
     });
     expect(result.ok).toBe(false);
@@ -122,10 +140,291 @@ describe("runHunkReview", () => {
     const result = await runHunkReview({ suspend, resume }, "/repo", {
       which: () => "/opt/homebrew/bin/hunk",
       resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: "",
       spawn,
     });
     expect(result.ok).toBe(false);
     expect(resume).not.toHaveBeenCalled();
     expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("returns before suspending when there are no changes to review", async () => {
+    const { renderer } = fakeRenderer();
+    const { spawn } = fakeSpawn(0);
+    const result = await runHunkReview(renderer, "/repo", {
+      which: () => "/opt/homebrew/bin/hunk",
+      resolveRoot: async () => "/repo",
+      gitStatus: async () => "",
+      paneId: "",
+      spawn,
+    });
+    expect(result).toEqual({ ok: false, error: "no changes to review" });
+    expect(renderer.suspend).not.toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("discovers by pane id, harvests the final snapshot, and extracts snippets", async () => {
+    const { renderer } = fakeRenderer();
+    let resolveExit!: (code: number) => void;
+    const spawn = mock(() => ({
+      exited: new Promise<number>((resolve) => (resolveExit = resolve)),
+    }));
+    let commentReads = 0;
+    const runHunkJson = mock(async (args: string[]) => {
+      if (args[1] === "list") {
+        return {
+          sessions: [
+            {
+              sessionId: "wrong",
+              terminal: { locations: [{ source: "tmux", paneId: "%8" }] },
+            },
+            {
+              sessionId: "hunk-1",
+              terminal: { locations: [{ source: "tmux", paneId: "%7" }] },
+            },
+          ],
+        };
+      }
+      commentReads++;
+      return commentReads === 1
+        ? { comments: [] }
+        : {
+            comments: [
+              {
+                noteId: "n1",
+                filePath: "src/foo.ts",
+                hunkIndex: 0,
+                newRange: [2, 10],
+                body: "Handle this case.",
+              },
+              {
+                noteId: "n2",
+                filePath: "src/old.ts",
+                hunkIndex: 1,
+                oldRange: [4, 4],
+                body: "Deleted behavior matters.",
+              },
+            ],
+          };
+    });
+    const sleep = mock(async (ms: number) => {
+      if (ms === 1_000) resolveExit(0);
+    });
+    const readFileLines = mock(async () => [
+      "one",
+      "two",
+      "three",
+      "four",
+      "five",
+      "six",
+      "seven",
+      "eight",
+      "nine",
+    ]);
+
+    const result = await runHunkReview(renderer, "/repo", {
+      which: () => "/opt/homebrew/bin/hunk",
+      resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: "%7",
+      spawn,
+      runHunkJson,
+      sleep,
+      readFileLines,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      notes: [
+        {
+          noteId: "n1",
+          filePath: "src/foo.ts",
+          hunkIndex: 0,
+          newRange: [2, 10],
+          body: "Handle this case.",
+          snippet: "two\nthree\nfour\nfive\nsix\nseven",
+        },
+        {
+          noteId: "n2",
+          filePath: "src/old.ts",
+          hunkIndex: 1,
+          oldRange: [4, 4],
+          body: "Deleted behavior matters.",
+        },
+      ],
+    });
+    expect(readFileLines).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the last snapshot when every final read fails", async () => {
+    const { renderer } = fakeRenderer();
+    let resolveExit!: (code: number) => void;
+    const spawn = mock(() => ({
+      exited: new Promise<number>((resolve) => (resolveExit = resolve)),
+    }));
+    let commentReads = 0;
+    const note = {
+      noteId: "n1",
+      filePath: "src/foo.ts",
+      hunkIndex: 0,
+      body: "Keep me.",
+    };
+    const runHunkJson = mock(async (args: string[]) => {
+      if (args[1] === "list") {
+        return {
+          sessions: [
+            {
+              sessionId: "h1",
+              terminal: { locations: [{ source: "tmux", paneId: "%1" }] },
+            },
+          ],
+        };
+      }
+      commentReads++;
+      return commentReads === 1 ? { comments: [note] } : null;
+    });
+    const result = await runHunkReview(renderer, "/repo", {
+      which: () => "hunk",
+      resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: "%1",
+      spawn,
+      runHunkJson,
+      sleep: async (ms) => {
+        if (ms === 1_000) resolveExit(0);
+      },
+    });
+    expect(result).toEqual({ ok: true, notes: [note] });
+    expect(commentReads).toBe(4);
+  });
+
+  it("degrades to no notes when discovery never matches", async () => {
+    const { renderer } = fakeRenderer();
+    let resolveExit!: (code: number) => void;
+    const result = await runHunkReview(renderer, "/repo", {
+      which: () => "hunk",
+      resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: "%1",
+      spawn: () => ({
+        exited: new Promise<number>((resolve) => (resolveExit = resolve)),
+      }),
+      runHunkJson: async () => ({ sessions: [] }),
+      sleep: async () => resolveExit(0),
+    });
+    expect(result).toEqual({ ok: true, notes: [] });
+  });
+
+  it("drops harvested notes when hunk exits non-zero", async () => {
+    const { renderer } = fakeRenderer();
+    let resolveExit!: (code: number) => void;
+    const result = await runHunkReview(renderer, "/repo", {
+      which: () => "hunk",
+      resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: "%1",
+      spawn: () => ({
+        exited: new Promise<number>((resolve) => (resolveExit = resolve)),
+      }),
+      runHunkJson: async (args) =>
+        args[1] === "list"
+          ? {
+              sessions: [
+                {
+                  sessionId: "h1",
+                  terminal: {
+                    locations: [{ source: "tmux", paneId: "%1" }],
+                  },
+                },
+              ],
+            }
+          : {
+              comments: [
+                { noteId: "n1", filePath: "x", hunkIndex: 0, body: "note" },
+              ],
+            },
+      sleep: async () => resolveExit(2),
+    });
+    expect(result).toEqual({ ok: false, error: "hunk exited with code 2" });
+  });
+
+  it("leaves snippet undefined when reading the working tree fails", async () => {
+    const { renderer } = fakeRenderer();
+    let resolveExit!: (code: number) => void;
+    const result = await runHunkReview(renderer, "/repo", {
+      which: () => "hunk",
+      resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: "%1",
+      spawn: () => ({
+        exited: new Promise<number>((resolve) => (resolveExit = resolve)),
+      }),
+      runHunkJson: async (args) =>
+        args[1] === "list"
+          ? {
+              sessions: [
+                {
+                  sessionId: "h1",
+                  terminal: {
+                    locations: [{ source: "tmux", paneId: "%1" }],
+                  },
+                },
+              ],
+            }
+          : {
+              comments: [
+                {
+                  noteId: "n1",
+                  filePath: "x",
+                  hunkIndex: 0,
+                  newRange: [1, 1],
+                  body: "note",
+                },
+              ],
+            },
+      sleep: async () => resolveExit(0),
+      readFileLines: async () => {
+        throw new Error("missing");
+      },
+    });
+    expect(result).toEqual({
+      ok: true,
+      notes: [{ noteId: "n1", filePath: "x", hunkIndex: 0, newRange: [1, 1], body: "note" }],
+    });
+  });
+});
+
+describe("formatReviewPrompt", () => {
+  it("formats new and old ranges, snippets, singular count, and omitted snippets", () => {
+    expect(
+      formatReviewPrompt([
+        {
+          noteId: "n1",
+          filePath: "src/foo.ts",
+          hunkIndex: 0,
+          newRange: [12, 14],
+          body: "Check the token.",
+          snippet: "const token = getToken();\nif (!token) return;",
+        },
+        {
+          noteId: "n2",
+          filePath: "src/bar.ts",
+          hunkIndex: 1,
+          oldRange: [7, 7],
+          body: "Preserve this behavior.",
+        },
+      ]),
+    ).toBe(
+      'I reviewed your changes in hunk and left 2 review comments:\n\n1. src/foo.ts:12-14\n   > const token = getToken();\n   > if (!token) return;\n   Check the token.\n2. src/bar.ts:old 7\n   Preserve this behavior.\n\nPlease address each comment.',
+    );
+  });
+
+  it("caps the prompt below the daemon limit with a truncation marker", () => {
+    const prompt = formatReviewPrompt([
+      { noteId: "n1", filePath: "x", hunkIndex: 0, newRange: [1, 1], body: "x".repeat(12_000) },
+    ]);
+    expect(prompt.length).toBe(MAX_REVIEW_PROMPT_CHARS);
+    expect(prompt).toEndWith("(truncated)");
   });
 });

--- a/src/tui/utils/review.test.ts
+++ b/src/tui/utils/review.test.ts
@@ -12,7 +12,6 @@ const {
   HUNK_INSTALL_HINT,
   MAX_REVIEW_PROMPT_CHARS,
   formatReviewPrompt,
-  hunkApiPayload,
   isHunkAvailable,
   runHunkReview,
 } = (await import(REAL_REVIEW_SPECIFIER)) as typeof import("./review");
@@ -42,6 +41,26 @@ function fakeSpawn(exitCode: number) {
 }
 
 const dirtyGitStatus = async () => " M file\n";
+
+function paneSession(sessionId: string, paneId: string) {
+  return { sessionId, terminal: { locations: [{ source: "tmux", paneId }] } };
+}
+
+function ttySession(sessionId: string, tty: string, launchedAt?: string) {
+  return {
+    sessionId,
+    launchedAt,
+    terminal: { locations: [{ source: "tty", tty }] },
+  };
+}
+
+/** A source with one pane-matched session (`h1` on `%1`) and fixed comments. */
+function hunkJsonWithComments(comments: unknown[]) {
+  return {
+    listSessions: async () => ({ sessions: [paneSession("h1", "%1")] }),
+    listUserComments: async () => ({ comments }),
+  };
+}
 
 describe("isHunkAvailable", () => {
   it("is true when which resolves the binary", () => {
@@ -173,43 +192,34 @@ describe("runHunkReview", () => {
       exited: new Promise<number>((resolve) => (resolveExit = resolve)),
     }));
     let commentReads = 0;
-    const runHunkJson = mock(async (args: string[]) => {
-      if (args[1] === "list") {
-        return {
-          sessions: [
-            {
-              sessionId: "wrong",
-              terminal: { locations: [{ source: "tmux", paneId: "%8" }] },
-            },
-            {
-              sessionId: "hunk-1",
-              terminal: { locations: [{ source: "tmux", paneId: "%7" }] },
-            },
-          ],
-        };
-      }
-      commentReads++;
-      return commentReads === 1
-        ? { comments: [] }
-        : {
-            comments: [
-              {
-                noteId: "n1",
-                filePath: "src/foo.ts",
-                hunkIndex: 0,
-                newRange: [2, 10],
-                body: "Handle this case.",
-              },
-              {
-                noteId: "n2",
-                filePath: "src/old.ts",
-                hunkIndex: 1,
-                oldRange: [4, 4],
-                body: "Deleted behavior matters.",
-              },
-            ],
-          };
-    });
+    const hunkJson = {
+      listSessions: async () => ({
+        sessions: [paneSession("wrong", "%8"), paneSession("hunk-1", "%7")],
+      }),
+      listUserComments: async () => {
+        commentReads++;
+        return commentReads === 1
+          ? { comments: [] }
+          : {
+              comments: [
+                {
+                  noteId: "n1",
+                  filePath: "src/foo.ts",
+                  hunkIndex: 0,
+                  newRange: [2, 10],
+                  body: "Handle this case.",
+                },
+                {
+                  noteId: "n2",
+                  filePath: "src/old.ts",
+                  hunkIndex: 1,
+                  oldRange: [4, 4],
+                  body: "Deleted behavior matters.",
+                },
+              ],
+            };
+      },
+    };
     const sleep = mock(async (ms: number) => {
       if (ms === HARVEST_DELAY_MS) resolveExit(0);
     });
@@ -231,7 +241,7 @@ describe("runHunkReview", () => {
       gitStatus: dirtyGitStatus,
       paneId: "%7",
       spawn,
-      runHunkJson,
+      hunkJson,
       sleep,
       readFileLines,
     });
@@ -262,28 +272,20 @@ describe("runHunkReview", () => {
   it("discovers by tty when there is no paneId (display-popup)", async () => {
     const { renderer } = fakeRenderer();
     let resolveExit!: (code: number) => void;
-    const runHunkJson = mock(async (args: string[]) => {
-      if (args[1] === "list") {
-        return {
-          sessions: [
-            {
-              sessionId: "other",
-              terminal: { locations: [{ source: "tty", tty: "/dev/ttys1" }] },
-            },
-            {
-              // Popup session: hunk records a tty location but no tmux paneId.
-              sessionId: "popup",
-              terminal: { locations: [{ source: "tty", tty: "/dev/ttys9" }] },
-            },
-          ],
-        };
-      }
-      return {
+    const hunkJson = {
+      listSessions: async () => ({
+        sessions: [
+          ttySession("other", "/dev/ttys1"),
+          // Popup session: hunk records a tty location but no tmux paneId.
+          ttySession("popup", "/dev/ttys9"),
+        ],
+      }),
+      listUserComments: async () => ({
         comments: [
           { noteId: "n1", filePath: "src/foo.ts", hunkIndex: 0, body: "Fix." },
         ],
-      };
-    });
+      }),
+    };
     const result = await runHunkReview(renderer, "/repo", {
       which: () => "hunk",
       resolveRoot: async () => "/repo",
@@ -293,7 +295,7 @@ describe("runHunkReview", () => {
       spawn: () => ({
         exited: new Promise<number>((resolve) => (resolveExit = resolve)),
       }),
-      runHunkJson,
+      hunkJson,
       sleep: async (ms: number) => {
         if (ms === HARVEST_DELAY_MS) resolveExit(0);
       },
@@ -310,26 +312,18 @@ describe("runHunkReview", () => {
     const { renderer } = fakeRenderer();
     let resolveExit!: (code: number) => void;
     let queriedSessionId: string | undefined;
-    const runHunkJson = mock(async (args: string[]) => {
-      if (args[1] === "list") {
-        return {
-          sessions: [
-            {
-              sessionId: "stale",
-              launchedAt: "2026-07-10T00:00:00Z",
-              terminal: { locations: [{ source: "tty", tty: "/dev/ttys9" }] },
-            },
-            {
-              sessionId: "fresh",
-              launchedAt: "2026-07-11T00:00:00Z",
-              terminal: { locations: [{ source: "tty", tty: "/dev/ttys9" }] },
-            },
-          ],
-        };
-      }
-      queriedSessionId = args[3];
-      return { comments: [] };
-    });
+    const hunkJson = {
+      listSessions: async () => ({
+        sessions: [
+          ttySession("stale", "/dev/ttys9", "2026-07-10T00:00:00Z"),
+          ttySession("fresh", "/dev/ttys9", "2026-07-11T00:00:00Z"),
+        ],
+      }),
+      listUserComments: async (sessionId: string) => {
+        queriedSessionId = sessionId;
+        return { comments: [] };
+      },
+    };
     const result = await runHunkReview(renderer, "/repo", {
       which: () => "hunk",
       resolveRoot: async () => "/repo",
@@ -339,7 +333,7 @@ describe("runHunkReview", () => {
       spawn: () => ({
         exited: new Promise<number>((resolve) => (resolveExit = resolve)),
       }),
-      runHunkJson,
+      hunkJson,
       sleep: async (ms: number) => {
         if (ms === HARVEST_DELAY_MS) resolveExit(0);
       },
@@ -369,19 +363,12 @@ describe("runHunkReview", () => {
         spawn: () => ({
           exited: new Promise<number>((resolve) => (resolveExit = resolve)),
         }),
-        runHunkJson: async (args) => {
-          if (args[1] === "list") {
-            return {
-              sessions: [
-                {
-                  sessionId: "h1",
-                  terminal: { locations: [{ source: "tmux", paneId: "%1" }] },
-                },
-              ],
-            };
-          }
-          events.push("comment-read");
-          return { comments: [] };
+        hunkJson: {
+          listSessions: async () => ({ sessions: [paneSession("h1", "%1")] }),
+          listUserComments: async () => {
+            events.push("comment-read");
+            return { comments: [] };
+          },
         },
         sleep: async (ms) => {
           if (ms === HARVEST_DELAY_MS) resolveExit(0);
@@ -412,27 +399,20 @@ describe("runHunkReview", () => {
       hunkIndex: 0,
       body: "Keep me.",
     };
-    const runHunkJson = mock(async (args: string[]) => {
-      if (args[1] === "list") {
-        return {
-          sessions: [
-            {
-              sessionId: "h1",
-              terminal: { locations: [{ source: "tmux", paneId: "%1" }] },
-            },
-          ],
-        };
-      }
-      commentReads++;
-      return commentReads === 1 ? { comments: [note] } : null;
-    });
+    const hunkJson = {
+      listSessions: async () => ({ sessions: [paneSession("h1", "%1")] }),
+      listUserComments: async () => {
+        commentReads++;
+        return commentReads === 1 ? { comments: [note] } : null;
+      },
+    };
     const result = await runHunkReview(renderer, "/repo", {
       which: () => "hunk",
       resolveRoot: async () => "/repo",
       gitStatus: dirtyGitStatus,
       paneId: "%1",
       spawn,
-      runHunkJson,
+      hunkJson,
       sleep: async (ms) => {
         if (ms === HARVEST_DELAY_MS) resolveExit(0);
       },
@@ -454,7 +434,10 @@ describe("runHunkReview", () => {
       spawn: () => ({
         exited: new Promise<number>((resolve) => (resolveExit = resolve)),
       }),
-      runHunkJson: async () => ({ sessions: [] }),
+      hunkJson: {
+        listSessions: async () => ({ sessions: [] }),
+        listUserComments: async () => null,
+      },
       sleep: async () => resolveExit(0),
     });
     expect(result).toEqual({ ok: true, notes: [] });
@@ -471,23 +454,9 @@ describe("runHunkReview", () => {
       spawn: () => ({
         exited: new Promise<number>((resolve) => (resolveExit = resolve)),
       }),
-      runHunkJson: async (args) =>
-        args[1] === "list"
-          ? {
-              sessions: [
-                {
-                  sessionId: "h1",
-                  terminal: {
-                    locations: [{ source: "tmux", paneId: "%1" }],
-                  },
-                },
-              ],
-            }
-          : {
-              comments: [
-                { noteId: "n1", filePath: "x", hunkIndex: 0, body: "note" },
-              ],
-            },
+      hunkJson: hunkJsonWithComments([
+        { noteId: "n1", filePath: "x", hunkIndex: 0, body: "note" },
+      ]),
       sleep: async () => resolveExit(2),
     });
     expect(result).toEqual({ ok: false, error: "hunk exited with code 2" });
@@ -504,19 +473,9 @@ describe("runHunkReview", () => {
       spawn: () => ({
         exited: new Promise<number>((resolve) => (resolveExit = resolve)),
       }),
-      runHunkJson: async (args) =>
-        args[1] === "list"
-          ? {
-              sessions: [
-                {
-                  sessionId: "h1",
-                  terminal: {
-                    locations: [{ source: "tmux", paneId: "%1" }],
-                  },
-                },
-              ],
-            }
-          : { comments: [{ filePath: "src/x.ts", body: "drifted note" }] },
+      hunkJson: hunkJsonWithComments([
+        { filePath: "src/x.ts", body: "drifted note" },
+      ]),
       sleep: async () => resolveExit(0),
     });
     expect(result).toEqual({
@@ -536,29 +495,15 @@ describe("runHunkReview", () => {
       spawn: () => ({
         exited: new Promise<number>((resolve) => (resolveExit = resolve)),
       }),
-      runHunkJson: async (args) =>
-        args[1] === "list"
-          ? {
-              sessions: [
-                {
-                  sessionId: "h1",
-                  terminal: {
-                    locations: [{ source: "tmux", paneId: "%1" }],
-                  },
-                },
-              ],
-            }
-          : {
-              comments: [
-                {
-                  noteId: "n1",
-                  filePath: "x",
-                  hunkIndex: 0,
-                  newRange: [1, 1],
-                  body: "note",
-                },
-              ],
-            },
+      hunkJson: hunkJsonWithComments([
+        {
+          noteId: "n1",
+          filePath: "x",
+          hunkIndex: 0,
+          newRange: [1, 1],
+          body: "note",
+        },
+      ]),
       sleep: async () => resolveExit(0),
       readFileLines: async () => {
         throw new Error("missing");
@@ -590,29 +535,15 @@ describe("runHunkReview", () => {
       spawn: () => ({
         exited: new Promise<number>((resolve) => (resolveExit = resolve)),
       }),
-      runHunkJson: async (args) =>
-        args[1] === "list"
-          ? {
-              sessions: [
-                {
-                  sessionId: "h1",
-                  terminal: {
-                    locations: [{ source: "tmux", paneId: "%1" }],
-                  },
-                },
-              ],
-            }
-          : {
-              comments: [
-                {
-                  noteId: "n1",
-                  filePath: "../../etc/passwd",
-                  hunkIndex: 0,
-                  newRange: [1, 1],
-                  body: "note",
-                },
-              ],
-            },
+      hunkJson: hunkJsonWithComments([
+        {
+          noteId: "n1",
+          filePath: "../../etc/passwd",
+          hunkIndex: 0,
+          newRange: [1, 1],
+          body: "note",
+        },
+      ]),
       sleep: async () => resolveExit(0),
       readFileLines: async (path) => {
         readPaths.push(path);
@@ -632,37 +563,6 @@ describe("runHunkReview", () => {
         },
       ],
     });
-  });
-});
-
-describe("hunkApiPayload", () => {
-  it("maps session list to the daemon's list action", () => {
-    expect(hunkApiPayload(["session", "list", "--json"])).toEqual({
-      action: "list",
-    });
-  });
-
-  it("maps comment list to comment-list with a sessionId selector", () => {
-    expect(
-      hunkApiPayload([
-        "session",
-        "comment",
-        "list",
-        "sid-1",
-        "--type",
-        "user",
-        "--json",
-      ]),
-    ).toEqual({
-      action: "comment-list",
-      selector: { sessionId: "sid-1" },
-      type: "user",
-    });
-  });
-
-  it("returns null for unmapped commands so they go through the CLI", () => {
-    expect(hunkApiPayload(["session", "comment", "rm", "sid-1"])).toBeNull();
-    expect(hunkApiPayload(["daemon", "serve"])).toBeNull();
   });
 });
 

--- a/src/tui/utils/review.test.ts
+++ b/src/tui/utils/review.test.ts
@@ -7,10 +7,12 @@ import { describe, it, expect, mock } from "bun:test";
 // attempt (and fail) to resolve the suffixed specifier on disk.
 const REAL_REVIEW_SPECIFIER = "./review" + "?real";
 const {
+  HARVEST_DELAY_MS,
   HUNK_DIFF_ARGS,
   HUNK_INSTALL_HINT,
   MAX_REVIEW_PROMPT_CHARS,
   formatReviewPrompt,
+  hunkApiPayload,
   isHunkAvailable,
   runHunkReview,
 } = (await import(REAL_REVIEW_SPECIFIER)) as typeof import("./review");
@@ -209,7 +211,7 @@ describe("runHunkReview", () => {
           };
     });
     const sleep = mock(async (ms: number) => {
-      if (ms === 1_000) resolveExit(0);
+      if (ms === HARVEST_DELAY_MS) resolveExit(0);
     });
     const readFileLines = mock(async () => [
       "one",
@@ -293,7 +295,7 @@ describe("runHunkReview", () => {
       }),
       runHunkJson,
       sleep: async (ms: number) => {
-        if (ms === 1_000) resolveExit(0);
+        if (ms === HARVEST_DELAY_MS) resolveExit(0);
       },
     });
     expect(result).toEqual({
@@ -339,14 +341,65 @@ describe("runHunkReview", () => {
       }),
       runHunkJson,
       sleep: async (ms: number) => {
-        if (ms === 1_000) resolveExit(0);
+        if (ms === HARVEST_DELAY_MS) resolveExit(0);
       },
     });
     expect(result).toEqual({ ok: true, notes: [] });
     expect(queriedSessionId).toBe("fresh");
   });
 
-  it("falls back to the last snapshot when every final read fails", async () => {
+  it("resumes the renderer the moment hunk exits, before the final reads", async () => {
+    const events: string[] = [];
+    let resolveExit!: (code: number) => void;
+    const result = await runHunkReview(
+      {
+        suspend: () => {
+          events.push("suspend");
+        },
+        resume: () => {
+          events.push("resume");
+        },
+      },
+      "/repo",
+      {
+        which: () => "hunk",
+        resolveRoot: async () => "/repo",
+        gitStatus: dirtyGitStatus,
+        paneId: "%1",
+        spawn: () => ({
+          exited: new Promise<number>((resolve) => (resolveExit = resolve)),
+        }),
+        runHunkJson: async (args) => {
+          if (args[1] === "list") {
+            return {
+              sessions: [
+                {
+                  sessionId: "h1",
+                  terminal: { locations: [{ source: "tmux", paneId: "%1" }] },
+                },
+              ],
+            };
+          }
+          events.push("comment-read");
+          return { comments: [] };
+        },
+        sleep: async (ms) => {
+          if (ms === HARVEST_DELAY_MS) resolveExit(0);
+        },
+      },
+    );
+    expect(result).toEqual({ ok: true, notes: [] });
+    // One harvest read while hunk runs, then resume immediately on exit, and
+    // only then the post-exit final read. resume must fire exactly once.
+    expect(events).toEqual([
+      "suspend",
+      "comment-read",
+      "resume",
+      "comment-read",
+    ]);
+  });
+
+  it("falls back to the last snapshot when the single final read fails", async () => {
     const { renderer } = fakeRenderer();
     let resolveExit!: (code: number) => void;
     const spawn = mock(() => ({
@@ -381,11 +434,13 @@ describe("runHunkReview", () => {
       spawn,
       runHunkJson,
       sleep: async (ms) => {
-        if (ms === 1_000) resolveExit(0);
+        if (ms === HARVEST_DELAY_MS) resolveExit(0);
       },
     });
     expect(result).toEqual({ ok: true, notes: [note] });
-    expect(commentReads).toBe(4);
+    // One harvest read plus exactly one post-exit final read: the session
+    // dies with the TUI, so retrying the final read only delays the dialog.
+    expect(commentReads).toBe(2);
   });
 
   it("degrades to no notes when discovery never matches", async () => {
@@ -577,6 +632,37 @@ describe("runHunkReview", () => {
         },
       ],
     });
+  });
+});
+
+describe("hunkApiPayload", () => {
+  it("maps session list to the daemon's list action", () => {
+    expect(hunkApiPayload(["session", "list", "--json"])).toEqual({
+      action: "list",
+    });
+  });
+
+  it("maps comment list to comment-list with a sessionId selector", () => {
+    expect(
+      hunkApiPayload([
+        "session",
+        "comment",
+        "list",
+        "sid-1",
+        "--type",
+        "user",
+        "--json",
+      ]),
+    ).toEqual({
+      action: "comment-list",
+      selector: { sessionId: "sid-1" },
+      type: "user",
+    });
+  });
+
+  it("returns null for unmapped commands so they go through the CLI", () => {
+    expect(hunkApiPayload(["session", "comment", "rm", "sid-1"])).toBeNull();
+    expect(hunkApiPayload(["daemon", "serve"])).toBeNull();
   });
 });
 

--- a/src/tui/utils/review.test.ts
+++ b/src/tui/utils/review.test.ts
@@ -349,6 +349,38 @@ describe("runHunkReview", () => {
     expect(result).toEqual({ ok: false, error: "hunk exited with code 2" });
   });
 
+  it("parses comments missing noteId/hunkIndex (schema drift)", async () => {
+    const { renderer } = fakeRenderer();
+    let resolveExit!: (code: number) => void;
+    const result = await runHunkReview(renderer, "/repo", {
+      which: () => "hunk",
+      resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: "%1",
+      spawn: () => ({
+        exited: new Promise<number>((resolve) => (resolveExit = resolve)),
+      }),
+      runHunkJson: async (args) =>
+        args[1] === "list"
+          ? {
+              sessions: [
+                {
+                  sessionId: "h1",
+                  terminal: {
+                    locations: [{ source: "tmux", paneId: "%1" }],
+                  },
+                },
+              ],
+            }
+          : { comments: [{ filePath: "src/x.ts", body: "drifted note" }] },
+      sleep: async () => resolveExit(0),
+    });
+    expect(result).toEqual({
+      ok: true,
+      notes: [{ filePath: "src/x.ts", body: "drifted note" }],
+    });
+  });
+
   it("leaves snippet undefined when reading the working tree fails", async () => {
     const { renderer } = fakeRenderer();
     let resolveExit!: (code: number) => void;
@@ -390,7 +422,71 @@ describe("runHunkReview", () => {
     });
     expect(result).toEqual({
       ok: true,
-      notes: [{ noteId: "n1", filePath: "x", hunkIndex: 0, newRange: [1, 1], body: "note" }],
+      notes: [
+        {
+          noteId: "n1",
+          filePath: "x",
+          hunkIndex: 0,
+          newRange: [1, 1],
+          body: "note",
+        },
+      ],
+    });
+  });
+
+  it("skips snippets for paths that escape the repo root", async () => {
+    const { renderer } = fakeRenderer();
+    let resolveExit!: (code: number) => void;
+    const readPaths: string[] = [];
+    const result = await runHunkReview(renderer, "/repo", {
+      which: () => "hunk",
+      resolveRoot: async () => "/repo",
+      gitStatus: dirtyGitStatus,
+      paneId: "%1",
+      spawn: () => ({
+        exited: new Promise<number>((resolve) => (resolveExit = resolve)),
+      }),
+      runHunkJson: async (args) =>
+        args[1] === "list"
+          ? {
+              sessions: [
+                {
+                  sessionId: "h1",
+                  terminal: {
+                    locations: [{ source: "tmux", paneId: "%1" }],
+                  },
+                },
+              ],
+            }
+          : {
+              comments: [
+                {
+                  noteId: "n1",
+                  filePath: "../../etc/passwd",
+                  hunkIndex: 0,
+                  newRange: [1, 1],
+                  body: "note",
+                },
+              ],
+            },
+      sleep: async () => resolveExit(0),
+      readFileLines: async (path) => {
+        readPaths.push(path);
+        return ["secret"];
+      },
+    });
+    expect(readPaths).toEqual([]);
+    expect(result).toEqual({
+      ok: true,
+      notes: [
+        {
+          noteId: "n1",
+          filePath: "../../etc/passwd",
+          hunkIndex: 0,
+          newRange: [1, 1],
+          body: "note",
+        },
+      ],
     });
   });
 });
@@ -416,13 +512,37 @@ describe("formatReviewPrompt", () => {
         },
       ]),
     ).toBe(
-      'I reviewed your changes in hunk and left 2 review comments:\n\n1. src/foo.ts:12-14\n   > const token = getToken();\n   > if (!token) return;\n   Check the token.\n2. src/bar.ts:old 7\n   Preserve this behavior.\n\nPlease address each comment.',
+      "I reviewed your changes in hunk and left 2 review comments:\n\n1. src/foo.ts:12-14\n   > const token = getToken();\n   > if (!token) return;\n   Check the token.\n2. src/bar.ts:old 7\n   Preserve this behavior.\n\nPlease address each comment.",
     );
+  });
+
+  it("strips control sequences that could break bracketed paste, keeping \\n and \\t", () => {
+    const prompt = formatReviewPrompt([
+      {
+        filePath: "src/x.ts",
+        newRange: [1, 1],
+        body: "before\x1b[201~evil\rmore",
+        snippet: "a\tb\nc\x1b[201~evil\rmore",
+      },
+    ]);
+    expect(prompt).toContain("evil");
+    expect(prompt).toContain("more");
+    expect(prompt).not.toContain("\x1b");
+    expect(prompt).not.toContain("\r");
+    // Tabs and newlines inside snippets survive the sanitizer.
+    expect(prompt).toContain("\t");
+    expect(prompt).toContain("\n");
   });
 
   it("caps the prompt below the daemon limit with a truncation marker", () => {
     const prompt = formatReviewPrompt([
-      { noteId: "n1", filePath: "x", hunkIndex: 0, newRange: [1, 1], body: "x".repeat(12_000) },
+      {
+        noteId: "n1",
+        filePath: "x",
+        hunkIndex: 0,
+        newRange: [1, 1],
+        body: "x".repeat(12_000),
+      },
     ]);
     expect(prompt.length).toBe(MAX_REVIEW_PROMPT_CHARS);
     expect(prompt).toEndWith("(truncated)");

--- a/src/tui/utils/review.ts
+++ b/src/tui/utils/review.ts
@@ -8,12 +8,15 @@ export const HUNK_DIFF_ARGS = ["diff", "--watch"] as const;
 export const HUNK_INSTALL_HINT =
   "hunk not found: install it to review diffs (see github.com/modem-dev/hunk)";
 
-const DISCOVERY_ATTEMPTS = 10;
-const DISCOVERY_DELAY_MS = 500;
-const HARVEST_DELAY_MS = 1_000;
-const FINAL_READ_ATTEMPTS = 3;
-const FINAL_READ_DELAY_MS = 500;
+const DISCOVERY_ATTEMPTS = 20;
+const DISCOVERY_DELAY_MS = 250;
+// Comments live only in the hunk daemon's memory and vanish the instant the
+// TUI exits, so a note saved just before quitting is only ever seen by the
+// poll that lands between save and quit. Keep the cadence tight: reads go
+// through the daemon's HTTP API (~ms each), so fast polling is nearly free.
+export const HARVEST_DELAY_MS = 250;
 const HUNK_JSON_TIMEOUT_MS = 5_000;
+const HUNK_API_TIMEOUT_MS = 1_000;
 const MAX_SNIPPET_LINES = 6;
 const MAX_SNIPPET_CHARS = 300;
 export const MAX_REVIEW_PROMPT_CHARS = MAX_SEND_TEXT_CHARS;
@@ -79,7 +82,76 @@ function debugLog(message: string): void {
   }
 }
 
+/**
+ * Map the CLI arg encoding of the two reads we do onto the hunk daemon's
+ * HTTP session API (`POST /session-api`, the same endpoint the hunk CLI
+ * itself calls). Returns null for arg shapes we don't map; those go through
+ * the CLI.
+ */
+export function hunkApiPayload(args: string[]): object | null {
+  if (args[0] === "session" && args[1] === "list") return { action: "list" };
+  if (
+    args[0] === "session" &&
+    args[1] === "comment" &&
+    args[2] === "list" &&
+    typeof args[3] === "string"
+  ) {
+    return {
+      action: "comment-list",
+      selector: { sessionId: args[3] },
+      type: "user",
+    };
+  }
+  return null;
+}
+
+function hunkApiOrigin(): string {
+  const host = process.env.HUNK_MCP_HOST?.trim() || "127.0.0.1";
+  const port = Number(process.env.HUNK_MCP_PORT) || 47657;
+  return `http://${host}:${port}`;
+}
+
+// Flips true after the first successful session-api response in this process.
+// From then on a JSON error from the API (e.g. "No active session matches" on
+// the post-exit read) is definitive and skips the CLI fallback: the hunk CLI
+// is itself a client of this same endpoint, so it can only repeat the answer,
+// ~300ms slower. Until proven, every HTTP failure still falls back to the CLI
+// so a hunk that moved or reshaped the API degrades to slow-but-correct.
+let hunkApiProven = false;
+
+/**
+ * Read hunk session JSON, preferring the daemon's HTTP API over spawning the
+ * `hunk` CLI: a fetch answers in ~1ms where a CLI spawn costs ~300ms, which is
+ * what makes the tight harvest cadence viable. HTTP failures fall back to the
+ * CLI, which stays the compatibility authority (see hunkApiProven).
+ */
 async function defaultRunHunkJson(args: string[]): Promise<unknown | null> {
+  const payload = hunkApiPayload(args);
+  if (payload) {
+    try {
+      const response = await fetch(`${hunkApiOrigin()}/session-api`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(HUNK_API_TIMEOUT_MS),
+      });
+      // Non-JSON bodies (e.g. a plain 404 from a hunk that moved the route)
+      // throw here and drop through to the CLI fallback below.
+      const body: unknown = await response.json();
+      if (response.ok) {
+        hunkApiProven = true;
+        return body;
+      }
+      const error =
+        typeof body === "object" && body !== null && "error" in body
+          ? String((body as { error: unknown }).error)
+          : `HTTP ${response.status}`;
+      debugLog(`session api ${args.join(" ")}: ${error}`);
+      if (hunkApiProven) return null;
+    } catch (err) {
+      debugLog(`session api unreachable (${err}); falling back to hunk CLI`);
+    }
+  }
   try {
     const proc = Bun.spawn(["hunk", ...args], {
       stdin: "ignore",
@@ -359,8 +431,12 @@ export function spawnHunkDiff(
  * with inherited stdio, then resume. Pre-flight checks (hunk on PATH, git
  * repo root) run before `suspend()` so error toasts render without a flicker.
  * `suspend()` has its own try/catch: if it throws, `resume()` is never
- * called (nothing to undo). Once suspended, `resume()` always runs via
- * try/finally, even if the spawn itself throws.
+ * called (nothing to undo). Once suspended, `resume()` is guaranteed via
+ * try/finally, even if the spawn itself throws — but it fires the moment
+ * hunk exits, not after the whole harvest: the post-exit comment reads and
+ * snippet extraction below all run against piped-stdio children that never
+ * touch the terminal, and leaving the renderer suspended through them showed
+ * the user seconds of blank screen after quitting hunk.
  *
  * While hunk runs, the picker polls hunk's session JSON to find the session
  * bound to this pane and harvest the user comments left during review,
@@ -400,6 +476,13 @@ export async function runHunkReview(
     return { ok: false, error: `suspend failed: ${err}` };
   }
 
+  let resumed = false;
+  const resumeOnce = () => {
+    if (resumed) return;
+    resumed = true;
+    renderer.resume();
+  };
+
   try {
     const proc = spawnHunkDiff(root, spawn);
     let exited = false;
@@ -426,7 +509,10 @@ export async function runHunkReview(
           sessionMatchesTerminal(session, paneId, tty),
         );
         sessionId = pickFreshest(matches)?.sessionId ?? null;
-        if (sessionId) break;
+        if (sessionId) {
+          debugLog(`discovered session ${sessionId} (attempt ${attempt})`);
+          break;
+        }
         if (!exited)
           await Promise.race([sleep(DISCOVERY_DELAY_MS), exitPromise]);
       }
@@ -446,38 +532,46 @@ export async function runHunkReview(
           "--json",
         ]),
       );
-      if (snapshot) latestNotes = snapshot;
+      if (snapshot) {
+        if (snapshot.length !== latestNotes.length) {
+          debugLog(`harvest snapshot: ${snapshot.length} note(s)`);
+        }
+        latestNotes = snapshot;
+      }
       if (!exited) await Promise.race([sleep(HARVEST_DELAY_MS), exitPromise]);
     }
 
     const exitCode = await exitPromise;
+    // hunk has restored the terminal: bring the picker back NOW. The final
+    // read and snippet extraction below don't touch the terminal, and waiting
+    // on them here is what left the screen blank for seconds after quitting.
+    resumeOnce();
     if (exitCode !== 0) {
       return { ok: false, error: `hunk exited with code ${exitCode}` };
     }
 
-    // Post-exit final read: a comment saved just before quitting can land after
-    // the harvest loop's last read. hunk keeps serving session JSON for a short
-    // teardown window, so retry a few times to catch it.
+    // Post-exit final read, one attempt only: a comment saved in the last
+    // harvest interval can land after the loop's final read, and this catches
+    // it IF the session is still readable. Usually it isn't — hunk drops the
+    // session the instant the TUI exits (every logged post-exit read fails
+    // with "No active session") — so retrying is pure latency between the
+    // picker coming back and the hand-back dialog. The real safeguard for
+    // last-second comments is the tight HARVEST_DELAY_MS cadence above.
     if (sessionId) {
-      for (let attempt = 0; attempt < FINAL_READ_ATTEMPTS; attempt++) {
-        const snapshot = asNotes(
-          await runHunkJson([
-            "session",
-            "comment",
-            "list",
-            sessionId,
-            "--type",
-            "user",
-            "--json",
-          ]),
-        );
-        if (snapshot) {
-          latestNotes = snapshot;
-          break;
-        }
-        if (attempt < FINAL_READ_ATTEMPTS - 1) await sleep(FINAL_READ_DELAY_MS);
-      }
+      const snapshot = asNotes(
+        await runHunkJson([
+          "session",
+          "comment",
+          "list",
+          sessionId,
+          "--type",
+          "user",
+          "--json",
+        ]),
+      );
+      if (snapshot) latestNotes = snapshot;
     }
+    debugLog(`review done: ${latestNotes.length} note(s) harvested`);
 
     return {
       ok: true,
@@ -486,6 +580,6 @@ export async function runHunkReview(
   } catch (err) {
     return { ok: false, error: `${err}` };
   } finally {
-    renderer.resume();
+    resumeOnce();
   }
 }

--- a/src/tui/utils/review.ts
+++ b/src/tui/utils/review.ts
@@ -51,7 +51,7 @@ export interface RunHunkReviewDeps {
   which?: (cmd: string) => string | null;
   spawn?: SpawnHunk;
   resolveRoot?: (cwd: string) => Promise<string | null>;
-  runHunkJson?: (args: string[]) => Promise<unknown | null>;
+  hunkJson?: HunkJsonSource;
   paneId?: string;
   /**
    * Resolve our own controlling tty (e.g. `/dev/ttys084`), or null if stdin
@@ -83,53 +83,38 @@ function debugLog(message: string): void {
 }
 
 /**
- * Map the CLI arg encoding of the two reads we do onto the hunk daemon's
- * HTTP session API (`POST /session-api`, the same endpoint the hunk CLI
- * itself calls). Returns null for arg shapes we don't map; those go through
- * the CLI.
+ * The two reads runHunkReview does against hunk's session daemon. Both return
+ * the daemon's raw JSON (`{sessions: [...]}` / `{comments: [...]}`) or null
+ * on failure; parsing stays with the caller (asSessions/asNotes) so injected
+ * test sources exercise the same validation as the real one.
  */
-export function hunkApiPayload(args: string[]): object | null {
-  if (args[0] === "session" && args[1] === "list") return { action: "list" };
-  if (
-    args[0] === "session" &&
-    args[1] === "comment" &&
-    args[2] === "list" &&
-    typeof args[3] === "string"
-  ) {
-    return {
-      action: "comment-list",
-      selector: { sessionId: args[3] },
-      type: "user",
-    };
-  }
-  return null;
+export interface HunkJsonSource {
+  listSessions(): Promise<unknown | null>;
+  listUserComments(sessionId: string): Promise<unknown | null>;
 }
-
-function hunkApiOrigin(): string {
-  const host = process.env.HUNK_MCP_HOST?.trim() || "127.0.0.1";
-  const port = Number(process.env.HUNK_MCP_PORT) || 47657;
-  return `http://${host}:${port}`;
-}
-
-// Flips true after the first successful session-api response in this process.
-// From then on a JSON error from the API (e.g. "No active session matches" on
-// the post-exit read) is definitive and skips the CLI fallback: the hunk CLI
-// is itself a client of this same endpoint, so it can only repeat the answer,
-// ~300ms slower. Until proven, every HTTP failure still falls back to the CLI
-// so a hunk that moved or reshaped the API degrades to slow-but-correct.
-let hunkApiProven = false;
 
 /**
- * Read hunk session JSON, preferring the daemon's HTTP API over spawning the
- * `hunk` CLI: a fetch answers in ~1ms where a CLI spawn costs ~300ms, which is
- * what makes the tight harvest cadence viable. HTTP failures fall back to the
- * CLI, which stays the compatibility authority (see hunkApiProven).
+ * Default source: prefer the daemon's HTTP session API (`POST /session-api`,
+ * the same endpoint the hunk CLI itself wraps) — a fetch answers in ~1ms
+ * where a CLI spawn costs ~300ms, which is what makes the tight harvest
+ * cadence viable. HTTP failures fall back to the CLI, which stays the
+ * compatibility authority: until the API has answered once this run
+ * (`apiProven`), any HTTP failure degrades to slow-but-correct. After that,
+ * a JSON error from the API (e.g. "No active session matches" on the
+ * post-exit read) is definitive and skips the fallback — the CLI is a client
+ * of this same endpoint and could only repeat the answer, ~300ms later.
  */
-async function defaultRunHunkJson(args: string[]): Promise<unknown | null> {
-  const payload = hunkApiPayload(args);
-  if (payload) {
+function createHunkJsonSource(): HunkJsonSource {
+  let apiProven = false;
+
+  const read = async (
+    payload: object,
+    cliArgs: string[],
+  ): Promise<unknown | null> => {
     try {
-      const response = await fetch(`${hunkApiOrigin()}/session-api`, {
+      const host = process.env.HUNK_MCP_HOST?.trim() || "127.0.0.1";
+      const port = Number(process.env.HUNK_MCP_PORT) || 47657;
+      const response = await fetch(`http://${host}:${port}/session-api`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(payload),
@@ -139,19 +124,37 @@ async function defaultRunHunkJson(args: string[]): Promise<unknown | null> {
       // throw here and drop through to the CLI fallback below.
       const body: unknown = await response.json();
       if (response.ok) {
-        hunkApiProven = true;
+        apiProven = true;
         return body;
       }
       const error =
         typeof body === "object" && body !== null && "error" in body
           ? String((body as { error: unknown }).error)
           : `HTTP ${response.status}`;
-      debugLog(`session api ${args.join(" ")}: ${error}`);
-      if (hunkApiProven) return null;
+      debugLog(`session api ${cliArgs.join(" ")}: ${error}`);
+      if (apiProven) return null;
     } catch (err) {
       debugLog(`session api unreachable (${err}); falling back to hunk CLI`);
     }
-  }
+    return runHunkCli(cliArgs);
+  };
+
+  return {
+    listSessions: () => read({ action: "list" }, ["session", "list", "--json"]),
+    listUserComments: (sessionId) =>
+      read({ action: "comment-list", selector: { sessionId }, type: "user" }, [
+        "session",
+        "comment",
+        "list",
+        sessionId,
+        "--type",
+        "user",
+        "--json",
+      ]),
+  };
+}
+
+async function runHunkCli(args: string[]): Promise<unknown | null> {
   try {
     const proc = Bun.spawn(["hunk", ...args], {
       stdin: "ignore",
@@ -450,7 +453,7 @@ export async function runHunkReview(
   const which = deps.which ?? Bun.which;
   const spawn = deps.spawn ?? (Bun.spawn as unknown as SpawnHunk);
   const resolveRoot = deps.resolveRoot ?? resolveRepoRoot;
-  const runHunkJson = deps.runHunkJson ?? defaultRunHunkJson;
+  const hunkJson = deps.hunkJson ?? createHunkJsonSource();
   const paneId = deps.paneId ?? process.env.TMUX_PANE;
   const readTty = deps.readTty ?? defaultReadTty;
   const sleep = deps.sleep ?? Bun.sleep;
@@ -502,9 +505,7 @@ export async function runHunkReview(
         attempt < DISCOVERY_ATTEMPTS && !exited;
         attempt++
       ) {
-        const sessions = asSessions(
-          await runHunkJson(["session", "list", "--json"]),
-        );
+        const sessions = asSessions(await hunkJson.listSessions());
         const matches = sessions.filter((session) =>
           sessionMatchesTerminal(session, paneId, tty),
         );
@@ -518,26 +519,14 @@ export async function runHunkReview(
       }
     }
 
-    // Harvest loop: re-read comments every second. Each await races the sleep
-    // against exitPromise so we bail out the moment hunk exits.
+    // Harvest loop: re-read comments every HARVEST_DELAY_MS. Each await races
+    // the sleep against exitPromise so we bail out the moment hunk exits.
     while (sessionId && !exited) {
-      const snapshot = asNotes(
-        await runHunkJson([
-          "session",
-          "comment",
-          "list",
-          sessionId,
-          "--type",
-          "user",
-          "--json",
-        ]),
-      );
-      if (snapshot) {
-        if (snapshot.length !== latestNotes.length) {
-          debugLog(`harvest snapshot: ${snapshot.length} note(s)`);
-        }
-        latestNotes = snapshot;
+      const snapshot = asNotes(await hunkJson.listUserComments(sessionId));
+      if (snapshot && snapshot.length !== latestNotes.length) {
+        debugLog(`harvest snapshot: ${snapshot.length} note(s)`);
       }
+      if (snapshot) latestNotes = snapshot;
       if (!exited) await Promise.race([sleep(HARVEST_DELAY_MS), exitPromise]);
     }
 
@@ -558,17 +547,7 @@ export async function runHunkReview(
     // picker coming back and the hand-back dialog. The real safeguard for
     // last-second comments is the tight HARVEST_DELAY_MS cadence above.
     if (sessionId) {
-      const snapshot = asNotes(
-        await runHunkJson([
-          "session",
-          "comment",
-          "list",
-          sessionId,
-          "--type",
-          "user",
-          "--json",
-        ]),
-      );
+      const snapshot = asNotes(await hunkJson.listUserComments(sessionId));
       if (snapshot) latestNotes = snapshot;
     }
     debugLog(`review done: ${latestNotes.length} note(s) harvested`);

--- a/src/tui/utils/review.ts
+++ b/src/tui/utils/review.ts
@@ -1,6 +1,7 @@
 import { appendFileSync } from "node:fs";
+import { resolve, sep } from "node:path";
 import type { CliRenderer } from "@opentui/core";
-import { LOG_FILE } from "../../lib/config";
+import { LOG_FILE, MAX_SEND_TEXT_CHARS } from "../../lib/config";
 import { resolveRepoRoot } from "../../lib/git";
 
 export const HUNK_DIFF_ARGS = ["diff", "--watch"] as const;
@@ -12,15 +13,16 @@ const DISCOVERY_DELAY_MS = 500;
 const HARVEST_DELAY_MS = 1_000;
 const FINAL_READ_ATTEMPTS = 3;
 const FINAL_READ_DELAY_MS = 500;
+const HUNK_JSON_TIMEOUT_MS = 5_000;
 const MAX_SNIPPET_LINES = 6;
 const MAX_SNIPPET_CHARS = 300;
-export const MAX_REVIEW_PROMPT_CHARS = 10_000;
+export const MAX_REVIEW_PROMPT_CHARS = MAX_SEND_TEXT_CHARS;
 const TRUNCATION_MARKER = "\n\n(truncated)";
 
 export interface HunkReviewNote {
-  noteId: string;
+  noteId?: string;
   filePath: string;
-  hunkIndex: number;
+  hunkIndex?: number;
   newRange?: [number, number];
   oldRange?: [number, number];
   body: string;
@@ -73,11 +75,33 @@ async function defaultRunHunkJson(args: string[]): Promise<unknown | null> {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ]);
+    // A hung child would otherwise pin the poll loop forever and keep the
+    // picker's renderer suspended. Kill it after a timeout; the killed child
+    // exits non-zero and closes its pipes, so the exitCode branch below returns
+    // null and the seam degrades to no-notes as designed. The hard deadline
+    // race covers the pathological remainder (a child that traps SIGTERM, or
+    // a leaked pipe held open past its exit): give up unconditionally one
+    // second after the SIGTERM and escalate to SIGKILL.
+    const timer = setTimeout(() => proc.kill(), HUNK_JSON_TIMEOUT_MS);
+    let result: [string, string, number] | null;
+    try {
+      result = await Promise.race([
+        Promise.all([
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+          proc.exited,
+        ]),
+        Bun.sleep(HUNK_JSON_TIMEOUT_MS + 1_000).then(() => null),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+    if (result === null) {
+      proc.kill(9);
+      debugLog(`${args.join(" ")} timed out`);
+      return null;
+    }
+    const [stdout, stderr, exitCode] = result;
     if (stderr.trim()) debugLog(`${args.join(" ")}: ${stderr.trim()}`);
     if (exitCode !== 0) {
       debugLog(`${args.join(" ")} exited ${exitCode}`);
@@ -138,20 +162,18 @@ function asNotes(value: unknown): HunkReviewNote[] | null {
   for (const entry of comments) {
     if (typeof entry !== "object" || entry === null) return null;
     const note = entry as Record<string, unknown>;
-    if (
-      typeof note.noteId !== "string" ||
-      typeof note.filePath !== "string" ||
-      typeof note.hunkIndex !== "number" ||
-      typeof note.body !== "string"
-    ) {
+    // Only filePath and body are genuinely required (formatting depends on
+    // them). noteId and hunkIndex are never consumed, so tolerate their
+    // absence rather than rejecting the whole batch on benign schema drift.
+    if (typeof note.filePath !== "string" || typeof note.body !== "string") {
       return null;
     }
     const parsed: HunkReviewNote = {
-      noteId: note.noteId,
       filePath: note.filePath,
-      hunkIndex: note.hunkIndex,
       body: note.body,
     };
+    if (typeof note.noteId === "string") parsed.noteId = note.noteId;
+    if (typeof note.hunkIndex === "number") parsed.hunkIndex = note.hunkIndex;
     if (isRange(note.newRange)) parsed.newRange = note.newRange;
     if (isRange(note.oldRange)) parsed.oldRange = note.oldRange;
     notes.push(parsed);
@@ -176,11 +198,18 @@ async function addSnippets(
   return Promise.all(
     notes.map(async (note) => {
       if (!note.newRange) return note;
+      // hunk output is treated as untrusted elsewhere (asNotes), so don't
+      // let a stray filePath escape the repo root either.
+      const path = resolve(root, note.filePath);
+      if (path !== root && !path.startsWith(root + sep)) return note;
       try {
-        const lines = await readFileLines(`${root}/${note.filePath}`);
+        const lines = await readFileLines(path);
         const [start, end] = note.newRange;
         const snippet = lines
-          .slice(Math.max(0, start - 1), Math.min(end, start + MAX_SNIPPET_LINES - 1))
+          .slice(
+            Math.max(0, start - 1),
+            Math.min(end, start + MAX_SNIPPET_LINES - 1),
+          )
           .join("\n")
           .slice(0, MAX_SNIPPET_CHARS);
         return snippet ? { ...note, snippet } : note;
@@ -195,7 +224,8 @@ function formatRange(note: HunkReviewNote): string {
   const range = note.newRange ?? note.oldRange;
   if (!range) return note.filePath;
   const prefix = note.newRange ? "" : "old ";
-  const lines = range[0] === range[1] ? `${range[0]}` : `${range[0]}-${range[1]}`;
+  const lines =
+    range[0] === range[1] ? `${range[0]}` : `${range[0]}-${range[1]}`;
   return `${note.filePath}:${prefix}${lines}`;
 }
 
@@ -210,7 +240,13 @@ export function formatReviewPrompt(notes: HunkReviewNote[]): string {
       : "";
     return `${index + 1}. ${formatRange(note)}${snippet}\n   ${note.body}`;
   });
-  const prompt = `I reviewed your changes in hunk and left ${count} review comment${count === 1 ? "" : "s"}:\n\n${blocks.join("\n")}\n\nPlease address each comment.`;
+  const assembled = `I reviewed your changes in hunk and left ${count} review comment${count === 1 ? "" : "s"}:\n\n${blocks.join("\n")}\n\nPlease address each comment.`;
+  // The prompt is delivered via `tmux paste-buffer -p` (bracketed paste), so
+  // strip C0 controls (except \n and \t), DEL, and C1 before capping. This
+  // removes ESC, killing any embedded [200~/[201~ markers (inert without their
+  // escape byte) so they can never terminate the paste early and leak bytes as
+  // live keystrokes. Sanitize first so the length cap stays exact.
+  const prompt = assembled.replace(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/g, "");
   if (prompt.length <= MAX_REVIEW_PROMPT_CHARS) return prompt;
   return `${prompt.slice(0, MAX_REVIEW_PROMPT_CHARS - TRUNCATION_MARKER.length)}${TRUNCATION_MARKER}`;
 }
@@ -221,6 +257,11 @@ export function isHunkAvailable(
   return which("hunk") !== null;
 }
 
+/**
+ * Spawn `hunk diff --watch` in `root` with inherited stdio (`hunk` resolved via
+ * PATH). Shared by the CLI `review` command and the in-picker review action;
+ * both verify `hunk` is on PATH (`isHunkAvailable`) before calling.
+ */
 export function spawnHunkDiff(
   root: string,
   spawn: SpawnHunk = Bun.spawn as unknown as SpawnHunk,
@@ -233,6 +274,18 @@ export function spawnHunkDiff(
   });
 }
 
+/**
+ * Suspend the picker's renderer, run `hunk diff --watch` in `cwd`'s repo root
+ * with inherited stdio, then resume. Pre-flight checks (hunk on PATH, git
+ * repo root) run before `suspend()` so error toasts render without a flicker.
+ * `suspend()` has its own try/catch: if it throws, `resume()` is never
+ * called (nothing to undo). Once suspended, `resume()` always runs via
+ * try/finally, even if the spawn itself throws.
+ *
+ * While hunk runs, the picker polls hunk's session JSON to find the session
+ * bound to this pane and harvest the user comments left during review,
+ * returning them so the caller can hand them back to the agent.
+ */
 export async function runHunkReview(
   renderer: Pick<CliRenderer, "suspend" | "resume">,
   cwd: string,
@@ -271,20 +324,32 @@ export async function runHunkReview(
     let sessionId: string | null = null;
     let latestNotes: HunkReviewNote[] = [];
 
+    // Discovery loop: find the hunk session whose tmux location matches this
+    // pane, so we harvest comments from the right review and not a sibling.
     if (paneId) {
-      for (let attempt = 0; attempt < DISCOVERY_ATTEMPTS && !exited; attempt++) {
-        const sessions = asSessions(await runHunkJson(["session", "list", "--json"]));
+      for (
+        let attempt = 0;
+        attempt < DISCOVERY_ATTEMPTS && !exited;
+        attempt++
+      ) {
+        const sessions = asSessions(
+          await runHunkJson(["session", "list", "--json"]),
+        );
         sessionId =
           sessions.find((session) =>
             session.terminal?.locations?.some(
-              (location) => location.source === "tmux" && location.paneId === paneId,
+              (location) =>
+                location.source === "tmux" && location.paneId === paneId,
             ),
           )?.sessionId ?? null;
         if (sessionId) break;
-        if (!exited) await Promise.race([sleep(DISCOVERY_DELAY_MS), exitPromise]);
+        if (!exited)
+          await Promise.race([sleep(DISCOVERY_DELAY_MS), exitPromise]);
       }
     }
 
+    // Harvest loop: re-read comments every second. Each await races the sleep
+    // against exitPromise so we bail out the moment hunk exits.
     while (sessionId && !exited) {
       const snapshot = asNotes(
         await runHunkJson([
@@ -306,6 +371,9 @@ export async function runHunkReview(
       return { ok: false, error: `hunk exited with code ${exitCode}` };
     }
 
+    // Post-exit final read: a comment saved just before quitting can land after
+    // the harvest loop's last read. hunk keeps serving session JSON for a short
+    // teardown window, so retry a few times to catch it.
     if (sessionId) {
       for (let attempt = 0; attempt < FINAL_READ_ATTEMPTS; attempt++) {
         const snapshot = asNotes(

--- a/src/tui/utils/review.ts
+++ b/src/tui/utils/review.ts
@@ -1,17 +1,36 @@
+import { appendFileSync } from "node:fs";
 import type { CliRenderer } from "@opentui/core";
+import { LOG_FILE } from "../../lib/config";
 import { resolveRepoRoot } from "../../lib/git";
 
 export const HUNK_DIFF_ARGS = ["diff", "--watch"] as const;
 export const HUNK_INSTALL_HINT =
   "hunk not found: install it to review diffs (see github.com/modem-dev/hunk)";
 
-export function isHunkAvailable(
-  which: (cmd: string) => string | null = Bun.which,
-): boolean {
-  return which("hunk") !== null;
+const DISCOVERY_ATTEMPTS = 10;
+const DISCOVERY_DELAY_MS = 500;
+const HARVEST_DELAY_MS = 1_000;
+const FINAL_READ_ATTEMPTS = 3;
+const FINAL_READ_DELAY_MS = 500;
+const MAX_SNIPPET_LINES = 6;
+const MAX_SNIPPET_CHARS = 300;
+export const MAX_REVIEW_PROMPT_CHARS = 10_000;
+const TRUNCATION_MARKER = "\n\n(truncated)";
+
+export interface HunkReviewNote {
+  noteId: string;
+  filePath: string;
+  hunkIndex: number;
+  newRange?: [number, number];
+  oldRange?: [number, number];
+  body: string;
+  /** Annotated lines read from the working tree at harvest time. */
+  snippet?: string;
 }
 
-export type ReviewResult = { ok: true } | { ok: false; error: string };
+export type ReviewResult =
+  | { ok: true; notes: HunkReviewNote[] }
+  | { ok: false; error: string };
 
 type SpawnHunk = (
   cmd: string[],
@@ -27,13 +46,181 @@ export interface RunHunkReviewDeps {
   which?: (cmd: string) => string | null;
   spawn?: SpawnHunk;
   resolveRoot?: (cwd: string) => Promise<string | null>;
+  runHunkJson?: (args: string[]) => Promise<unknown | null>;
+  paneId?: string;
+  sleep?: (ms: number) => Promise<void>;
+  readFileLines?: (path: string) => Promise<string[]>;
+  gitStatus?: (root: string) => Promise<string | null>;
 }
 
-/**
- * Spawn `hunk diff --watch` in `root` with inherited stdio (`hunk` resolved via
- * PATH). Shared by the CLI `review` command and the in-picker review action;
- * both verify `hunk` is on PATH (`isHunkAvailable`) before calling.
- */
+interface HunkSessionListEntry {
+  sessionId: string;
+  terminal?: { locations?: Array<{ source?: string; paneId?: string }> };
+}
+
+function debugLog(message: string): void {
+  try {
+    appendFileSync(LOG_FILE, `[hunk-review] ${message}\n`);
+  } catch {
+    // Hand-back is best-effort; logging must not disturb the review flow.
+  }
+}
+
+async function defaultRunHunkJson(args: string[]): Promise<unknown | null> {
+  try {
+    const proc = Bun.spawn(["hunk", ...args], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (stderr.trim()) debugLog(`${args.join(" ")}: ${stderr.trim()}`);
+    if (exitCode !== 0) {
+      debugLog(`${args.join(" ")} exited ${exitCode}`);
+      return null;
+    }
+    return JSON.parse(stdout) as unknown;
+  } catch (err) {
+    debugLog(`${args.join(" ")} failed: ${err}`);
+    return null;
+  }
+}
+
+async function defaultGitStatus(root: string): Promise<string | null> {
+  try {
+    const proc = Bun.spawn(["git", "status", "--porcelain"], {
+      cwd: root,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (exitCode !== 0) {
+      debugLog(`git status --porcelain failed: ${stderr.trim()}`);
+      return null;
+    }
+    return stdout;
+  } catch (err) {
+    debugLog(`git status --porcelain failed: ${err}`);
+    return null;
+  }
+}
+
+function asSessions(value: unknown): HunkSessionListEntry[] {
+  const sessions =
+    typeof value === "object" && value !== null && "sessions" in value
+      ? (value as { sessions?: unknown }).sessions
+      : value;
+  if (!Array.isArray(sessions)) return [];
+  return sessions.filter(
+    (entry): entry is HunkSessionListEntry =>
+      typeof entry === "object" &&
+      entry !== null &&
+      typeof (entry as { sessionId?: unknown }).sessionId === "string",
+  );
+}
+
+function asNotes(value: unknown): HunkReviewNote[] | null {
+  const comments =
+    typeof value === "object" && value !== null && "comments" in value
+      ? (value as { comments?: unknown }).comments
+      : value;
+  if (!Array.isArray(comments)) return null;
+  const notes: HunkReviewNote[] = [];
+  for (const entry of comments) {
+    if (typeof entry !== "object" || entry === null) return null;
+    const note = entry as Record<string, unknown>;
+    if (
+      typeof note.noteId !== "string" ||
+      typeof note.filePath !== "string" ||
+      typeof note.hunkIndex !== "number" ||
+      typeof note.body !== "string"
+    ) {
+      return null;
+    }
+    const parsed: HunkReviewNote = {
+      noteId: note.noteId,
+      filePath: note.filePath,
+      hunkIndex: note.hunkIndex,
+      body: note.body,
+    };
+    if (isRange(note.newRange)) parsed.newRange = note.newRange;
+    if (isRange(note.oldRange)) parsed.oldRange = note.oldRange;
+    notes.push(parsed);
+  }
+  return notes;
+}
+
+function isRange(value: unknown): value is [number, number] {
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    Number.isInteger(value[0]) &&
+    Number.isInteger(value[1])
+  );
+}
+
+async function addSnippets(
+  notes: HunkReviewNote[],
+  root: string,
+  readFileLines: (path: string) => Promise<string[]>,
+): Promise<HunkReviewNote[]> {
+  return Promise.all(
+    notes.map(async (note) => {
+      if (!note.newRange) return note;
+      try {
+        const lines = await readFileLines(`${root}/${note.filePath}`);
+        const [start, end] = note.newRange;
+        const snippet = lines
+          .slice(Math.max(0, start - 1), Math.min(end, start + MAX_SNIPPET_LINES - 1))
+          .join("\n")
+          .slice(0, MAX_SNIPPET_CHARS);
+        return snippet ? { ...note, snippet } : note;
+      } catch {
+        return note;
+      }
+    }),
+  );
+}
+
+function formatRange(note: HunkReviewNote): string {
+  const range = note.newRange ?? note.oldRange;
+  if (!range) return note.filePath;
+  const prefix = note.newRange ? "" : "old ";
+  const lines = range[0] === range[1] ? `${range[0]}` : `${range[0]}-${range[1]}`;
+  return `${note.filePath}:${prefix}${lines}`;
+}
+
+export function formatReviewPrompt(notes: HunkReviewNote[]): string {
+  const count = notes.length;
+  const blocks = notes.map((note, index) => {
+    const snippet = note.snippet
+      ? `\n${note.snippet
+          .split("\n")
+          .map((line) => `   > ${line}`)
+          .join("\n")}`
+      : "";
+    return `${index + 1}. ${formatRange(note)}${snippet}\n   ${note.body}`;
+  });
+  const prompt = `I reviewed your changes in hunk and left ${count} review comment${count === 1 ? "" : "s"}:\n\n${blocks.join("\n")}\n\nPlease address each comment.`;
+  if (prompt.length <= MAX_REVIEW_PROMPT_CHARS) return prompt;
+  return `${prompt.slice(0, MAX_REVIEW_PROMPT_CHARS - TRUNCATION_MARKER.length)}${TRUNCATION_MARKER}`;
+}
+
+export function isHunkAvailable(
+  which: (cmd: string) => string | null = Bun.which,
+): boolean {
+  return which("hunk") !== null;
+}
+
 export function spawnHunkDiff(
   root: string,
   spawn: SpawnHunk = Bun.spawn as unknown as SpawnHunk,
@@ -46,14 +233,6 @@ export function spawnHunkDiff(
   });
 }
 
-/**
- * Suspend the picker's renderer, run `hunk diff --watch` in `cwd`'s repo root
- * with inherited stdio, then resume. Pre-flight checks (hunk on PATH, git
- * repo root) run before `suspend()` so error toasts render without a flicker.
- * `suspend()` has its own try/catch: if it throws, `resume()` is never
- * called (nothing to undo). Once suspended, `resume()` always runs via
- * try/finally, even if the spawn itself throws.
- */
 export async function runHunkReview(
   renderer: Pick<CliRenderer, "suspend" | "resume">,
   cwd: string,
@@ -62,12 +241,19 @@ export async function runHunkReview(
   const which = deps.which ?? Bun.which;
   const spawn = deps.spawn ?? (Bun.spawn as unknown as SpawnHunk);
   const resolveRoot = deps.resolveRoot ?? resolveRepoRoot;
+  const runHunkJson = deps.runHunkJson ?? defaultRunHunkJson;
+  const paneId = deps.paneId ?? process.env.TMUX_PANE;
+  const sleep = deps.sleep ?? Bun.sleep;
+  const readFileLines =
+    deps.readFileLines ??
+    (async (path: string) => (await Bun.file(path).text()).split("\n"));
+  const gitStatus = deps.gitStatus ?? defaultGitStatus;
 
-  const hunk = which("hunk");
-  if (!hunk) return { ok: false, error: HUNK_INSTALL_HINT };
-
+  if (!which("hunk")) return { ok: false, error: HUNK_INSTALL_HINT };
   const root = await resolveRoot(cwd);
   if (!root) return { ok: false, error: "not a git repository" };
+  const status = await gitStatus(root);
+  if (status === "") return { ok: false, error: "no changes to review" };
 
   try {
     renderer.suspend();
@@ -77,11 +263,74 @@ export async function runHunkReview(
 
   try {
     const proc = spawnHunkDiff(root, spawn);
-    const exitCode = await proc.exited;
+    let exited = false;
+    const exitPromise = proc.exited.then((code) => {
+      exited = true;
+      return code;
+    });
+    let sessionId: string | null = null;
+    let latestNotes: HunkReviewNote[] = [];
+
+    if (paneId) {
+      for (let attempt = 0; attempt < DISCOVERY_ATTEMPTS && !exited; attempt++) {
+        const sessions = asSessions(await runHunkJson(["session", "list", "--json"]));
+        sessionId =
+          sessions.find((session) =>
+            session.terminal?.locations?.some(
+              (location) => location.source === "tmux" && location.paneId === paneId,
+            ),
+          )?.sessionId ?? null;
+        if (sessionId) break;
+        if (!exited) await Promise.race([sleep(DISCOVERY_DELAY_MS), exitPromise]);
+      }
+    }
+
+    while (sessionId && !exited) {
+      const snapshot = asNotes(
+        await runHunkJson([
+          "session",
+          "comment",
+          "list",
+          sessionId,
+          "--type",
+          "user",
+          "--json",
+        ]),
+      );
+      if (snapshot) latestNotes = snapshot;
+      if (!exited) await Promise.race([sleep(HARVEST_DELAY_MS), exitPromise]);
+    }
+
+    const exitCode = await exitPromise;
     if (exitCode !== 0) {
       return { ok: false, error: `hunk exited with code ${exitCode}` };
     }
-    return { ok: true };
+
+    if (sessionId) {
+      for (let attempt = 0; attempt < FINAL_READ_ATTEMPTS; attempt++) {
+        const snapshot = asNotes(
+          await runHunkJson([
+            "session",
+            "comment",
+            "list",
+            sessionId,
+            "--type",
+            "user",
+            "--json",
+          ]),
+        );
+        if (snapshot) {
+          latestNotes = snapshot;
+          break;
+        }
+        if (attempt < FINAL_READ_ATTEMPTS - 1) await sleep(FINAL_READ_DELAY_MS);
+      }
+    }
+
+    return {
+      ok: true,
+      notes: await addSnippets(latestNotes, root, readFileLines),
+    };
   } catch (err) {
     return { ok: false, error: `${err}` };
   } finally {

--- a/src/tui/utils/review.ts
+++ b/src/tui/utils/review.ts
@@ -50,6 +50,14 @@ export interface RunHunkReviewDeps {
   resolveRoot?: (cwd: string) => Promise<string | null>;
   runHunkJson?: (args: string[]) => Promise<unknown | null>;
   paneId?: string;
+  /**
+   * Resolve our own controlling tty (e.g. `/dev/ttys084`), or null if stdin
+   * isn't a tty. hunk spawned with inherited stdio shares this tty, so matching
+   * on it finds the review session even when `paneId` discovery can't — notably
+   * inside a tmux `display-popup`, where hunk registers only a `tty` location
+   * and no `{source:"tmux", paneId}` (a popup is not a real pane).
+   */
+  readTty?: () => Promise<string | null>;
   sleep?: (ms: number) => Promise<void>;
   readFileLines?: (path: string) => Promise<string[]>;
   gitStatus?: (root: string) => Promise<string | null>;
@@ -57,7 +65,10 @@ export interface RunHunkReviewDeps {
 
 interface HunkSessionListEntry {
   sessionId: string;
-  terminal?: { locations?: Array<{ source?: string; paneId?: string }> };
+  launchedAt?: string;
+  terminal?: {
+    locations?: Array<{ source?: string; paneId?: string; tty?: string }>;
+  };
 }
 
 function debugLog(message: string): void {
@@ -136,6 +147,75 @@ async function defaultGitStatus(root: string): Promise<string | null> {
     debugLog(`git status --porcelain failed: ${err}`);
     return null;
   }
+}
+
+async function defaultReadTty(): Promise<string | null> {
+  try {
+    // `tty` reports the pathname of the terminal on stdin (fd 0). Resolve this
+    // before the renderer suspends, while fd 0 is still our interactive tty; it
+    // matches the `tty` location hunk records for the child we spawn with
+    // inherited stdio. Exits non-zero ("not a tty") when stdin is redirected.
+    const proc = Bun.spawn(["tty"], {
+      stdin: "inherit",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const [stdout, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      proc.exited,
+    ]);
+    if (exitCode !== 0) return null;
+    const tty = stdout.trim();
+    return tty.startsWith("/dev/") ? tty : null;
+  } catch (err) {
+    debugLog(`tty resolution failed: ${err}`);
+    return null;
+  }
+}
+
+/**
+ * Does this hunk session's terminal match the pane we're launched in or the tty
+ * we share with the hunk child? Either signal is enough; the tty path is what
+ * makes discovery work inside a `display-popup` (no paneId there).
+ */
+function sessionMatchesTerminal(
+  session: HunkSessionListEntry,
+  paneId: string | null | undefined,
+  tty: string | null,
+): boolean {
+  return (
+    session.terminal?.locations?.some(
+      (location) =>
+        (paneId != null &&
+          location.source === "tmux" &&
+          location.paneId === paneId) ||
+        (tty != null && location.source === "tty" && location.tty === tty),
+    ) ?? false
+  );
+}
+
+/**
+ * Pick the newest session by `launchedAt`, so the review we just spawned wins
+ * over any stale session lingering on the same pane or tty (a reused
+ * `/dev/ttysNNN` or a repeat review in the same popup pane). Entries without a
+ * parseable `launchedAt` sort oldest so a dated match always wins.
+ */
+function pickFreshest(
+  sessions: HunkSessionListEntry[],
+): HunkSessionListEntry | null {
+  let best: HunkSessionListEntry | null = null;
+  let bestTime = Number.NEGATIVE_INFINITY;
+  for (const session of sessions) {
+    const parsed = session.launchedAt
+      ? Date.parse(session.launchedAt)
+      : Number.NaN;
+    const time = Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
+    if (best === null || time >= bestTime) {
+      best = session;
+      bestTime = time;
+    }
+  }
+  return best;
 }
 
 function asSessions(value: unknown): HunkSessionListEntry[] {
@@ -296,6 +376,7 @@ export async function runHunkReview(
   const resolveRoot = deps.resolveRoot ?? resolveRepoRoot;
   const runHunkJson = deps.runHunkJson ?? defaultRunHunkJson;
   const paneId = deps.paneId ?? process.env.TMUX_PANE;
+  const readTty = deps.readTty ?? defaultReadTty;
   const sleep = deps.sleep ?? Bun.sleep;
   const readFileLines =
     deps.readFileLines ??
@@ -307,6 +388,11 @@ export async function runHunkReview(
   if (!root) return { ok: false, error: "not a git repository" };
   const status = await gitStatus(root);
   if (status === "") return { ok: false, error: "no changes to review" };
+
+  // Resolve our tty while fd 0 is still the interactive terminal (before
+  // suspend). This is the discovery fallback when there's no paneId to match,
+  // e.g. inside a display-popup.
+  const tty = await readTty();
 
   try {
     renderer.suspend();
@@ -324,9 +410,10 @@ export async function runHunkReview(
     let sessionId: string | null = null;
     let latestNotes: HunkReviewNote[] = [];
 
-    // Discovery loop: find the hunk session whose tmux location matches this
-    // pane, so we harvest comments from the right review and not a sibling.
-    if (paneId) {
+    // Discovery loop: find the hunk session whose terminal matches this pane or
+    // (in a popup, where there's no paneId) the tty we share with the hunk
+    // child, so we harvest comments from the right review and not a sibling.
+    if (paneId || tty) {
       for (
         let attempt = 0;
         attempt < DISCOVERY_ATTEMPTS && !exited;
@@ -335,13 +422,10 @@ export async function runHunkReview(
         const sessions = asSessions(
           await runHunkJson(["session", "list", "--json"]),
         );
-        sessionId =
-          sessions.find((session) =>
-            session.terminal?.locations?.some(
-              (location) =>
-                location.source === "tmux" && location.paneId === paneId,
-            ),
-          )?.sessionId ?? null;
+        const matches = sessions.filter((session) =>
+          sessionMatchesTerminal(session, paneId, tty),
+        );
+        sessionId = pickFreshest(matches)?.sessionId ?? null;
         if (sessionId) break;
         if (!exited)
           await Promise.race([sleep(DISCOVERY_DELAY_MS), exitPromise]);


### PR DESCRIPTION
## Overview

Adds review hand-back to the <kbd>d</kbd> hunk integration: after annotating a session's diff in hunk, ccmux offers to send the review notes back to the agent that authored the changes as a single prompt. Follow-up to #11.

## Motivation

The `d` review from #11 is read-only: notes written in hunk die with the hunk session, so feedback still had to be retyped into the agent by hand. This closes the loop. Annotate in hunk, quit, confirm, and the agent starts addressing the comments while the picker keeps watching its state.

Hunk brokers comments only in the live session's memory (nothing is written to disk), so ccmux polls the session while hunk runs, keyed on the picker's own tmux pane id, and takes a final read the moment hunk exits.

## Changes

### Daemon send path

- **src/daemon/server.ts** - Routes `POST /sessions/:id/send` through the pane-io helpers: multiline text uses tmux bracketed paste (`sendPromptToPane`), single-line keeps `sendLiteralToPane`, and `enter: false` threads through as paste-without-submit
- **src/daemon/pane-io.ts** - `sendPromptToPane` gains a `pressEnter` param for fill mode
- **src/daemon/invokers/claude-invoker.ts** - Passes `pressEnter: true` at existing call sites

This is a general `ccmux send` improvement riding along: multiline text now arrives as one message instead of one submit per line, and the 150ms paste-to-Enter gap fixes the Codex >= 0.124 batching bug where sent text sat in the composer without submitting.

### Review poller

- **src/tui/utils/review.ts** - Polls `hunk session list` / `comment list --type user` sequentially while hunk runs, discovers the session by tmux pane id, retries a final read at exit against hunk's ~2s teardown window, extracts working-tree snippets per note (6 lines / 300 chars caps), and formats the prompt (truncated at the daemon's 10k cap). All hunk-facing calls sit behind one injectable `runHunkJson` seam that degrades to no-offer on any drift. Also adds the empty-diff guard so `d` on a clean tree reports "no changes to review" instead of opening a blank hunk

### Picker hand-off

- **src/tui/App.tsx** - On hunk exit with notes: paneless sessions get a "captured, no pane" toast; otherwise the `reviewHandback` mode decides between the confirm dialog, immediate send, or composer fill. Delivery posts to the daemon's send endpoint and toasts the outcome
- **src/tui/store.ts**, **src/tui/components/ConfirmationDialog.tsx** - `send-review` confirm action ("Send N comments to <agent>?")
- **src/lib/preferences.ts**, **src/tui/index.tsx**, **src/commands/picker.ts**, **src/commands/sidebar.ts** - `reviewHandback` preference (`confirm` default, `auto`, `fill`) threaded through both entrypoints

### Docs

- **README.md** - Hand-back flow, `reviewHandback` config key, updated `d` row description
- **docs/architecture.md** - One-line note on the send path's paste-buffer branch

## Breaking Changes

None

## Testing

- [x] Unit tests: poller discovery/harvest/final-read races, snippet extraction, prompt formatting and truncation, empty-diff guard, all three hand-back modes, confirm/cancel/paneless/zero-note paths, send-route branch selection and `pressEnter` threading
- [x] `bun run typecheck`, `bun test` (2367 pass), `bun run knip` all green
- [x] Live multiline send against real Claude Code and Codex panes: 3+ line prompt arrives as one message and submits once
- [x] Full hand-back e2e against a real Claude pane: edit, <kbd>d</kbd>, two notes via <kbd>c</kbd>, quit, confirm dialog, prompt delivered with snippets, agent addressed both comments
- [x] Poller shapes verified against live hunk 0.17.0 (`{sessions: [...]}` / `{comments: [...]}` wrappers)
- [x] E2E recording (posted as a comment below)

Step 5 from the plan (CLI parity: harvesting notes from `ccmux review` and a `--send` flag) is deferred to a follow-up; the TUI flow is the product.

