### PR TITLE
fix(sidebar): Prevent width-persist resize oscillation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux",
-  "version": "1.2.1-rc.1",
+  "version": "1.2.0",
   "private": true,
   "description": "Track all your AI coding agents (Claude Code, Codex, Cursor, ...) in tmux and jump to the one that needs you",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccmux",
-  "version": "1.2.0",
+  "version": "1.2.1-rc.1",
   "private": true,
   "description": "Track all your AI coding agents (Claude Code, Codex, Cursor, ...) in tmux and jump to the one that needs you",
   "license": "MIT",

--- a/src/tui/utils/sidebar-width.test.ts
+++ b/src/tui/utils/sidebar-width.test.ts
@@ -31,9 +31,7 @@ describe("shouldPersistWidth", () => {
   it("ignores width changes that coincide with a window resize", () => {
     // Session switch / terminal resize: tmux rescaled the pane and the
     // window-resized hook will re-pin it. Must not persist the transient.
-    expect(
-      shouldPersistWidth(passing({ windowWidth: 220, prevWindowWidth: 80 })),
-    ).toBe(false);
+    expect(shouldPersistWidth(passing({ prevWindowWidth: 80 }))).toBe(false);
   });
 
   it("fails safe when window width cannot be determined", () => {

--- a/src/tui/utils/sidebar-width.test.ts
+++ b/src/tui/utils/sidebar-width.test.ts
@@ -1,69 +1,104 @@
 import { describe, it, expect } from "bun:test";
-import { shouldPersistWidth } from "./sidebar-width";
+import { shouldPersistWidth, PREFS_QUIET_MS } from "./sidebar-width";
+
+/** A decision where every gate passes; individual tests override one field to
+ * isolate the gate under test. windowWidth 220 leaves 40 comfortably under the
+ * half-window ceiling (110). */
+function passing(
+  overrides: Partial<Parameters<typeof shouldPersistWidth>[0]> = {},
+) {
+  return {
+    settledWidth: 40,
+    configuredWidth: 30,
+    windowWidth: 220,
+    prevWindowWidth: 220,
+    windowActive: true,
+    sessionAttached: true,
+    prefsAgeMs: null,
+    ...overrides,
+  };
+}
 
 describe("shouldPersistWidth", () => {
   it("persists a drag: width changed while window size held", () => {
-    expect(
-      shouldPersistWidth({
-        settledWidth: 40,
-        configuredWidth: 30,
-        windowWidth: 220,
-        prevWindowWidth: 220,
-      }),
-    ).toBe(true);
+    expect(shouldPersistWidth(passing())).toBe(true);
   });
 
   it("ignores a settled width equal to the configured width", () => {
-    expect(
-      shouldPersistWidth({
-        settledWidth: 30,
-        configuredWidth: 30,
-        windowWidth: 220,
-        prevWindowWidth: 220,
-      }),
-    ).toBe(false);
+    expect(shouldPersistWidth(passing({ settledWidth: 30 }))).toBe(false);
   });
 
   it("ignores width changes that coincide with a window resize", () => {
     // Session switch / terminal resize: tmux rescaled the pane and the
     // window-resized hook will re-pin it. Must not persist the transient.
     expect(
-      shouldPersistWidth({
-        settledWidth: 98,
-        configuredWidth: 30,
-        windowWidth: 220,
-        prevWindowWidth: 80,
-      }),
+      shouldPersistWidth(passing({ windowWidth: 220, prevWindowWidth: 80 })),
     ).toBe(false);
   });
 
   it("fails safe when window width cannot be determined", () => {
-    expect(
-      shouldPersistWidth({
-        settledWidth: 40,
-        configuredWidth: 30,
-        windowWidth: null,
-        prevWindowWidth: 220,
-      }),
-    ).toBe(false);
-    expect(
-      shouldPersistWidth({
-        settledWidth: 40,
-        configuredWidth: 30,
-        windowWidth: 220,
-        prevWindowWidth: null,
-      }),
-    ).toBe(false);
+    expect(shouldPersistWidth(passing({ windowWidth: null }))).toBe(false);
+    expect(shouldPersistWidth(passing({ prevWindowWidth: null }))).toBe(false);
   });
 
   it("ignores degenerate squeezed widths", () => {
-    expect(
-      shouldPersistWidth({
-        settledWidth: 4,
-        configuredWidth: 30,
-        windowWidth: 220,
-        prevWindowWidth: 220,
-      }),
-    ).toBe(false);
+    expect(shouldPersistWidth(passing({ settledWidth: 4 }))).toBe(false);
+  });
+
+  describe("window-relative ceiling", () => {
+    it("rejects a settled width just over half the window", () => {
+      // 111 * 2 = 222 > 220
+      expect(shouldPersistWidth(passing({ settledWidth: 111 }))).toBe(false);
+    });
+
+    it("allows a settled width at exactly half the window", () => {
+      // 110 * 2 = 220, not > 220
+      expect(shouldPersistWidth(passing({ settledWidth: 110 }))).toBe(true);
+    });
+
+    it("allows a settled width comfortably under half the window", () => {
+      expect(shouldPersistWidth(passing({ settledWidth: 60 }))).toBe(true);
+    });
+  });
+
+  describe("focus gate", () => {
+    it("rejects when the window is not active", () => {
+      expect(shouldPersistWidth(passing({ windowActive: false }))).toBe(false);
+    });
+
+    it("rejects when the session is not attached", () => {
+      expect(shouldPersistWidth(passing({ sessionAttached: false }))).toBe(
+        false,
+      );
+    });
+
+    it("rejects when focus state is unknown", () => {
+      expect(shouldPersistWidth(passing({ windowActive: null }))).toBe(false);
+      expect(shouldPersistWidth(passing({ sessionAttached: null }))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("prefs quiet period", () => {
+    it("rejects when the prefs file changed within the quiet period", () => {
+      expect(
+        shouldPersistWidth(passing({ prefsAgeMs: PREFS_QUIET_MS - 1 })),
+      ).toBe(false);
+      expect(shouldPersistWidth(passing({ prefsAgeMs: 0 }))).toBe(false);
+    });
+
+    it("allows once the prefs write is older than the quiet period", () => {
+      expect(shouldPersistWidth(passing({ prefsAgeMs: PREFS_QUIET_MS }))).toBe(
+        true,
+      );
+      expect(
+        shouldPersistWidth(passing({ prefsAgeMs: PREFS_QUIET_MS + 1 })),
+      ).toBe(true);
+    });
+
+    it("allows when the prefs age is unknown (no file)", () => {
+      expect(shouldPersistWidth(passing({ prefsAgeMs: null }))).toBe(true);
+    });
   });
 });

--- a/src/tui/utils/sidebar-width.ts
+++ b/src/tui/utils/sidebar-width.ts
@@ -4,13 +4,10 @@ import { PREFS_FILE } from "../../lib/config";
 import { PANE_FIELD_SEP } from "../../lib/tmux-format";
 
 /** Quiet period after the last pane-width change before we treat it as settled.
- * This debounce is the first line of defense against oscillation: it lets a
- * transient proportional rescale collapse back before we ever look at it. It is
- * NOT sufficient on its own — on a heavily loaded machine the `--apply-width`
- * subprocess that propagates a width to every other sidebar can take seconds to
- * spawn, so a propagated resize can land well after this window elapses and read
- * as a fresh user drag. The three gates in `shouldPersistWidth` are what keep the
- * system safe once latency exceeds this settle window. */
+ * First line of defense against oscillation: lets a transient proportional
+ * rescale collapse back before we ever look at it. Not sufficient alone — see
+ * the anti-oscillation gates in `shouldPersistWidth` for what keeps the system
+ * safe once propagation latency exceeds this window. */
 export const WIDTH_SETTLE_MS = 800;
 
 /** Widths below this are layout accidents (squeezed panes), never preferences. */
@@ -20,7 +17,10 @@ const MIN_PERSIST_WIDTH = 10;
  * to persist. A recent prefs write means another sidebar just propagated a
  * width and this settle is the propagation arriving, not user intent. Sized to
  * outlast propagation latency on a heavily loaded machine (measured ~3s per
- * subprocess spawn under load), with generous headroom for staggered fan-out. */
+ * subprocess spawn under load), with generous headroom for staggered fan-out.
+ * Deliberately keys off ANY prefs write (the mtime is file-wide, not
+ * width-specific): a false suppress self-heals on the next settle, while a
+ * missed suppress re-arms the oscillation. */
 export const PREFS_QUIET_MS = 15_000;
 
 interface PersistDecision {
@@ -59,12 +59,8 @@ export function shouldPersistWidth(d: PersistDecision): boolean {
   if (d.settledWidth < MIN_PERSIST_WIDTH) return false;
   if (d.windowWidth === null || d.prevWindowWidth === null) return false;
   if (d.windowWidth !== d.prevWindowWidth) return false;
-  // Window-relative ceiling: a sidebar wider than half the window is a layout
-  // artifact, never a deliberate drag.
   if (d.settledWidth * 2 > d.windowWidth) return false;
-  // Focus gate: only a foreground, attached sidebar can be under a user drag.
   if (d.windowActive !== true || d.sessionAttached !== true) return false;
-  // Quiet period: a recent prefs write means this settle is a propagated width.
   if (d.prefsAgeMs !== null && d.prefsAgeMs < PREFS_QUIET_MS) return false;
   return d.settledWidth !== d.configuredWidth;
 }
@@ -132,14 +128,12 @@ function spawnApplyWidth(width: number): void {
 
 /**
  * Returns a callback the sidebar invokes with its settled pane width.
- * When the settled width is a genuine user drag (see shouldPersistWidth), it
- * spawns `ccmux sidebar --apply-width` to persist the preference and resize
- * every other sidebar. The settle debounce alone does not distinguish a drag
- * from a late-arriving propagated resize on a loaded machine, so the decision
- * is gated by a window-relative ceiling, a focus check (active window of an
- * attached session), and a quiet period after any prefs write — the latter two
- * queried here and passed into the pure decision. Propagated resizes settle at
- * the already-persisted width and no-op, so sidebars never echo each other.
+ * When the settled width is a genuine user drag, it spawns
+ * `ccmux sidebar --apply-width` to persist the preference and resize every
+ * other sidebar. What counts as a drag is decided by `shouldPersistWidth`'s
+ * anti-oscillation gates; this wrapper only gathers their inputs (tmux window
+ * state, prefs age) and hands off. Propagated resizes settle at the
+ * already-persisted width and no-op, so sidebars never echo each other.
  */
 export function createSidebarWidthPersister(): (width: number) => void {
   let lastWindowWidth: number | null = null;

--- a/src/tui/utils/sidebar-width.ts
+++ b/src/tui/utils/sidebar-width.ts
@@ -1,12 +1,27 @@
+import { stat } from "fs/promises";
 import { getPreferences, DEFAULT_SIDEBAR_WIDTH } from "../../lib/preferences";
+import { PREFS_FILE } from "../../lib/config";
+import { PANE_FIELD_SEP } from "../../lib/tmux-format";
 
 /** Quiet period after the last pane-width change before we treat it as settled.
- * Long enough to outlast the window-resized hook's re-pin (a CLI boot plus a
- * resize-pane), so transient proportional rescales never read as user intent. */
+ * This debounce is the first line of defense against oscillation: it lets a
+ * transient proportional rescale collapse back before we ever look at it. It is
+ * NOT sufficient on its own — on a heavily loaded machine the `--apply-width`
+ * subprocess that propagates a width to every other sidebar can take seconds to
+ * spawn, so a propagated resize can land well after this window elapses and read
+ * as a fresh user drag. The three gates in `shouldPersistWidth` are what keep the
+ * system safe once latency exceeds this settle window. */
 export const WIDTH_SETTLE_MS = 800;
 
 /** Widths below this are layout accidents (squeezed panes), never preferences. */
 const MIN_PERSIST_WIDTH = 10;
+
+/** Quiet period after the preferences file last changed during which we refuse
+ * to persist. A recent prefs write means another sidebar just propagated a
+ * width and this settle is the propagation arriving, not user intent. Sized to
+ * outlast propagation latency on a heavily loaded machine (measured ~3s per
+ * subprocess spawn under load), with generous headroom for staggered fan-out. */
+export const PREFS_QUIET_MS = 15_000;
 
 interface PersistDecision {
   settledWidth: number;
@@ -15,6 +30,12 @@ interface PersistDecision {
   windowWidth: number | null;
   /** Window width at the previous settle (or mount); null when unknown. */
   prevWindowWidth: number | null;
+  /** Whether the sidebar's window is the active window; null when unknown. */
+  windowActive: boolean | null;
+  /** Whether the sidebar's session has an attached client; null when unknown. */
+  sessionAttached: boolean | null;
+  /** Age of the last preferences write in ms; null when unknown/no file. */
+  prefsAgeMs: number | null;
 }
 
 /**
@@ -22,26 +43,81 @@ interface PersistDecision {
  * Window resizes (session switch with window-size=latest, terminal resize)
  * change both, and the window-resized hook re-pins those, so they must not
  * be persisted. Unknown window widths fail safe: never persist.
+ *
+ * Three further gates make this safe when propagation latency exceeds the
+ * settle window (the observed oscillation storm across many windows):
+ *   1. Window-relative ceiling — a real drag never makes a sidebar most of the
+ *      window; widths beyond half are layout artifacts (proportional rescales,
+ *      dying neighbor panes) and must not become the preference.
+ *   2. Focus gate — only the active window of an attached session can be under
+ *      a live user drag; a background/detached sidebar settling is propagation.
+ *   3. Quiet period — a recent prefs write means another sidebar just
+ *      propagated a width, so this settle is that arriving, not user intent.
+ * Each gate fails safe: unknown inputs never persist.
  */
 export function shouldPersistWidth(d: PersistDecision): boolean {
   if (d.settledWidth < MIN_PERSIST_WIDTH) return false;
   if (d.windowWidth === null || d.prevWindowWidth === null) return false;
   if (d.windowWidth !== d.prevWindowWidth) return false;
+  // Window-relative ceiling: a sidebar wider than half the window is a layout
+  // artifact, never a deliberate drag.
+  if (d.settledWidth * 2 > d.windowWidth) return false;
+  // Focus gate: only a foreground, attached sidebar can be under a user drag.
+  if (d.windowActive !== true || d.sessionAttached !== true) return false;
+  // Quiet period: a recent prefs write means this settle is a propagated width.
+  if (d.prefsAgeMs !== null && d.prefsAgeMs < PREFS_QUIET_MS) return false;
   return d.settledWidth !== d.configuredWidth;
 }
 
-async function getWindowWidth(): Promise<number | null> {
+interface WindowState {
+  windowWidth: number | null;
+  windowActive: boolean | null;
+  sessionAttached: boolean | null;
+}
+
+const UNKNOWN_WINDOW_STATE: WindowState = {
+  windowWidth: null,
+  windowActive: null,
+  sessionAttached: null,
+};
+
+async function getWindowState(): Promise<WindowState> {
   const pane = process.env.TMUX_PANE;
-  if (!pane) return null;
+  if (!pane) return UNKNOWN_WINDOW_STATE;
   try {
+    const format = [
+      "#{window_width}",
+      "#{window_active}",
+      "#{session_attached}",
+    ].join(PANE_FIELD_SEP);
     const proc = Bun.spawn(
-      ["tmux", "display-message", "-p", "-t", pane, "#{window_width}"],
+      ["tmux", "display-message", "-p", "-t", pane, format],
       { stdout: "pipe", stderr: "ignore" },
     );
     const out = (await new Response(proc.stdout).text()).trim();
     await proc.exited;
-    const width = Number.parseInt(out, 10);
-    return Number.isInteger(width) ? width : null;
+    const parts = out.split(PANE_FIELD_SEP);
+    if (parts.length < 3) return UNKNOWN_WINDOW_STATE;
+    const width = Number.parseInt(parts[0], 10);
+    const active = Number.parseInt(parts[1], 10);
+    // session_attached is a count of attached clients (>0 means attached).
+    const attached = Number.parseInt(parts[2], 10);
+    return {
+      windowWidth: Number.isInteger(width) ? width : null,
+      windowActive: Number.isInteger(active) ? active === 1 : null,
+      sessionAttached: Number.isInteger(attached) ? attached > 0 : null,
+    };
+  } catch {
+    return UNKNOWN_WINDOW_STATE;
+  }
+}
+
+/** Age of the last preferences write in ms, or null when the file is missing or
+ * cannot be stat'd (no file → no propagation in flight → persist allowed). */
+async function getPrefsAgeMs(): Promise<number | null> {
+  try {
+    const s = await stat(PREFS_FILE);
+    return Date.now() - s.mtimeMs;
   } catch {
     return null;
   }
@@ -56,31 +132,41 @@ function spawnApplyWidth(width: number): void {
 
 /**
  * Returns a callback the sidebar invokes with its settled pane width.
- * When the settled width is a user drag (see shouldPersistWidth), it spawns
- * `ccmux sidebar --apply-width` to persist the preference and resize every
- * other sidebar. Propagated resizes settle at the already-persisted width
- * and no-op, so sidebars never echo each other.
+ * When the settled width is a genuine user drag (see shouldPersistWidth), it
+ * spawns `ccmux sidebar --apply-width` to persist the preference and resize
+ * every other sidebar. The settle debounce alone does not distinguish a drag
+ * from a late-arriving propagated resize on a loaded machine, so the decision
+ * is gated by a window-relative ceiling, a focus check (active window of an
+ * attached session), and a quiet period after any prefs write — the latter two
+ * queried here and passed into the pure decision. Propagated resizes settle at
+ * the already-persisted width and no-op, so sidebars never echo each other.
  */
 export function createSidebarWidthPersister(): (width: number) => void {
   let lastWindowWidth: number | null = null;
-  void getWindowWidth().then((w) => {
-    lastWindowWidth = w;
+  void getWindowState().then((s) => {
+    lastWindowWidth = s.windowWidth;
   });
 
   return (settledWidth: number) => {
     void (async () => {
-      const windowWidth = await getWindowWidth();
+      const [state, prefsAgeMs, prefs] = await Promise.all([
+        getWindowState(),
+        getPrefsAgeMs(),
+        getPreferences(),
+      ]);
       const prevWindowWidth = lastWindowWidth;
-      lastWindowWidth = windowWidth;
+      lastWindowWidth = state.windowWidth;
 
-      const prefs = await getPreferences();
       const configuredWidth = prefs.sidebar?.width ?? DEFAULT_SIDEBAR_WIDTH;
       if (
         shouldPersistWidth({
           settledWidth,
           configuredWidth,
-          windowWidth,
+          windowWidth: state.windowWidth,
           prevWindowWidth,
+          windowActive: state.windowActive,
+          sessionAttached: state.sessionAttached,
+          prefsAgeMs,
         })
       ) {
         spawnApplyWidth(settledWidth);


### PR DESCRIPTION
## Summary

Sidebar panes across many windows could enter a resize feedback loop: full width <-> configured width, repeating indefinitely. Every cycle SIGWINCHes each agent pane in every window, and the redraw storm drowns the tmux server. Observed on a machine running 41 live agent sessions, where tmux became unusable until `ccmux sidebar --toggle` killed the sidebars (`CCMUX_PERF` showed identical daemon workload running 30x slower during the episode: 15-29s scans, 3s capture-panes).

Root cause is in the width persister (`src/tui/utils/sidebar-width.ts`): any settled pane-width change with a stable window width is treated as a user drag and persisted via `--apply-width`, which resizes every sidebar in every window. The echo suppression assumes that propagation completes within the 800ms settle window. On a loaded machine subprocess spawns take seconds, so propagated resizes arrive late and staggered, get misread as fresh drags, and multiple sidebars ping-pong the preference. There was also no ceiling relative to the window, so a transient full-width layout artifact could become the persisted preference.

The fix adds three independent, fail-safe gates to `shouldPersistWidth`, so the loop cannot form at any latency:

- **Window-relative ceiling**: never persist a width above half the window; a real drag never makes a sidebar most of the window.
- **Focus gate**: only persist from the active window of an attached session (queried in one `display-message` call alongside the window width); a background or detached sidebar settling is propagation, not intent.
- **Quiet period**: skip persisting within 15s of any prefs write; a recent write means another sidebar just propagated a width.

After the fix, at most one sidebar in the system can persist anything, at most once per 15s, and never a full-width artifact. Every gate fails closed: unknown tmux state means no persist, so the worst failure mode is a drag that doesn't stick, never a resize storm.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (2958 tests; 14 in `sidebar-width.test.ts` covering each gate in isolation plus the pre-existing rules)
- [x] Verified the affected TUI surface (picker / sidebar) in a detached tmux session (if this touches the TUI, columns, layout, theming, or the daemon → TUI data path)
- [x] Verified end to end with a real agent session (if this touches detection, state, the daemon, or the CLI)

E2e was a deterministic before/after comparison in a fully isolated stack (own tmux server socket, own daemon on a separate port, own `CCMUX_HOME`), with the old code run from a `HEAD` worktree:

| scenario | old code (HEAD) | new code |
|---|---|---|
| resize a detached sidebar to 180 (window 200) | persisted + all sidebars balloon to 180 | prefs stay 30, no propagation |
| then resize a different sidebar to 30 | preference flips back everywhere (ping-pong) | n/a (nothing to flip) |
| resize detached sidebar to 45 (clears ceiling) | persisted | blocked by focus gate alone |
| attached client, active window, drag to 45 | n/a | persisted + propagated in ~2s |
| re-drag within 15s of that persist | n/a | suppressed (quiet period) |
| re-drag after 15s | n/a | persisted + propagated |

## Notes for reviewers

- The persister callback signature is unchanged, so `App.tsx` is untouched; the new inputs feed the pure `shouldPersistWidth`, which is where all the new tests point.
- `session_attached` is a client count, hence the `> 0` check; `window_active` is 0/1.
- Behavior change worth knowing: `resize-pane` on a sidebar in a detached session no longer persists the width (focus gate). That is intentional; it is exactly the propagation/artifact path the loop rode on.
- Deferred follow-ups (separate issues, not blockers): daemon scan backoff when a scan exceeds the 5s interval on a saturated machine, a concurrency cap on the per-scan capture-pane fan-out, and the `window-resized` re-pin hook spawning a full CLI boot per real window resize.