### PR TITLE
feat(tui): Assign brand colors to Copilot, Antigravity, and Cursor

### DIFF
--- a/src/tui/components/SessionItem.tsx
+++ b/src/tui/components/SessionItem.tsx
@@ -173,12 +173,18 @@ function getAttentionColor(session: EnrichedSession): string {
  * reads the live `theme` after `applyTheme`, rather than freezing the default
  * palette at import time. */
 export function agentColorFor(agentType: string): string {
+  // Brand-matched slots; sharing (blue, mauve) is deliberate: brand fidelity
+  // over per-agent uniqueness. Cursor/OpenCode/Pi brands are monochrome, so
+  // cursor gets the near-neutral rosewater and opencode/pi keep their slots.
   const colors: Record<string, string> = {
     claude: theme.peach,
     codex: theme.green,
     opencode: theme.blue,
     gemini: theme.mauve,
     pi: theme.teal,
+    cursor: theme.rosewater,
+    antigravity: theme.blue,
+    copilot: theme.mauve,
   };
   return colors[agentType] ?? theme.overlay;
 }

--- a/src/tui/components/SessionItem.tsx
+++ b/src/tui/components/SessionItem.tsx
@@ -173,9 +173,7 @@ function getAttentionColor(session: EnrichedSession): string {
  * reads the live `theme` after `applyTheme`, rather than freezing the default
  * palette at import time. */
 export function agentColorFor(agentType: string): string {
-  // Brand-matched slots; sharing (blue, mauve) is deliberate: brand fidelity
-  // over per-agent uniqueness. Cursor/OpenCode/Pi brands are monochrome, so
-  // cursor gets the near-neutral rosewater and opencode/pi keep their slots.
+  // Brand-matched colors; shared slots (blue, mauve) are intentional.
   const colors: Record<string, string> = {
     claude: theme.peach,
     codex: theme.green,

--- a/src/tui/components/theme-propagation.test.tsx
+++ b/src/tui/components/theme-propagation.test.tsx
@@ -37,6 +37,9 @@ describe("module-scope color resolvers follow the active theme", () => {
     expect(agentColorFor("unknown-agent")).toBe(
       catppuccinLatte.semantic.overlay,
     );
+    expect(agentColorFor("copilot")).toBe(catppuccinLatte.semantic.mauve);
+    expect(agentColorFor("antigravity")).toBe(catppuccinLatte.semantic.blue);
+    expect(agentColorFor("cursor")).toBe(catppuccinLatte.semantic.rosewater);
     expect(prStateColor("red")).toBe(catppuccinLatte.semantic.red);
     expect(prStateColor("none")).toBe(catppuccinLatte.semantic.mauve);
   });


### PR DESCRIPTION
## Overview

Assigns brand-matched colors to Copilot, Antigravity, and Cursor in the TUI agent color map, replacing their overlay-gray fallback so every built-in agent renders with a deliberate color.

## Motivation

Cursor, Antigravity, and Copilot rows currently render in the same overlay gray as unknown custom agents, so mixed-agent sessions lose at-a-glance identity in the picker and sidebar. Each agent now gets the theme slot closest to its actual brand:

- **Copilot** - `mauve` (Copilot Purple `#8534F3`, per [GitHub's brand toolkit](https://brand.github.com/brand-identity/copilot))
- **Antigravity** - `blue` (the dominant hue of its logo gradient)
- **Cursor** - `rosewater` (its official off-white `#F7F7F4`, per [Cursor's brand guidelines](https://cursor.com/brand))

Sharing slots with existing agents (gemini on mauve, opencode on blue) is deliberate: brand fidelity wins over per-agent uniqueness. OpenCode and Pi keep their current slots; both brands are monochrome with no color to match.

## Changes

### TUI

- **SessionItem.tsx** - Adds `cursor`, `antigravity`, and `copilot` entries to `agentColorFor`, with a comment noting the shared slots are intentional
- **theme-propagation.test.tsx** - Asserts the three new mappings follow the active theme

## Breaking Changes

None

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (2794 pass, 0 fail)
- [ ] Verified picker rendering in a detached tmux session (ANSI capture shows the new agent colors) - confirmed the picker renders correctly (existing claude rows show peach `38;2;250;179;135`), but no live Cursor, Antigravity, or Copilot sessions were running at verification time, so the three new mappings are confirmed only by the unit test above, not by a live capture