### PR TITLE
fix(tui): Stop session-list reorder churn from breaking j/k navigation

### DIFF
--- a/src/tui/store.test.ts
+++ b/src/tui/store.test.ts
@@ -87,7 +87,7 @@ describe("store", () => {
       expect(sorted.map((s) => s.id)).toEqual(["newer", "older"]);
     });
 
-    it("should fall back to lastActivityAt when lastUserInputAt is null", () => {
+    it("should fall back to statusChangedAt when lastUserInputAt is null", () => {
       const store = createTUIStore({ groupBy: "none" });
 
       store.actions.setSessions([
@@ -101,12 +101,54 @@ describe("store", () => {
           id: "no-input",
           status: "idle",
           lastUserInputAt: null,
-          lastActivityAt: "2024-01-01T12:30:00Z",
+          statusChangedAt: "2024-01-01T12:30:00Z",
+          // Fresher than everything else, but activity must NOT be a sort
+          // key: it churns while working (see the j/k regression below).
+          lastActivityAt: "2024-01-01T13:00:00Z",
         }),
       ]);
 
       const sorted = store.sortedSessions();
       expect(sorted.map((s) => s.id)).toEqual(["no-input", "with-input"]);
+    });
+
+    it("keeps j/k navigation advancing while working sessions emit activity", () => {
+      const store = createTUIStore({ groupBy: "none" });
+
+      // Marker/terminal-tracked agents: no lastUserInputAt, so they sort by
+      // the statusChangedAt fallback. All working, all churning activity.
+      const base = Date.parse("2024-01-15T12:00:00Z");
+      store.actions.setSessions(
+        Array.from({ length: 8 }, (_, i) =>
+          createMockSession({
+            id: `s${i}`,
+            status: "working",
+            lastUserInputAt: null,
+            statusChangedAt: new Date(base + i * 1000).toISOString(),
+            lastActivityAt: new Date(base + i * 1000).toISOString(),
+          }),
+        ),
+      );
+
+      // Press j repeatedly; between presses, agents emit activity (the SSE
+      // session_updated deltas a busy daemon streams). With lastActivityAt as
+      // a sort key this reordered the list under the cursor and navigation
+      // looped instead of reaching the bottom.
+      let clock = base + 100_000;
+      for (let press = 0; press < 20; press++) {
+        store.actions.moveSelection(1);
+        for (const id of [`s${press % 8}`, `s${(press + 3) % 8}`]) {
+          const cur = store.state.sessions.find((s) => s.id === id)!;
+          clock += 1000;
+          store.actions.updateSession({
+            ...cur,
+            lastActivityAt: new Date(clock).toISOString(),
+          });
+        }
+      }
+
+      expect(store.selectedIndex()).toBe(store.flatItems().length - 1);
+      expect(store.selectedSession()?.id).toBe("s0");
     });
 
     it("should remain stable when lastActivityAt changes but lastUserInputAt does not", () => {

--- a/src/tui/store.ts
+++ b/src/tui/store.ts
@@ -456,11 +456,16 @@ export function createTUIStore(options: TUIStoreOptions = {}) {
       const keyed = state.sessions.map((s) => ({
         session: s,
         status: statusOrder[s.status],
-        // Within same status, sort by last user input (stable, doesn't jump while working)
+        // Within same status, sort by last user input; sessions that never
+        // get one (marker/terminal-tracked agents, invoke rows) fall back to
+        // their last status transition. Both keys are frozen while a session
+        // works. Never lastActivityAt: it refreshes continuously on working
+        // sessions, and a list that reorders between two keypresses makes j/k
+        // navigation orbit the churning rows instead of advancing.
         time: s.lastUserInputAt
           ? Date.parse(s.lastUserInputAt)
-          : s.lastActivityAt
-            ? Date.parse(s.lastActivityAt)
+          : s.statusChangedAt
+            ? Date.parse(s.statusChangedAt)
             : 0,
       }));
       keyed.sort((a, b) => a.status - b.status || b.time - a.time);


### PR DESCRIPTION
## Summary

With many active sessions, pressing `j` in the sidebar/picker looped within a group instead of advancing: the selection would walk down a few rows, then get thrown back up, forever.

Root cause: `sortedSessions` sorts within a status band by `lastUserInputAt`, falling back to `lastActivityAt` for sessions that never get one (marker/terminal-tracked agents, invoke rows). `lastActivityAt` refreshes continuously while an agent works, and the daemon broadcasts every bump as `session_updated`, so the list reordered between two keypresses and navigation orbited the churning rows.

Fix: fall back to `statusChangedAt` instead. It only moves on real status transitions, so rows hold still under the cursor while agents work, and the intended "waiting bubbles to the top" reordering survives. Sessions with neither timestamp keep daemon insertion order (JS sort is stable).

Side benefit: pure activity bumps no longer reorder the list, so keyed rows stop shuffling between renders. (They still rebuild the flatItems memo chain: `updateSession` replaces the session object, which defeats `sortedSessions`' identity-based equality regardless of sort key.)

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (2959 tests; includes a new regression test replaying the churn scenario, verified to fail on the old sort key)
- [x] Verified the affected TUI surface (picker / sidebar) in a detached tmux session (if this touches the TUI, columns, layout, theming, or the daemon → TUI data path)
- [x] Verified end to end with a real agent session (if this touches detection, state, the daemon, or the CLI)

## Notes for reviewers

E2E evidence (real picker TUI in a detached tmux session, driven by a mock daemon streaming `session_updated` events that bump `lastActivityAt` on 2 of 10 working sessions every 200ms; numbers are the screen line holding the selection highlight after each of 25 `j` presses):

Before (main):

```
5 4 7 4 3 6 9 12 4 9 11 4 3 6 9 12 3 6 10 12 4 3 6 9 12
```

After (this branch, identical churn):

```
3 4 5 6 7 8 9 10 11 12 12 12 12 12 12 12 12 12 12 12 12 12 12 12 12
```

Also verified against 30 real sessions on the default daemon: groups, waiting band, and header/row navigation all render and step correctly.