### PR TITLE
feat(tui): Show runtime since spawn in the preview Agents list

### DIFF
--- a/src/daemon/adapters/claude/log-adapter.test.ts
+++ b/src/daemon/adapters/claude/log-adapter.test.ts
@@ -113,6 +113,38 @@ describe("ClaudeLogAdapter subagent watching", () => {
     expect(sub.status).toBe("working");
   });
 
+  it("records startedAt from the first transcript entry (runtime since spawn)", async () => {
+    // The preview shows runtime since spawn, so the subagent's startedAt
+    // must come from the head of the transcript, not the latest (tail)
+    // activity. Fresh timestamps so the stale-seed cap keeps the working
+    // subagent; the spawn (head) is earlier than the latest (tail) write.
+    const now = Date.now();
+    const spawn = new Date(now - 5 * 60_000).toISOString();
+    const latest = new Date(now).toISOString();
+    const head = JSON.stringify({
+      type: "user",
+      uuid: "head",
+      parentUuid: null,
+      timestamp: spawn,
+      message: { role: "user", content: "go" },
+    });
+    const file = join(subagentDir, "agent-astarted.jsonl");
+    writeFileSync(file, `${head}\n${workingLogContent(latest)}`);
+
+    adapter.onSessionStateUpdated(
+      SESSION_ID,
+      parentState({ hasActiveSubagent: false }),
+    );
+
+    const populated = await waitFor(
+      () => manager.getSession(SESSION_ID)!.subagents.length === 1,
+    );
+    expect(populated).toBe(true);
+    const sub = manager.getSession(SESSION_ID)!.subagents[0];
+    expect(sub.startedAt).toBe(spawn);
+    expect(sub.lastActivityAt).toBe(latest);
+  });
+
   it("tracks named teammate files (agent-a<name>-<hex>.jsonl)", async () => {
     // Teammates embed the agent name in the filename; the extraction regex
     // must accept more than bare hex (regression: named teammates were

--- a/src/daemon/adapters/claude/log-adapter.ts
+++ b/src/daemon/adapters/claude/log-adapter.ts
@@ -11,6 +11,7 @@ import {
   extractSessionIdFromPath,
   readLogTail,
   readLogIncremental,
+  readFirstEntryTimestamp,
 } from "../../parser";
 import {
   deriveStateFromEntries,
@@ -400,6 +401,14 @@ export class ClaudeLogAdapter implements LogAdapter {
       this.sessionManager.getSessionByNativeSessionId(sessionId) ?? null;
     if (!session) return;
 
+    const existing = session.subagents.find((s) => s.agentId === agentId);
+    // Spawn time = first transcript entry; read once and carry it forward so
+    // the preview can show runtime-since-spawn (the clock Claude's own agent
+    // panel displays). The head is immutable, so a re-read after eviction or
+    // a daemon restart derives the same value.
+    const startedAt =
+      existing?.startedAt ?? (await readFirstEntryTimestamp(path));
+
     const offset = this.subagentFileOffsets.get(path) ?? 0;
     let state: SessionState;
 
@@ -414,7 +423,6 @@ export class ClaudeLogAdapter implements LogAdapter {
       const { entries, newOffset } = await readLogIncremental(path, offset);
       this.subagentFileOffsets.set(path, newOffset);
 
-      const existing = session.subagents.find((s) => s.agentId === agentId);
       const currentState: SessionState = existing
         ? {
             status: existing.status,
@@ -442,6 +450,7 @@ export class ClaudeLogAdapter implements LogAdapter {
       attentionType: state.attentionType,
       pendingTool: state.pendingTool,
       lastActivityAt: state.lastActivityAt ?? null,
+      startedAt,
     });
 
     // Propagate subagent activity to parent session to keep it fresh

--- a/src/daemon/parser.test.ts
+++ b/src/daemon/parser.test.ts
@@ -10,6 +10,7 @@ import {
   extractProjectInfo,
   readLogIncremental,
   readLogTail,
+  readFirstEntryTimestamp,
 } from "./parser";
 
 describe("parser", () => {
@@ -84,6 +85,37 @@ invalid json
       const path = join(testDir, "tail-zero.jsonl");
       await Bun.write(path, line(1) + "\n");
       expect(await readLogTail(path, 10, 0)).toEqual([]);
+    });
+  });
+
+  describe("readFirstEntryTimestamp", () => {
+    it("returns the timestamp of the first entry (the head)", async () => {
+      const path = join(testDir, "head.jsonl");
+      const lines = [
+        JSON.stringify({ uuid: "u0", timestamp: "2024-01-01T00:00:00Z" }),
+        JSON.stringify({ uuid: "u1", timestamp: "2024-01-01T00:05:00Z" }),
+      ];
+      await Bun.write(path, lines.join("\n") + "\n");
+      expect(await readFirstEntryTimestamp(path)).toBe("2024-01-01T00:00:00Z");
+    });
+
+    it("skips leading lines without a timestamp", async () => {
+      const path = join(testDir, "head-skip.jsonl");
+      const lines = [
+        JSON.stringify({ type: "summary" }),
+        JSON.stringify({ uuid: "u0", timestamp: "2024-01-01T00:00:00Z" }),
+      ];
+      await Bun.write(path, lines.join("\n") + "\n");
+      expect(await readFirstEntryTimestamp(path)).toBe("2024-01-01T00:00:00Z");
+    });
+
+    it("returns null for an empty or missing file", async () => {
+      const empty = join(testDir, "empty.jsonl");
+      await Bun.write(empty, "");
+      expect(await readFirstEntryTimestamp(empty)).toBeNull();
+      expect(
+        await readFirstEntryTimestamp(join(testDir, "nope.jsonl")),
+      ).toBeNull();
     });
   });
 

--- a/src/daemon/parser.ts
+++ b/src/daemon/parser.ts
@@ -66,6 +66,37 @@ export async function readLogTail(
 }
 
 /**
+ * Read the timestamp of the first entry in a JSONL log (the head), used to
+ * derive a subagent's spawn time. Reads only the leading chunk and returns
+ * the first parsed entry that carries a `timestamp`. Returns null on any
+ * read/parse failure or if no timestamped entry is found in the head.
+ */
+export async function readFirstEntryTimestamp(
+  path: string,
+): Promise<string | null> {
+  try {
+    const file = Bun.file(path);
+    const size = file.size;
+    if (size === 0) return null;
+
+    const CHUNK_SIZE = 64 * 1024;
+    const content = await file.slice(0, Math.min(CHUNK_SIZE, size)).text();
+    for (const line of content.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line) as { timestamp?: string };
+        if (entry.timestamp) return entry.timestamp;
+      } catch {
+        // Skip malformed lines (including a possibly truncated tail line).
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Extract session ID (UUID) from log file path
  * Path format: ~/.claude/projects/<encoded-path>/<uuid>.jsonl
  */

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,5 +1,29 @@
 import { describe, it, expect, setSystemTime, afterAll } from "bun:test";
-import { formatRelativeTime } from "./format";
+import { formatDuration, formatRelativeTime } from "./format";
+
+describe("formatDuration", () => {
+  it("formats sub-minute durations as seconds", () => {
+    expect(formatDuration(0)).toBe("0s");
+    expect(formatDuration(42_000)).toBe("42s");
+    expect(formatDuration(59_999)).toBe("59s");
+  });
+
+  it("keeps seconds precision under an hour", () => {
+    expect(formatDuration(60_000)).toBe("1m0s");
+    expect(formatDuration(134_000)).toBe("2m14s");
+    expect(formatDuration(59 * 60_000 + 59_000)).toBe("59m59s");
+  });
+
+  it("drops seconds at an hour and above", () => {
+    expect(formatDuration(60 * 60_000)).toBe("1h0m");
+    expect(formatDuration(65 * 60_000 + 30_000)).toBe("1h5m");
+    expect(formatDuration(3 * 60 * 60_000 + 12 * 60_000)).toBe("3h12m");
+  });
+
+  it("clamps negative durations (clock skew) to 0s", () => {
+    expect(formatDuration(-5_000)).toBe("0s");
+  });
+});
 
 describe("formatRelativeTime", () => {
   afterAll(() => setSystemTime());

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,3 +1,22 @@
+/**
+ * Compact elapsed-duration label with seconds precision: `42s`, `2m14s`,
+ * `1h5m`. Unlike {@link formatRelativeTime} (which rounds to whole
+ * minutes), this keeps sub-minute detail so concurrent durations stay
+ * distinguishable — e.g. agents spawned seconds apart in a fan-out.
+ * Negative input (clock skew) clamps to `0s`.
+ */
+export function formatDuration(ms: number): string {
+  const totalSecs = Math.max(0, Math.floor(ms / 1000));
+  const secs = totalSecs % 60;
+  const totalMins = Math.floor(totalSecs / 60);
+  const mins = totalMins % 60;
+  const hours = Math.floor(totalMins / 60);
+
+  if (hours > 0) return `${hours}h${mins}m`;
+  if (totalMins > 0) return `${mins}m${secs}s`;
+  return `${secs}s`;
+}
+
 export function formatRelativeTime(date: Date, suffix = ""): string {
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();

--- a/src/tui/components/Preview.test.tsx
+++ b/src/tui/components/Preview.test.tsx
@@ -144,8 +144,52 @@ describe("Preview", () => {
     expect(frame).toContain("3a0227");
     // Lifted status label in the header, not raw idle/working
     expect(frame).toContain("agents");
-    // No time column: last-activity is jitter for a working agent, and
-    // runtime duplicates the lead's agent panel in the pane capture below.
+  });
+
+  it("shows runtime since spawn, anchored to startedAt (not last activity)", async () => {
+    // The agent wrote to its transcript 2s ago but spawned 2m14s ago; the
+    // row must show the spawn-anchored runtime (matching Claude's own
+    // agent panel), with seconds precision so concurrent rows stay
+    // distinguishable.
+    const now = Date.now();
+    const frame = await renderPreview(
+      mockEnrichedSession({
+        status: "idle",
+        tmuxPane: "%1",
+        subagents: [
+          {
+            agentId: "areviewer-quality-4e04b65eee350afe",
+            status: "working",
+            attentionType: null,
+            pendingTool: null,
+            lastActivityAt: new Date(now - 2_000).toISOString(),
+            startedAt: new Date(now - 134_000).toISOString(),
+          },
+        ],
+      }),
+    );
+    expect(frame).toMatch(/2m1[45]s/);
+  });
+
+  it("renders no duration when startedAt is unknown", async () => {
+    // Without a spawn time we render nothing rather than silently swapping
+    // in the last-activity metric (the confusion this column replaced).
+    const now = Date.now();
+    const frame = await renderPreview(
+      mockEnrichedSession({
+        status: "idle",
+        tmuxPane: "%1",
+        subagents: [
+          {
+            agentId: "areviewer-quality-4e04b65eee350afe",
+            status: "working",
+            attentionType: null,
+            pendingTool: null,
+            lastActivityAt: new Date(now - 2_000).toISOString(),
+          },
+        ],
+      }),
+    );
     const row = frame
       .split("\n")
       .find((line) => line.includes("reviewer-quality"));

--- a/src/tui/components/Preview.tsx
+++ b/src/tui/components/Preview.tsx
@@ -27,7 +27,9 @@ import { getStatusColor } from "./StatusBadge";
 import { getEffectiveStatus } from "../../daemon/status-machine";
 import { useStatusIcon } from "../utils/useStatusIcon";
 import { theme } from "../theme";
+import { useTick } from "../store";
 import {
+  formatDuration,
   formatRelativeTime,
   formatSubagentName,
   formatVersion,
@@ -35,12 +37,14 @@ import {
 } from "../utils/format";
 
 /**
- * One row of the preview's Agents section: activity spinner and the agent's
- * human name (parsed from its transcript filename). Deliberately no time
- * column — last-activity is jittery noise for a working agent, and runtime
- * since spawn duplicates the lead's own agent panel in the pane capture
- * right below. Presence in the list is the liveness signal (dead agents
- * are evicted by the stale sweep).
+ * One row of the preview's Agents section: activity spinner, the agent's
+ * human name (parsed from its transcript filename), and runtime since spawn.
+ * The duration is spawn-anchored (`startedAt`, the transcript's first
+ * entry), NOT last-activity — last-activity is jittery near-zero noise for
+ * a working agent, while runtime matches the clock Claude's own agent panel
+ * shows. It also fills the glance gap for background agents, whose pane
+ * hides per-agent times behind an interaction. No `startedAt` (head read
+ * failed) renders no duration rather than silently swapping metrics.
  * Both `working` and `waiting` subagents render as activity — a subagent's
  * `waiting` is an unresolved tool_use (usually a tool mid-execution), not a
  * prompt for the user (see `getEffectiveStatus`).
@@ -49,18 +53,28 @@ const SubagentRow: Component<{
   sub: SubagentState;
   iconStyle?: IconStyle;
 }> = (props) => {
+  const { tick } = useTick();
   const icon = useStatusIcon(
     () => "working",
     () => null,
     () => props.iconStyle,
     () => undefined,
   );
+  // Memoized on the 1s tick so the runtime counts up live; string equality
+  // means the text re-renders only when the label actually flips.
+  const runtime = createMemo((): string => {
+    void tick();
+    return props.sub.startedAt
+      ? formatDuration(Date.now() - new Date(props.sub.startedAt).getTime())
+      : "";
+  });
   return (
     <box flexDirection="row">
       <text fg={theme.peach}>{"  " + icon()}</text>
       <box flexGrow={1} paddingLeft={1}>
         <text fg={theme.text}>{formatSubagentName(props.sub.agentId)}</text>
       </box>
+      <text fg={theme.overlay}>{runtime()}</text>
     </box>
   );
 };

--- a/src/tui/utils/format.ts
+++ b/src/tui/utils/format.ts
@@ -1,4 +1,4 @@
-export { formatRelativeTime } from "../../lib/format";
+export { formatDuration, formatRelativeTime } from "../../lib/format";
 
 export function shortenCwd(cwd: string): string {
   const home = process.env.HOME ?? "";

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -91,6 +91,13 @@ export interface SubagentState {
   pendingTool: string | null;
   /** Last activity timestamp */
   lastActivityAt: string | null;
+  /**
+   * Spawn timestamp (first entry in the subagent's transcript). Drives the
+   * runtime-since-spawn duration in the preview's Agents section, matching
+   * the clock Claude's own agent panel displays. Best-effort: absent if the
+   * head read failed, in which case no duration renders.
+   */
+  startedAt?: string | null;
 }
 
 /**


### PR DESCRIPTION
> [!NOTE]
> Stacked on #20; review after it merges (base is `feat/agents-ui`).

## Summary

Adds a per-agent **runtime since spawn** to the preview's Agents section (from #20), right-aligned and counting up live:

```
Agents (5)
  ◐ 42e769                           2m14s
  ◐ 6f3508                            2m1s
  ◐ 73b40d                           1m47s
  ◐ 5b4f98                           1m33s
  +1 more
```

#20 originally showed a last-activity age here and then removed it: for a working agent that value is jittery near-zero noise (2s/15s/28s), and it visibly contradicted the runtime numbers in Claude's own agent panel. This PR brings the column back anchored to the right clock:

- **`startedAt` = the subagent transcript's first entry.** The Claude log adapter reads the head once per agent (`readFirstEntryTimestamp`, leading 64KB chunk) and carries it forward on every update. The head is immutable, so a re-read after eviction or a daemon restart derives the same value.
- **Why the transcript head is trustworthy**: every observed subagent transcript opens with a timestamped `type: "user"` entry, and head timestamps of a real fan-out reproduced Claude's agent-panel runtimes to within a second (spawn deltas 13.5s/13.3s/14.4s vs the panel's 13s/14s/14s). Where Claude's panel is visible in the pane capture below, the two now agree; file birthtime or daemon-first-seen would both drift.
- **Why bring the column back at all**: background agents. Their rows are unnamed hex prefixes and their pane shows only `N background agents launched (↓ to manage)`, hiding per-agent times behind an interaction — so the Agents section is the only glanceable per-agent signal.
- **Seconds precision**: a new `formatDuration` (`42s`, `2m14s`, `1h5m`) instead of the minute-rounded house `formatRelativeTime`, so agents spawned seconds apart stay distinguishable (all four rows above would otherwise read `2m`/`1m`).
- **Live updates**: the label memoizes on the 1s tick (same pattern as `SessionItem`'s age column); string equality gates re-renders to actual label flips.
- **Honest on missing data**: no `startedAt` (head read failed) renders no duration rather than silently swapping back to the last-activity metric. The stale sweep still keys off `lastActivityAt`, untouched.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (2434 tests; new coverage for `formatDuration` boundaries, `readFirstEntryTimestamp` head/skip/missing cases, the adapter threading `startedAt` from head-not-tail, the spawn-anchored render, and the no-`startedAt` no-duration render)
- [x] Verified the affected TUI surface: the snippet above is the real `Preview` component rendered headlessly with spawn offsets matching the live repro
- [ ] Live e2e with a real fan-out on this branch (the daemon-side threading is unit-tested; a live run confirming the SSE path end to end is the remaining check)

## Notes for reviewers

- `startedAt` is optional on `SubagentState` (best-effort, set only by the Claude log adapter), so the ~15 existing test literals constructing subagents are untouched.
- If the head read returns null it retries on subsequent change events (self-healing, ≤64KB per read, immutable target), and concurrent handler interleavings derive the same value.
