### PR TITLE
fix(daemon): Derive project from git repo root

### DIFF
--- a/src/daemon/parser.ts
+++ b/src/daemon/parser.ts
@@ -1,5 +1,6 @@
 import { closeSync, openSync, readSync } from "fs";
 import type { LogEntry } from "../types";
+import { deriveProject } from "./project-derivation";
 
 export function parseLogEntries(content: string): LogEntry[] {
   const lines = content.trim().split("\n");
@@ -136,7 +137,7 @@ export function extractProjectInfo(logPath: string): {
 
   const encodedPath = parts[projectsIndex + 1];
   const cwd = decodeProjectPath(encodedPath);
-  const project = cwd.split("/").pop() || "unknown";
+  const project = deriveProject(cwd, "unknown");
 
   return { project, cwd };
 }

--- a/src/daemon/project-derivation.test.ts
+++ b/src/daemon/project-derivation.test.ts
@@ -123,6 +123,54 @@ describe("deriveProject", () => {
     expect(unbounded).toBe(basename(outer));
   });
 
+  it("does not let homeDir's own .git absorb a strict-descendant non-repo cwd", () => {
+    // $HOME is itself a git repo (e.g. ~/.git dotfiles). A non-repo dir
+    // under home must NOT walk up into homeDir's .git and collapse into
+    // the home basename; it resolves to its own basename instead.
+    const fakeHome = tempDir("home-git-home");
+    mkdirSync(join(fakeHome, ".git"));
+
+    const cwd = join(fakeHome, "work", "project-dir");
+    mkdirSync(cwd, { recursive: true });
+
+    const project = deriveProject(cwd, "fallback", {
+      cache: new Map(),
+      homeDir: fakeHome,
+    });
+    expect(project).toBe(basename(cwd));
+    expect(project).not.toBe(basename(fakeHome));
+  });
+
+  it("still resolves cwd === homeDir to the home basename when homeDir is itself a repo", () => {
+    const fakeHome = tempDir("home-git-self");
+    mkdirSync(join(fakeHome, ".git"));
+
+    const project = deriveProject(fakeHome, "fallback", {
+      cache: new Map(),
+      homeDir: fakeHome,
+    });
+    expect(project).toBe(basename(fakeHome));
+  });
+
+  it("resolves a real repo under home even when homeDir itself is a repo", () => {
+    // homeDir's .git must not over-block a genuine repo below it: the
+    // pre-probe guard only fires AT homeDir, so a repo strictly under home
+    // still resolves to its own root's basename.
+    const fakeHome = tempDir("home-git-nested");
+    mkdirSync(join(fakeHome, ".git"));
+
+    const repo = join(fakeHome, "projects", "repo");
+    mkdirSync(join(repo, ".git"), { recursive: true });
+    const cwd = join(repo, "src");
+    mkdirSync(cwd, { recursive: true });
+
+    const project = deriveProject(cwd, "fallback", {
+      cache: new Map(),
+      homeDir: fakeHome,
+    });
+    expect(project).toBe("repo");
+  });
+
   it("caches by cwd: a second call reuses the cached value without re-walking the filesystem", () => {
     const main = tempDir("cache-main");
     const worktreesDir = join(main, ".git", "worktrees", "wt");

--- a/src/daemon/project-derivation.test.ts
+++ b/src/daemon/project-derivation.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join, basename, relative } from "path";
+import { deriveProject } from "./project-derivation";
+
+const cleanupDirs: string[] = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(
+    join(tmpdir(), `ccmux-project-derivation-${prefix}-`),
+  );
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (cleanupDirs.length > 0) {
+    const dir = cleanupDirs.pop()!;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("deriveProject", () => {
+  it("resolves the main checkout root's own basename", () => {
+    const root = tempDir("main");
+    mkdirSync(join(root, ".git"));
+
+    expect(deriveProject(root, "fallback", { cache: new Map() })).toBe(
+      basename(root),
+    );
+  });
+
+  it("resolves a subdirectory of a repo to the repo root's basename, not the subdir", () => {
+    const root = tempDir("main-sub");
+    mkdirSync(join(root, ".git"));
+    const subdir = join(root, "src", "nested");
+    mkdirSync(subdir, { recursive: true });
+
+    expect(deriveProject(subdir, "fallback", { cache: new Map() })).toBe(
+      basename(root),
+    );
+  });
+
+  it("resolves a worktree via an absolute `gitdir:` path to the main root's basename", () => {
+    const main = tempDir("wt-main-abs");
+    const worktreesDir = join(main, ".git", "worktrees", "feature-x");
+    mkdirSync(worktreesDir, { recursive: true });
+
+    const worktree = tempDir("wt-abs");
+    writeFileSync(join(worktree, ".git"), `gitdir: ${worktreesDir}\n`);
+
+    const project = deriveProject(worktree, "fallback", { cache: new Map() });
+    expect(project).toBe(basename(main));
+    expect(project).not.toBe(basename(worktree));
+  });
+
+  it("resolves a worktree via a relative `gitdir:` path to the main root's basename", () => {
+    const main = tempDir("wt-main-rel");
+    const worktreesDir = join(main, ".git", "worktrees", "feature-y");
+    mkdirSync(worktreesDir, { recursive: true });
+
+    const worktree = tempDir("wt-rel");
+    const relativeGitdir = relative(worktree, worktreesDir);
+    writeFileSync(join(worktree, ".git"), `gitdir: ${relativeGitdir}\n`);
+
+    const project = deriveProject(worktree, "fallback", { cache: new Map() });
+    expect(project).toBe(basename(main));
+    expect(project).not.toBe(basename(worktree));
+  });
+
+  it("falls back to the submodule's own cwd basename when the gitdir doesn't match the worktrees shape", () => {
+    const parent = tempDir("submodule-parent");
+    const submoduleGitdir = join(parent, ".git", "modules", "sub");
+    mkdirSync(submoduleGitdir, { recursive: true });
+
+    const submodule = tempDir("submodule");
+    writeFileSync(join(submodule, ".git"), `gitdir: ${submoduleGitdir}\n`);
+
+    const project = deriveProject(submodule, "fallback", { cache: new Map() });
+    expect(project).toBe(basename(submodule));
+  });
+
+  it("falls back to the cwd basename when not inside a git repo", () => {
+    const dir = tempDir("non-git");
+
+    expect(deriveProject(dir, "fallback", { cache: new Map() })).toBe(
+      basename(dir),
+    );
+  });
+
+  it("falls back to the provided fallback when the basename is empty (root cwd)", () => {
+    expect(deriveProject("/", "root-fallback", { cache: new Map() })).toBe(
+      "root-fallback",
+    );
+  });
+
+  it("stops walking upward at homeDir and does not find a .git above it", () => {
+    const outer = tempDir("home-boundary-outer");
+    mkdirSync(join(outer, ".git"));
+
+    const fakeHome = join(outer, "home");
+    const cwd = join(fakeHome, "work", "project-dir");
+    mkdirSync(cwd, { recursive: true });
+
+    // Bounded by homeDir: must not see outer's .git, so it falls back to
+    // the cwd's own basename.
+    const bounded = deriveProject(cwd, "fallback", {
+      cache: new Map(),
+      homeDir: fakeHome,
+    });
+    expect(bounded).toBe(basename(cwd));
+    expect(bounded).not.toBe(basename(outer));
+
+    // Same fixture, unbounded (homeDir doesn't match anything on the walk):
+    // the walk continues past where fakeHome would have stopped it and
+    // finds outer's .git, proving the boundary in the first assertion was
+    // actually doing something.
+    const unbounded = deriveProject(cwd, "fallback", {
+      cache: new Map(),
+      homeDir: "/nonexistent-home-for-test",
+    });
+    expect(unbounded).toBe(basename(outer));
+  });
+
+  it("caches by cwd: a second call reuses the cached value without re-walking the filesystem", () => {
+    const main = tempDir("cache-main");
+    const worktreesDir = join(main, ".git", "worktrees", "wt");
+    mkdirSync(worktreesDir, { recursive: true });
+
+    const worktree = tempDir("cache-wt");
+    const gitFile = join(worktree, ".git");
+    writeFileSync(gitFile, `gitdir: ${worktreesDir}\n`);
+
+    const cache = new Map<string, string>();
+    const first = deriveProject(worktree, "fallback", { cache });
+    expect(first).toBe(basename(main));
+    expect(cache.get(worktree)).toBe(basename(main));
+
+    // Remove the .git file so a fresh (uncached) walk would find nothing
+    // and fall back to the worktree's own basename instead.
+    unlinkSync(gitFile);
+
+    const second = deriveProject(worktree, "fallback", { cache });
+    expect(second).toBe(basename(main));
+    expect(second).not.toBe(basename(worktree));
+  });
+
+  it("uses a separate result per cwd within the same cache", () => {
+    const a = tempDir("cache-a");
+    mkdirSync(join(a, ".git"));
+    const b = tempDir("cache-b");
+    mkdirSync(join(b, ".git"));
+
+    const cache = new Map<string, string>();
+    expect(deriveProject(a, "fallback", { cache })).toBe(basename(a));
+    expect(deriveProject(b, "fallback", { cache })).toBe(basename(b));
+    expect(cache.size).toBe(2);
+  });
+});

--- a/src/daemon/project-derivation.ts
+++ b/src/daemon/project-derivation.ts
@@ -1,0 +1,152 @@
+import { existsSync, readFileSync, statSync } from "fs";
+import { dirname, isAbsolute, join, resolve, sep } from "path";
+import { homedir } from "os";
+
+/** Process-wide default cache for {@link deriveProject}. */
+export const projectCache: Map<string, string> = new Map();
+
+export interface DeriveProjectOptions {
+  /**
+   * Memoization cache, keyed by the raw `cwd` string. Defaults to the
+   * process-wide {@link projectCache} so every call site shares one cache.
+   * Callers pass their own `Map` in tests to observe cache population
+   * without touching daemon-wide state.
+   */
+  cache?: Map<string, string>;
+  /**
+   * Home directory to stop the upward walk at (never scan above it).
+   * Defaults to `os.homedir()`. Overridable for tests, since Bun's
+   * `os.homedir()` does not track a test-time `process.env.HOME` override.
+   */
+  homeDir?: string;
+}
+
+/**
+ * Derive the display "project" name for a `cwd`, git-aware so worktrees of
+ * the same repo group together instead of fragmenting by worktree
+ * directory name.
+ *
+ * Resolution:
+ * 1. Walk parent directories from `cwd` looking for a `.git` entry,
+ *    stopping at `$HOME` or the filesystem root (never scanning above the
+ *    user's home directory).
+ * 2. A `.git` DIRECTORY means the main checkout: project is that
+ *    directory's own basename.
+ * 3. A `.git` FILE (a worktree) contains `gitdir: <path>` pointing into
+ *    `<main>/.git/worktrees/<name>`; the main root is derived by stripping
+ *    that suffix. A relative `gitdir` path is resolved against the
+ *    directory containing the `.git` file first. If the resolved path
+ *    doesn't match the `/.git/worktrees/<name>` shape (e.g. a submodule's
+ *    `.git/modules/<name>` gitdir), this falls back to the plain cwd
+ *    basename rather than guessing a wrong repo root.
+ * 4. If no `.git` is found (not a git repo), falls back to the cwd
+ *    basename, matching prior behavior byte-for-byte for a repo root or a
+ *    non-git directory.
+ *
+ * Results are memoized (see {@link DeriveProjectOptions.cache}) so the
+ * filesystem walk runs at most once per unique cwd (this is called on
+ * every session create/update and reconcile tick). The cache has no
+ * invalidation; a cwd's git-repo identity is not expected to change for
+ * the life of the daemon process.
+ */
+export function deriveProject(
+  cwd: string,
+  fallback: string,
+  options: DeriveProjectOptions = {},
+): string {
+  const cache = options.cache ?? projectCache;
+
+  const cached = cache.get(cwd);
+  if (cached !== undefined) return cached;
+
+  const homeDir = options.homeDir ?? homedir();
+  const project =
+    resolveGitAwareProject(cwd, homeDir) ?? cwdBasename(cwd) ?? fallback;
+  cache.set(cwd, project);
+  return project;
+}
+
+/**
+ * Mirrors the pre-existing `cwd.split("/").pop()` derivation exactly
+ * (rather than `path.basename`, which strips trailing slashes
+ * differently) so a repo-root cwd produces a byte-identical result to
+ * before this helper existed.
+ */
+function cwdBasename(cwd: string): string | null {
+  const name = cwd.split("/").pop();
+  return name ? name : null;
+}
+
+/**
+ * Walk up from `cwd` looking for `.git`, stopping at `homeDir` or the
+ * filesystem root. Returns the git-aware project name, or null if `cwd`
+ * isn't inside a git repo (caller falls back to the cwd basename).
+ */
+function resolveGitAwareProject(cwd: string, homeDir: string): string | null {
+  if (!isAbsolute(cwd)) return null;
+
+  let dir = cwd;
+
+  while (true) {
+    const gitPath = join(dir, ".git");
+    if (existsSync(gitPath)) {
+      // statSync can still throw if the entry vanishes between the
+      // existsSync check and here (e.g. a worktree being removed while
+      // the daemon walks); the daemon loop must not see that throw.
+      let stat;
+      try {
+        stat = statSync(gitPath);
+      } catch {
+        return null;
+      }
+      if (stat.isDirectory()) {
+        // Main checkout: project = this dir's own basename.
+        return cwdBasename(dir);
+      }
+      if (stat.isFile()) {
+        return resolveWorktreeProject(gitPath, dir);
+      }
+      // Neither file nor directory (unexpected); treat as not a repo.
+      return null;
+    }
+
+    if (dir === homeDir) return null;
+    const parent = dirname(dir);
+    if (parent === dir) return null; // filesystem root
+    dir = parent;
+  }
+}
+
+/**
+ * A `.git` FILE holds `gitdir: <path>`. For a worktree, `<path>` points
+ * into `<main>/.git/worktrees/<name>`; derive the main root's basename by
+ * stripping that suffix. Returns null (caller falls back to cwd basename)
+ * when the gitdir doesn't have that shape, e.g. a submodule's
+ * `.git/modules/<name>` gitdir.
+ */
+function resolveWorktreeProject(
+  gitFilePath: string,
+  gitFileDir: string,
+): string | null {
+  let content: string;
+  try {
+    content = readFileSync(gitFilePath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const match = content.match(/^gitdir:\s*(.+?)\s*$/m);
+  if (!match) return null;
+
+  const rawGitdir = match[1];
+  const gitdir = isAbsolute(rawGitdir)
+    ? rawGitdir
+    : resolve(gitFileDir, rawGitdir);
+
+  const marker = `${sep}.git${sep}worktrees${sep}`;
+  const markerIdx = gitdir.lastIndexOf(marker);
+  if (markerIdx === -1) return null;
+
+  const mainRoot = gitdir.slice(0, markerIdx);
+  return cwdBasename(mainRoot);
+}

--- a/src/daemon/project-derivation.ts
+++ b/src/daemon/project-derivation.ts
@@ -29,7 +29,11 @@ export interface DeriveProjectOptions {
  * Resolution:
  * 1. Walk parent directories from `cwd` looking for a `.git` entry,
  *    stopping at `$HOME` or the filesystem root (never scanning above the
- *    user's home directory).
+ *    user's home directory). `$HOME`'s OWN `.git` is only honored when
+ *    `cwd` IS `$HOME`; a strict descendant of `$HOME` stops at the home
+ *    boundary WITHOUT probing it, so a `~/.git` dotfiles repo (someone ran
+ *    a bare `git init` in their home) does not swallow every non-repo
+ *    directory under home into one giant "home-basename" group.
  * 2. A `.git` DIRECTORY means the main checkout: project is that
  *    directory's own basename.
  * 3. A `.git` FILE (a worktree) contains `gitdir: <path>` pointing into
@@ -81,6 +85,14 @@ function cwdBasename(cwd: string): string | null {
  * Walk up from `cwd` looking for `.git`, stopping at `homeDir` or the
  * filesystem root. Returns the git-aware project name, or null if `cwd`
  * isn't inside a git repo (caller falls back to the cwd basename).
+ *
+ * The home boundary stops the walk BEFORE probing `homeDir`'s own `.git`,
+ * but only for strict descendants (`dir !== cwd`). A user whose `$HOME` is
+ * itself a git repo (`~/.git` from dotfiles or a stray `git init`) would
+ * otherwise have every non-repo directory under home walk up, hit that
+ * `.git`, and collapse into a single group named after the home directory.
+ * A session launched AT `$HOME` (cwd === homeDir) still resolves through
+ * the probe below, so `$HOME`-is-itself-a-repo keeps its own basename.
  */
 function resolveGitAwareProject(cwd: string, homeDir: string): string | null {
   if (!isAbsolute(cwd)) return null;
@@ -88,6 +100,11 @@ function resolveGitAwareProject(cwd: string, homeDir: string): string | null {
   let dir = cwd;
 
   while (true) {
+    // Home boundary for strict descendants: stop without probing homeDir's
+    // own `.git` (see the doc comment above). When cwd === homeDir this is
+    // skipped so the probe can still claim a real `$HOME` repo.
+    if (dir === homeDir && dir !== cwd) return null;
+
     const gitPath = join(dir, ".git");
     if (existsSync(gitPath)) {
       // statSync can still throw if the entry vanishes between the
@@ -110,6 +127,8 @@ function resolveGitAwareProject(cwd: string, homeDir: string): string | null {
       return null;
     }
 
+    // Reached only when cwd === homeDir and homeDir has no `.git` (the
+    // pre-probe guard above already handles every strict descendant).
     if (dir === homeDir) return null;
     const parent = dirname(dir);
     if (parent === dir) return null; // filesystem root

--- a/src/daemon/sessions.ts
+++ b/src/daemon/sessions.ts
@@ -12,6 +12,7 @@ import type {
 import { extractProjectInfo } from "./parser";
 import { appendPrompt } from "./status-machine";
 import { getSessionPidMarker } from "./session-markers";
+import { deriveProject } from "./project-derivation";
 import { findSoftEvictTargets } from "./binder/primitives";
 
 interface PaneTrackedSessionInput {
@@ -284,7 +285,7 @@ export class SessionManager extends EventEmitter {
     const paneNumberMatch = input.paneId.match(/^%(\d+)$/);
     const paneToken = paneNumberMatch ? `pane${paneNumberMatch[1]}` : "pane";
     const sessionId = `${input.agentType}_${paneToken}`;
-    const project = input.cwd.split("/").pop() || input.agentType;
+    const project = deriveProject(input.cwd, input.agentType);
 
     const existing = this.sessions.get(sessionId);
     if (existing) {
@@ -389,7 +390,7 @@ export class SessionManager extends EventEmitter {
    * only when the short drops from `roster.workers`.
    */
   createBackgroundSession(input: BackgroundSessionInput): Session {
-    const project = input.cwd.split("/").pop() || "claude";
+    const project = deriveProject(input.cwd, "claude");
 
     const session: Session = {
       id: input.daemonShort,
@@ -498,7 +499,7 @@ export class SessionManager extends EventEmitter {
     // Update cwd/project if provided from log entries (more accurate than decoded path)
     if (state.cwd && state.cwd !== session.cwd) {
       session.cwd = state.cwd;
-      session.project = state.cwd.split("/").pop() || session.project;
+      session.project = deriveProject(state.cwd, session.project);
       changed = true;
     }
 

--- a/src/daemon/status-machine.ts
+++ b/src/daemon/status-machine.ts
@@ -21,6 +21,7 @@ import {
   MAX_PROMPT_CHARS,
   MAX_PROMPTS_TOTAL_BYTES,
 } from "../lib/config";
+import { deriveProject } from "./project-derivation";
 
 /**
  * Append a user prompt to the capped prompt index. Trims and truncates the
@@ -338,7 +339,9 @@ function processUserEntry(
   const { content } = entry.message;
 
   const cwd = entry.cwd || currentState.cwd;
-  const project = cwd ? cwd.split("/").pop() : currentState.project;
+  const project = cwd
+    ? deriveProject(cwd, currentState.project ?? "unknown")
+    : currentState.project;
   const version = entry.version || currentState.version;
   const gitBranch = entry.gitBranch || currentState.gitBranch;
 

--- a/src/tui/store.ts
+++ b/src/tui/store.ts
@@ -156,10 +156,15 @@ export const INVOKE_FINISHED_LINGER_MS = 6000;
  * invoke worker (codex/cursor/opencode/gemini), which creates no tmux
  * session and would otherwise be invisible. Keyed by `invocationId`.
  *
- * `project` mirrors the daemon's pane-tracked derivation
- * (`cwd.split("/").pop()`, see `sessions.ts:createPaneTrackedSession`) so
- * the row co-locates with real sessions in the same directory under
- * project/cwd grouping. `lastActivityAt` is the start time so the existing
+ * `project` uses the plain `cwd.split("/").pop()` basename, NOT the
+ * daemon's git-aware `deriveProject` (`src/daemon/project-derivation.ts`),
+ * because that resolution walks the filesystem and must stay out of the
+ * TUI process. This is a deliberate, documented divergence: the row
+ * fabricated here is a placeholder shown before the daemon reports the
+ * real session, so it snaps to the daemon's repo-aware `project` value on
+ * the first SSE update for this invocation (a worktree cwd may briefly
+ * show its own directory name instead of the main repo's before that
+ * update lands). `lastActivityAt` is the start time so the existing
  * `useTick` age column counts up live (a stuck worker reads as stale).
  */
 export function fabricateInvokeSession(

--- a/src/tui/store.ts
+++ b/src/tui/store.ts
@@ -159,13 +159,16 @@ export const INVOKE_FINISHED_LINGER_MS = 6000;
  * `project` uses the plain `cwd.split("/").pop()` basename, NOT the
  * daemon's git-aware `deriveProject` (`src/daemon/project-derivation.ts`),
  * because that resolution walks the filesystem and must stay out of the
- * TUI process. This is a deliberate, documented divergence: the row
- * fabricated here is a placeholder shown before the daemon reports the
- * real session, so it snaps to the daemon's repo-aware `project` value on
- * the first SSE update for this invocation (a worktree cwd may briefly
- * show its own directory name instead of the main repo's before that
- * update lands). `lastActivityAt` is the start time so the existing
- * `useTick` age column counts up live (a stuck worker reads as stale).
+ * TUI process. This divergence is permanent for the row's lifetime, not a
+ * brief placeholder: subprocess invoke rows live ONLY in the TUI (no
+ * daemon session is ever created for them, which is why the `setSessions`
+ * merge preserves them), so nothing ever updates `project` to the
+ * git-aware value. An invoke launched from a git worktree therefore groups
+ * under the worktree's directory name for its whole lifetime (the
+ * invocation duration plus the finished linger), while real sessions in
+ * that same worktree group under the main repo name. `lastActivityAt` is
+ * the start time so the existing `useTick` age column counts up live (a
+ * stuck worker reads as stale).
  */
 export function fabricateInvokeSession(
   event: InvocationStartedEvent,


### PR DESCRIPTION
## Summary

Derives the `project` group-by key from the git repository identity instead of the raw cwd basename. Sessions in git worktrees now resolve through the `.git` file's `gitdir:` pointer to the main checkout root, so all worktrees (and subdirectory launches) of a repo share one group. Non-git directories keep the old basename derivation byte for byte.

- **project-derivation.ts** - New `deriveProject(cwd, fallback)` helper: walks parent directories for `.git` (stopping at `$HOME` or the filesystem root), treats a `.git` directory as the main checkout, parses `gitdir:` for worktrees (absolute and relative paths, submodule-shaped gitdirs fall back safely), and memoizes per cwd so git resolution runs at most once per unique cwd
- **sessions.ts** - Pane-tracked create, background create, and log-driven update all route through the helper
- **parser.ts** - `extractProjectInfo` feeds the decoded log-path cwd through the helper
- **status-machine.ts** - A sixth ad-hoc derivation site (not listed in the issue, currently dead in practice since `updateSession` recomputes from `state.cwd`) routed through the helper for consistency
- **store.ts** - Fabricated invoke rows keep the plain basename (no filesystem walks in the TUI process) with a comment documenting that the row snaps to the daemon's value on the first SSE update
- **project-derivation.test.ts** - 10 unit tests on real temp-dir fixtures: main checkout root, subdirectory, worktree via absolute and relative `gitdir:`, submodule fallback, non-git dir, `$HOME` boundary (with a contrasting unbounded case), and cache behavior proven by deleting `.git` between calls

## Related issue

Resolves #41

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (2916 pass, 0 fail, 134 files)
- [x] Verified the affected TUI surface (picker / sidebar) in a detached tmux session (if this touches the TUI, columns, layout, theming, or the daemon → TUI data path)
- [x] Verified end to end with a real agent session (if this touches detection, state, the daemon, or the CLI)

Live verification against the daemon running this branch, with 34 real sessions tracked: main-repo and worktree sessions merge into one `ccmux` group, a `Cameo` group absorbs two worktrees plus the main checkout, an `Annotate` worktree living outside the main repo directory (`Annotate-worktrees/icon-remake`) resolves correctly through its gitdir, and a session launched from `Cap/apps/desktop/src-tauri` groups under `Cap`. Non-git scratchpad dirs and a separate `ccmux2` clone are unchanged.

Picker capture (previously three groups: `ccmux`, `osc-notify-backend`, `repo-aware-grouping`):

```
 ▼ ccmux (6)
   ● idle    epilande/ccmux:main  ...
   ● idle    worktrees/osc-notify-backend:feat/osc-notify-backend+  ...
   ◒ working worktrees/repo-aware-grouping:fix/repo-aware-project-grouping+  ...
   ● idle    epilande/ccmux:main  ...
   ● idle    epilande/ccmux:main  ...
   ● idle    epilande/ccmux:main  ...
```

## Notes for reviewers

- Persisted `pinnedGroups` / `collapsedGroups` entries keyed by old worktree basenames go stale after this change. They are pruned to active keys, so previously fragmented groups arrive merged, unpinned, and expanded once. No migration needed.
- Monorepo sessions launched from different packages now merge into one repo group (previously separated by accident). Package-level or per-worktree separation remains available via `cwd` mode.
- The cache is a `Map<cwd, project>` with no invalidation: a directory's repo membership effectively never changes mid-session, and the daemon restart clears it.
- The walk is lexical (`dirname`, no `realpath`), matching how the daemon already treats cwd strings, and `statSync` is guarded so a `.git` entry vanishing mid-walk (worktree removal) cannot throw into the reconcile loop.