### PR TITLE
feat(search): Rank picker search results by relevance

### DIFF
--- a/src/daemon/transcript-search.test.ts
+++ b/src/daemon/transcript-search.test.ts
@@ -287,13 +287,14 @@ describe("transcript-search", () => {
         { id: "s1", agentType: "claude", logPath },
         "match",
       );
-      // The two well-formed user turns match; the malformed lines are skipped
-      // without dropping the whole session (which the outer catch would do).
+      // The two well-formed user turns match (ranked newest-first); the
+      // malformed lines are skipped without dropping the whole session
+      // (which the outer catch would do).
       expect(result).not.toBeNull();
       expect(result!.matches.length).toBe(2);
       expect(result!.matches.map((m) => m.snippet)).toEqual([
-        "first match here",
         "second match here",
+        "first match here",
       ]);
     });
 
@@ -333,13 +334,13 @@ describe("transcript-search", () => {
       );
       // The bare `null` line is a JSON primitive, not an object; it must be
       // skipped without dropping the whole session (which the outer catch
-      // in `searchTranscript` would otherwise do).
+      // in `searchTranscript` would otherwise do). Matches rank newest-first.
       expect(result).not.toBeNull();
       expect(result!.matches.length).toBe(3);
       expect(result!.matches.map((m) => m.snippet)).toEqual([
-        "first match here",
-        "second match here",
         "third match here",
+        "second match here",
+        "first match here",
       ]);
     });
 
@@ -364,6 +365,182 @@ describe("transcript-search", () => {
         { maxMatches: 2 },
       );
       expect(result!.matches.length).toBe(2);
+    });
+
+    it("ranks user turns before assistant turns, newest first within a role", async () => {
+      const logPath = join(dir, "claude.jsonl");
+      // File order: old assistant, old user, new assistant, new user. The
+      // returned order must be user-newest, user-oldest, assistant-newest,
+      // assistant-oldest regardless of file position.
+      writeFileSync(
+        logPath,
+        jsonl(
+          {
+            type: "assistant",
+            uuid: "a1",
+            parentUuid: null,
+            timestamp: "2024-01-01T12:00:00Z",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "assistant old match" }],
+            },
+          },
+          {
+            type: "user",
+            uuid: "u1",
+            parentUuid: "a1",
+            timestamp: "2024-01-01T12:01:00Z",
+            message: { role: "user", content: "user old match" },
+          },
+          {
+            type: "assistant",
+            uuid: "a2",
+            parentUuid: "u1",
+            timestamp: "2024-01-01T12:02:00Z",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "assistant new match" }],
+            },
+          },
+          {
+            type: "user",
+            uuid: "u2",
+            parentUuid: "a2",
+            timestamp: "2024-01-01T12:03:00Z",
+            message: { role: "user", content: "user new match" },
+          },
+        ),
+      );
+
+      const result = await searchTranscript(
+        { id: "s1", agentType: "claude", logPath },
+        "match",
+      );
+      expect(result!.matches.map((m) => m.snippet)).toEqual([
+        "user new match",
+        "user old match",
+        "assistant new match",
+        "assistant old match",
+      ]);
+      // Shape is unchanged: role/snippet/timestamp per match.
+      expect(result!.matches[0]).toEqual({
+        role: "user",
+        snippet: "user new match",
+        timestamp: "2024-01-01T12:03:00Z",
+      });
+    });
+
+    it("sinks matches without a parseable timestamp below dated ones of the same role", async () => {
+      const logPath = join(dir, "claude.jsonl");
+      writeFileSync(
+        logPath,
+        jsonl(
+          {
+            type: "user",
+            uuid: "u1",
+            parentUuid: null,
+            message: { role: "user", content: "undated match" },
+          },
+          {
+            type: "user",
+            uuid: "u2",
+            parentUuid: "u1",
+            timestamp: "2024-01-01T12:00:00Z",
+            message: { role: "user", content: "dated match" },
+          },
+        ),
+      );
+
+      const result = await searchTranscript(
+        { id: "s1", agentType: "claude", logPath },
+        "match",
+      );
+      expect(result!.matches.map((m) => m.snippet)).toEqual([
+        "dated match",
+        "undated match",
+      ]);
+    });
+
+    it("returns the best 5 of all tail matches, still capped at 5 by default", async () => {
+      const logPath = join(dir, "claude.jsonl");
+      // Ten assistant matches followed by one user match: the old
+      // first-5-in-file-order behavior would return only assistant turns and
+      // drop the user one entirely.
+      const lines: object[] = [];
+      for (let i = 0; i < 10; i++) {
+        lines.push({
+          type: "assistant",
+          uuid: `a${i}`,
+          parentUuid: null,
+          timestamp: `2024-01-01T12:0${i}:00Z`,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: `assistant match ${i}` }],
+          },
+        });
+      }
+      lines.push({
+        type: "user",
+        uuid: "u1",
+        parentUuid: null,
+        timestamp: "2024-01-01T13:00:00Z",
+        message: { role: "user", content: "user match last in file" },
+      });
+      writeFileSync(logPath, jsonl(...lines));
+
+      const result = await searchTranscript(
+        { id: "s1", agentType: "claude", logPath },
+        "match",
+      );
+      expect(result!.matches.length).toBe(5);
+      expect(result!.matches[0].snippet).toBe("user match last in file");
+      // The remaining four are the newest assistant matches.
+      expect(result!.matches.slice(1).map((m) => m.snippet)).toEqual([
+        "assistant match 9",
+        "assistant match 8",
+        "assistant match 7",
+        "assistant match 6",
+      ]);
+    });
+
+    it("ranks a recent user match first even when more than 25 older matches precede it", async () => {
+      const logPath = join(dir, "claude.jsonl");
+      // 30 old user matches followed by one recent user match. A count-capped
+      // candidate pool (the tail iterates oldest-first) would fill up on the
+      // old matches and never rank the recent one; collecting the whole tail
+      // must surface it at matches[0].
+      const lines: object[] = [];
+      for (let i = 0; i < 30; i++) {
+        lines.push({
+          type: "user",
+          uuid: `u${i}`,
+          parentUuid: null,
+          timestamp: `2024-01-01T12:${String(i).padStart(2, "0")}:00Z`,
+          message: { role: "user", content: `old match ${i}` },
+        });
+      }
+      lines.push({
+        type: "user",
+        uuid: "recent",
+        parentUuid: null,
+        timestamp: "2024-01-02T09:00:00Z",
+        message: { role: "user", content: "recent match wins" },
+      });
+      writeFileSync(logPath, jsonl(...lines));
+
+      const result = await searchTranscript(
+        { id: "s1", agentType: "claude", logPath },
+        "match",
+      );
+      expect(result!.matches.length).toBe(5);
+      expect(result!.matches[0].snippet).toBe("recent match wins");
+      // The rest are the newest of the old matches, newest first.
+      expect(result!.matches.slice(1).map((m) => m.snippet)).toEqual([
+        "old match 29",
+        "old match 28",
+        "old match 27",
+        "old match 26",
+      ]);
     });
 
     it("tail-truncates when the file exceeds maxBytes, dropping the partial first line", async () => {

--- a/src/daemon/transcript-search.ts
+++ b/src/daemon/transcript-search.ts
@@ -141,6 +141,14 @@ function buildSnippet(
   return snippet;
 }
 
+/** A match's time for recency ranking; missing or unparseable timestamps map
+ *  to the minimum so they sort after every dated match. */
+function matchTime(m: TranscriptMatch): number {
+  if (!m.timestamp) return Number.MIN_SAFE_INTEGER;
+  const t = Date.parse(m.timestamp);
+  return Number.isNaN(t) ? Number.MIN_SAFE_INTEGER : t;
+}
+
 /** Read the tail of a transcript, discarding a partial first line when the
  *  file was larger than the window (same idiom as `readLogTail`). */
 export async function readTranscriptTail(
@@ -218,37 +226,49 @@ export async function searchTranscript(
       return { sessionId: sess.id, matches: [] };
     }
 
+    // Collect EVERY match in the tail, then rank: the snippet the TUI shows
+    // is `matches[0]`, and a user prompt from a recent turn explains a match
+    // far better than the first assistant paragraph the file happens to
+    // contain. No collection cap: entries iterate oldest-first, so any
+    // count-based stop would keep the OLDEST candidates and starve the
+    // recency ranking of exactly the matches it wants. The pool is already
+    // bounded by the `maxBytes` tail read.
     const matches: TranscriptMatch[] = [];
+    const collect = (roleTexts: RoleText[], timestamp?: string): void => {
+      for (const { role, text } of roleTexts) {
+        const snippet = buildSnippet(text, query, leadRadius, trailRadius);
+        if (snippet) {
+          matches.push({ role, snippet, timestamp });
+        }
+      }
+    };
 
+    // `entry?.timestamp`, not `entry.timestamp`: a bare `null`/primitive line
+    // parses to a non-object entry, and an eager property read here would
+    // throw into the outer catch and drop the whole session (the extractors
+    // guard their own reads, but this one runs before them).
     if (sess.agentType === "claude") {
       const entries: LogEntry[] = parseLogEntries(content);
       for (const entry of entries) {
-        for (const { role, text } of claudeEntryTexts(entry)) {
-          const snippet = buildSnippet(text, query, leadRadius, trailRadius);
-          if (snippet) {
-            matches.push({ role, snippet, timestamp: entry.timestamp });
-            if (matches.length >= maxMatches) {
-              return { sessionId: sess.id, matches };
-            }
-          }
-        }
+        collect(claudeEntryTexts(entry), entry?.timestamp);
       }
     } else {
       const entries = parseCodexEntries(content);
       for (const entry of entries) {
-        for (const { role, text } of codexEntryTexts(entry)) {
-          const snippet = buildSnippet(text, query, leadRadius, trailRadius);
-          if (snippet) {
-            matches.push({ role, snippet, timestamp: entry.timestamp });
-            if (matches.length >= maxMatches) {
-              return { sessionId: sess.id, matches };
-            }
-          }
-        }
+        collect(codexEntryTexts(entry), entry?.timestamp);
       }
     }
 
-    return { sessionId: sess.id, matches };
+    // Rank: user turns before assistant turns, newest first within each role.
+    // Matches without a parseable timestamp sink to the end of their role
+    // block; the stable sort keeps file order as the final tiebreak.
+    matches.sort(
+      (a, b) =>
+        (a.role === "user" ? 0 : 1) - (b.role === "user" ? 0 : 1) ||
+        matchTime(b) - matchTime(a),
+    );
+
+    return { sessionId: sess.id, matches: matches.slice(0, maxMatches) };
   } catch {
     return null;
   }

--- a/src/tui/components/SessionItem.test.tsx
+++ b/src/tui/components/SessionItem.test.tsx
@@ -25,6 +25,7 @@ async function renderItem(
     promptDisplay?: import("../../lib/preferences").PromptDisplay;
     highlights?: import("./SessionItem").SessionItemHighlights | null;
     transcriptSnippet?: string;
+    matchSource?: import("../utils/grouping").MatchSource;
   },
   width = 100,
   height = 3,
@@ -45,6 +46,7 @@ async function renderItem(
           promptDisplay={props.promptDisplay}
           highlights={props.highlights}
           transcriptSnippet={props.transcriptSnippet}
+          matchSource={props.matchSource}
         />
       </TickContext.Provider>
     ),
@@ -729,6 +731,85 @@ describe("SessionItem row 2 (subtitle)", () => {
     });
     expect(frame).toContain("ZZHIT");
     expect(frame).not.toContain("the newest message");
+  });
+
+  it("tags a pane-ranked match with a dim [pane] cue in the prompt cell", async () => {
+    const frame = await renderItem({
+      session: mockEnrichedSession({ lastPrompt: "the newest message" }),
+      // A pane-content match leaves no highlight anywhere on the row.
+      highlights: null,
+      matchSource: "pane",
+    });
+    expect(frame).toContain("[pane]");
+    expect(frame).toContain("the newest message");
+  });
+
+  it("tags a transcript-ranked match alongside its snippet", async () => {
+    const frame = await renderItem({
+      session: mockEnrichedSession({ lastPrompt: "the newest message" }),
+      highlights: { lastPrompt: null },
+      transcriptSnippet: "ZZHIT from the assistant transcript",
+      matchSource: "transcript",
+    });
+    expect(frame).toContain("[transcript]");
+    expect(frame).toContain("ZZHIT");
+  });
+
+  it("tags a cwd-ranked match whose highlights carry no visible field", async () => {
+    const frame = await renderItem({
+      session: mockEnrichedSession({ lastPrompt: "the newest message" }),
+      // A cwd fuzzy match builds a highlights object, but the cwd markup is
+      // not rendered by any cell, so the tag must still appear.
+      highlights: {
+        project: null,
+        cwd: "/Users/test/<b>Code</b>/myapp",
+        gitBranch: null,
+        lastPrompt: null,
+        prompts: null,
+      },
+      matchSource: "cwd",
+    });
+    expect(frame).toContain("[cwd]");
+  });
+
+  it("renders no tag for identity or prompt matches (highlights already visible)", async () => {
+    const identityFrame = await renderItem({
+      session: mockEnrichedSession({ lastPrompt: "the newest message" }),
+      highlights: { project: "<b>myapp</b>" },
+      matchSource: "identity",
+    });
+    expect(identityFrame).not.toContain("[identity]");
+
+    const promptFrame = await renderItem({
+      session: mockEnrichedSession({
+        lastPrompt: "the newest message",
+        prompts: ["please refactor the parser", "the newest message"],
+      }),
+      highlights: {
+        lastPrompt: null,
+        prompts: "please <b>refactor the parser</b>",
+      },
+      matchSource: "prompt",
+    });
+    expect(promptFrame).not.toContain("[prompt]");
+  });
+
+  it("suppresses the tag when a visible highlight already explains the match", async () => {
+    // Primary source is cwd (a higher tier), but the prompt substring also
+    // matched and renders highlighted; the row explains itself without a tag.
+    const frame = await renderItem({
+      session: mockEnrichedSession({ lastPrompt: "check the shared-dir now" }),
+      highlights: {
+        project: null,
+        cwd: "/tmp/<b>shared-dir</b>",
+        gitBranch: null,
+        lastPrompt: "check the <b>shared-dir</b> now",
+        prompts: null,
+      },
+      matchSource: "cwd",
+    });
+    expect(frame).not.toContain("[cwd]");
+    expect(frame).toContain("check the shared-dir now");
   });
 
   it("prefers a prompt highlight over the transcript snippet when both are present", async () => {

--- a/src/tui/components/SessionItem.tsx
+++ b/src/tui/components/SessionItem.tsx
@@ -38,6 +38,7 @@ import {
   ATTENTION_LABEL_MAX,
 } from "./session-columns";
 import { theme } from "../theme";
+import type { MatchSource } from "../utils/grouping";
 import {
   formatRelativeTime,
   formatVersion,
@@ -62,6 +63,11 @@ interface SessionItemProps {
   /** Live transcript-search snippet, shown dim in the prompt cell to explain
    * why the row matched when no prompt highlight applies. */
   transcriptSnippet?: string;
+  /** The search source that ranked this row (`FilteredSession.primarySource`).
+   * Renders a dim `[pane]`/`[transcript]`/`[cwd]` tag in the prompt cell for
+   * matches that would otherwise leave no visible trace on the row; identity
+   * and prompt matches already show highlights and get no tag. */
+  matchSource?: MatchSource;
   iconStyle?: IconStyle;
   showPreview?: boolean;
   previewWidth: number;
@@ -213,6 +219,7 @@ interface FieldRenderContext {
   dimmed?: boolean;
   sidebar?: boolean;
   transcriptSnippet?: string;
+  matchSource?: MatchSource;
   agentColor: string;
   attentionColor: string;
   attentionLabel: string | null;
@@ -450,11 +457,31 @@ const FieldCell: Component<{
       // field) keep their spot. Search highlights are windowed the same way by
       // `truncateHighlighted`, which trims to a visible-char budget while
       // keeping the matched span whole.
+      // Match-source cue: a pane/transcript/cwd-ranked match leaves no
+      // highlight anywhere on the row, so a dim `[source]` tag says why it is
+      // here. Suppressed whenever any highlight is visible (identity or
+      // prompt), which already explains the match. The tag's width comes out
+      // of the prompt budget so truncation still lands inside the row.
+      const sourceTag = (): string | null => {
+        const src = ctx.matchSource;
+        if (src !== "pane" && src !== "transcript" && src !== "cwd") {
+          return null;
+        }
+        const h = ctx.highlights;
+        if (h?.project || h?.gitBranch || h?.lastPrompt || h?.prompts) {
+          return null;
+        }
+        return src;
+      };
+      const promptBudget = () => {
+        const tag = sourceTag();
+        return ctx.maxPromptLen - (tag ? tag.length + 3 : 0);
+      };
       const text = () =>
         ctx.session.lastPrompt
           ? truncateText(
               normalizePrompt(ctx.session.lastPrompt),
-              ctx.maxPromptLen,
+              promptBudget(),
             )
           : "";
       // A matched OLDER prompt: when the newest prompt (`lastPrompt`) didn't
@@ -472,7 +499,7 @@ const FieldCell: Component<{
         if (!ctx.transcriptSnippet) return null;
         return truncateText(
           normalizePrompt(ctx.transcriptSnippet),
-          ctx.maxPromptLen,
+          promptBudget(),
         );
       };
       // The prompt is the row's flexible filler: its box grows into the
@@ -484,6 +511,13 @@ const FieldCell: Component<{
       // cell); without it a multi-span highlight renders as garbled overlap.
       return (
         <box flexGrow={1} flexShrink={1} flexDirection="row">
+          <Show when={sourceTag()}>
+            {(tag: () => string) => (
+              <box width={tag().length + 3} flexShrink={0}>
+                <text fg={dimColor(ctx, theme.overlay)}>{`[${tag()}]`}</text>
+              </box>
+            )}
+          </Show>
           <Show
             when={ctx.highlights?.lastPrompt}
             fallback={
@@ -849,6 +883,9 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
     },
     get transcriptSnippet() {
       return props.transcriptSnippet;
+    },
+    get matchSource() {
+      return props.matchSource;
     },
     get agentColor() {
       return agentColor();

--- a/src/tui/components/SessionList.tsx
+++ b/src/tui/components/SessionList.tsx
@@ -149,6 +149,7 @@ export const SessionList: Component<SessionListProps> = (props) => {
             ? item.filteredSession.transcriptSnippet
             : undefined
         }
+        matchSource={item.filteredSession.primarySource}
         iconStyle={props.iconStyle}
         showPreview={props.showPreview}
         previewWidth={props.previewWidth}

--- a/src/tui/store.test.ts
+++ b/src/tui/store.test.ts
@@ -1584,6 +1584,261 @@ describe("store", () => {
 
       expect(filtered.map((f) => f.session.id)).toEqual(["hit"]);
     });
+
+    describe("relevance ranking (issue #50)", () => {
+      it("ranks an idle identity match above a waiting transcript-only match", async () => {
+        const origFetch = globalThis.fetch;
+        globalThis.fetch = (async () =>
+          ({
+            ok: true,
+            json: async () => ({
+              results: [
+                {
+                  sessionId: "noisy",
+                  matches: [{ role: "user", snippet: "ccmux mentioned once" }],
+                },
+              ],
+            }),
+          }) as unknown as Response) as unknown as typeof fetch;
+        try {
+          const store = createTUIStore({ groupBy: "none" });
+          store.actions.setSessions([
+            // Waiting sorts first in the base order, but its only match is a
+            // deep transcript hit; the idle session's project IS the query.
+            createMockSession({
+              id: "noisy",
+              status: "waiting",
+              attentionType: "permission",
+              project: "other-thing",
+              cwd: "/tmp/noisy",
+              gitBranch: null,
+            }),
+            createMockSession({
+              id: "target",
+              status: "idle",
+              project: "ccmux",
+              cwd: "/tmp/target",
+              gitBranch: null,
+            }),
+          ]);
+          store.actions.setSearchQuery("ccmux");
+          await waitForDebounce();
+
+          const filtered = store.filteredSessions();
+          expect(filtered.map((f) => f.session.id)).toEqual([
+            "target",
+            "noisy",
+          ]);
+          expect(filtered[0].primarySource).toBe("identity");
+          expect(filtered[1].primarySource).toBe("transcript");
+          expect(filtered[0].score!).toBeGreaterThan(filtered[1].score!);
+        } finally {
+          globalThis.fetch = origFetch;
+        }
+      });
+
+      it("scores a newer matching prompt above an older one", () => {
+        const store = createTUIStore({ groupBy: "none" });
+        store.actions.setSessions([
+          // "stale" matched the query several prompts ago and sorts first in
+          // the base order (newer statusChangedAt); "fresh" matched in its
+          // newest prompt and must outrank it.
+          createMockSession({
+            id: "stale",
+            project: "px",
+            cwd: "/tmp/x1",
+            gitBranch: null,
+            statusChangedAt: "2024-01-01T13:00:00Z",
+            lastPrompt: "something else",
+            prompts: ["fix the flaky test", "something else"],
+          }),
+          createMockSession({
+            id: "fresh",
+            project: "py",
+            cwd: "/tmp/x2",
+            gitBranch: null,
+            statusChangedAt: "2024-01-01T12:00:00Z",
+            lastPrompt: "fix the flaky test again",
+            prompts: ["something else", "fix the flaky test again"],
+          }),
+        ]);
+
+        store.actions.setSearchQuery("flaky test");
+        const filtered = store.filteredSessions();
+        expect(filtered.map((f) => f.session.id)).toEqual(["fresh", "stale"]);
+        expect(filtered[0].primarySource).toBe("prompt");
+      });
+
+      it("adds a cross-source bonus that breaks ties but cannot jump a tier", () => {
+        const store = createTUIStore({ groupBy: "none" });
+        store.actions.setSessions([
+          // Identical identity match; "single" sorts first in the base order
+          // (newer statusChangedAt) but "corroborated" also matches on its
+          // prompt, so its bonus wins the tie.
+          createMockSession({
+            id: "single",
+            project: "ccmux",
+            cwd: "/tmp/a",
+            gitBranch: null,
+            statusChangedAt: "2024-01-01T13:00:00Z",
+          }),
+          createMockSession({
+            id: "corroborated",
+            project: "ccmux",
+            cwd: "/tmp/b",
+            gitBranch: null,
+            statusChangedAt: "2024-01-01T12:00:00Z",
+            lastPrompt: "wire ccmux into tmux",
+            prompts: ["wire ccmux into tmux"],
+          }),
+        ]);
+
+        store.actions.setSearchQuery("ccmux");
+        const filtered = store.filteredSessions();
+        expect(filtered.map((f) => f.session.id)).toEqual([
+          "corroborated",
+          "single",
+        ]);
+        // Both are identity-tier; the bonus is 50 per extra source, far less
+        // than the 1000-point tier gap.
+        expect(filtered[0].primarySource).toBe("identity");
+        expect(filtered[0].matchSources).toEqual(["identity", "prompt"]);
+        expect(filtered[0].score! - filtered[1].score!).toBe(50);
+      });
+
+      it("keeps the waiting-first base order as the tiebreak for equal scores", () => {
+        const store = createTUIStore({ groupBy: "none" });
+        store.actions.setSessions([
+          createMockSession({
+            id: "idle-match",
+            status: "idle",
+            project: "ccmux",
+            cwd: "/tmp/a",
+            gitBranch: null,
+          }),
+          createMockSession({
+            id: "waiting-match",
+            status: "waiting",
+            attentionType: "permission",
+            project: "ccmux",
+            cwd: "/tmp/b",
+            gitBranch: null,
+          }),
+        ]);
+
+        store.actions.setSearchQuery("ccmux");
+        const filtered = store.filteredSessions();
+        // Same project text, same query: identical scores. The stable sort
+        // leaves the upstream waiting-first order in place.
+        expect(filtered[0].score).toBe(filtered[1].score);
+        expect(filtered.map((f) => f.session.id)).toEqual([
+          "waiting-match",
+          "idle-match",
+        ]);
+      });
+
+      it("attaches no score on the empty-query path and keeps the base order", () => {
+        const store = createTUIStore({ groupBy: "none" });
+        store.actions.setSessions([
+          createMockSession({
+            id: "waiting",
+            status: "waiting",
+            attentionType: "permission",
+          }),
+          createMockSession({ id: "idle", status: "idle" }),
+        ]);
+
+        const filtered = store.filteredSessions();
+        expect(filtered.map((f) => f.session.id)).toEqual(["waiting", "idle"]);
+        expect(filtered[0].score).toBeUndefined();
+        expect(filtered[0].matchSources).toBeUndefined();
+        expect(filtered[0].primarySource).toBeUndefined();
+      });
+
+      it("makes the tmux session name searchable via the group key under session grouping", () => {
+        const store = createTUIStore({ groupBy: "session" });
+        store.actions.setSessions([
+          createMockSession({
+            id: "s1",
+            project: "proj",
+            cwd: "/tmp/s1",
+            gitBranch: null,
+            tmuxPane: "%1",
+            tmuxTarget: "sidequest:0.1",
+          }),
+          createMockSession({
+            id: "s2",
+            project: "proj",
+            cwd: "/tmp/s2",
+            gitBranch: null,
+            tmuxPane: "%2",
+            tmuxTarget: "other:0.1",
+          }),
+        ]);
+
+        store.actions.setSearchQuery("sidequest");
+        const filtered = store.filteredSessions();
+        expect(filtered.map((f) => f.session.id)).toEqual(["s1"]);
+        expect(filtered[0].primarySource).toBe("identity");
+      });
+
+      it("keeps the selection pinned by id when a late transcript result re-ranks the list", async () => {
+        const origFetch = globalThis.fetch;
+        globalThis.fetch = (async () =>
+          ({
+            ok: true,
+            json: async () => ({
+              results: [
+                {
+                  sessionId: "s2",
+                  matches: [{ role: "user", snippet: "shared-dir noted" }],
+                },
+              ],
+            }),
+          }) as unknown as Response) as unknown as typeof fetch;
+        try {
+          const store = createTUIStore({ groupBy: "none" });
+          store.actions.setSessions([
+            // Both match only on the identical cwd (equal scores); s1 leads
+            // on the base-order tiebreak until s2's transcript hit lands and
+            // its +50 bonus flips the order.
+            createMockSession({
+              id: "s1",
+              project: "px",
+              cwd: "/tmp/shared-dir",
+              gitBranch: null,
+              statusChangedAt: "2024-01-01T13:00:00Z",
+            }),
+            createMockSession({
+              id: "s2",
+              project: "py",
+              cwd: "/tmp/shared-dir",
+              gitBranch: null,
+              statusChangedAt: "2024-01-01T12:00:00Z",
+            }),
+          ]);
+          store.actions.setSearchQuery("shared-dir");
+          expect(store.filteredSessions().map((f) => f.session.id)).toEqual([
+            "s1",
+            "s2",
+          ]);
+          // Select s1 (index 0), then let the async transcript result land.
+          store.actions.setSelectedIndex(0);
+          expect(store.state.selectedSessionId).toBe("s1");
+          await waitForDebounce();
+
+          const filtered = store.filteredSessions();
+          expect(filtered.map((f) => f.session.id)).toEqual(["s2", "s1"]);
+          // The re-rank moved the rows, not the selection: still s1, now at
+          // index 1.
+          expect(store.state.selectedSessionId).toBe("s1");
+          expect(store.selectedSession()?.id).toBe("s1");
+          expect(store.selectedIndex()).toBe(1);
+        } finally {
+          globalThis.fetch = origFetch;
+        }
+      });
+    });
   });
 
   describe("grouping", () => {

--- a/src/tui/store.ts
+++ b/src/tui/store.ts
@@ -46,6 +46,7 @@ import {
   type FlatItem,
   type GroupBy,
   type FilteredSession,
+  type MatchSource,
 } from "./utils/grouping";
 
 export type ConfirmAction =
@@ -529,8 +530,21 @@ export function createTUIStore(options: TUIStoreOptions = {}) {
     // keeping genuinely fuzzy identity lookups ("fjump" -> FlashJump,
     // "ccmx" -> ccmux; 0.5 already rejects the latter). The v2-era -10000
     // this replaces filtered nothing on the v3 scale.
+    //
+    // The group key rides along as a fifth fuzzy field (issue #50): under
+    // session/window grouping it is the tmux session/window name, which no
+    // other field covers; under project/cwd it mostly mirrors those fields,
+    // and under "none" it is "" and can never match.
+    const groupBy = state.groupBy;
     const results = fuzzysort.go(query, sorted, {
-      keys: ["project", "cwd", "gitBranch", "lastPrompt"],
+      keys: [
+        "project",
+        "cwd",
+        "gitBranch",
+        "lastPrompt",
+        (s: EnrichedSession) =>
+          groupBy === "none" ? "" : getGroupKey(s, groupBy),
+      ],
       threshold: 0.3,
     });
     const metadataMap = new Map(results.map((r) => [r.obj.id, r]));
@@ -543,13 +557,18 @@ export function createTUIStore(options: TUIStoreOptions = {}) {
     // notifications, teammate messages) can't render embedded newlines that
     // overlap in the height-1 row, and so a spaced query can match across what
     // was a newline.
-    const promptMatches = new Map<string, string>();
+    // `recency` is the matched prompt's position in the index (newest = 1,
+    // oldest = 0), feeding the score so a fresh prompt outranks a stale one.
+    const promptMatches = new Map<string, { line: string; recency: number }>();
     for (const s of sorted) {
       const prompts = s.prompts ?? [];
       for (let i = prompts.length - 1; i >= 0; i--) {
         const norm = normalizePrompt(prompts[i]);
         if (norm.toLowerCase().includes(lowerQuery)) {
-          promptMatches.set(s.id, wrapFirstMatch(norm, lowerQuery));
+          promptMatches.set(s.id, {
+            line: wrapFirstMatch(norm, lowerQuery),
+            recency: prompts.length > 1 ? i / (prompts.length - 1) : 1,
+          });
           break;
         }
       }
@@ -577,8 +596,14 @@ export function createTUIStore(options: TUIStoreOptions = {}) {
       ...transcript.keys(),
     ]);
 
-    // Build results preserving original sort order
-    return sorted
+    // Build result rows, each with a composite relevance score (issue #50),
+    // then order by score descending. The upstream waiting-first/recency
+    // order survives ONLY as the tiebreak: the sort is stable, so equal
+    // scores keep their original relative order. Scores are a pure function
+    // of this memo's tracked inputs (query, sessions, caches, groupBy), so a
+    // re-rank happens only when one of them changes; selection survives it
+    // because it is pinned by session id, not by index.
+    const rows = sorted
       .filter((s) => allMatchIds.has(s.id))
       .map((s) => {
         const fzResult = metadataMap.get(s.id);
@@ -607,17 +632,75 @@ export function createTUIStore(options: TUIStoreOptions = {}) {
                 cwd: fzResult?.[1]?.highlight("<b>", "</b>") || null,
                 gitBranch: fzResult?.[2]?.highlight("<b>", "</b>") || null,
                 lastPrompt: lastPromptHl,
-                prompts: promptMatch ?? null,
+                prompts: promptMatch?.line ?? null,
               }
             : null;
+
+        // Per-key fuzzysort scores (0..1; 0 = key didn't match) split the
+        // metadata union into tiers: project/branch/group key are identity,
+        // cwd is location (long paths scatter-match, so it weighs less).
+        const identityFz = fzResult
+          ? Math.max(
+              fzResult[0]?.score ?? 0,
+              fzResult[2]?.score ?? 0,
+              fzResult[4]?.score ?? 0,
+            )
+          : 0;
+        const cwdFz = fzResult?.[1]?.score ?? 0;
+        const lastPromptFz = fzResult?.[3]?.score ?? 0;
+
+        // One contribution per matched source. Tier bases keep ordering
+        // strict: identity 3000+, cwd 2000+, prompt substring 1000+ (newer
+        // prompts higher), pane 600, transcript 400. A fuzzy-only lastPrompt
+        // hit (scatter match, no substring occurrence) is weak evidence and
+        // scores below pane. The row's score is its best contribution plus 50
+        // per additional matched source. INVARIANT: the maximum total bonus
+        // (50 x 4 extra sources = 200) must stay strictly below every gap a
+        // row could actually cross; keep it well under the smallest tier gap
+        // (pane 600 - transcript 400 = 200) when retuning either number, so
+        // corroboration can never lift a row past a stronger tier.
+        const contributions: { source: MatchSource; value: number }[] = [];
+        if (identityFz > 0) {
+          contributions.push({
+            source: "identity",
+            value: 3000 + 1000 * identityFz,
+          });
+        }
+        if (cwdFz > 0) {
+          contributions.push({ source: "cwd", value: 2000 + 500 * cwdFz });
+        }
+        if (promptMatch) {
+          contributions.push({
+            source: "prompt",
+            value: 1000 + 500 * promptMatch.recency,
+          });
+        } else if (lastPromptFz > 0) {
+          contributions.push({ source: "prompt", value: 500 * lastPromptFz });
+        }
+        if (paneMatches.has(s.id)) {
+          contributions.push({ source: "pane", value: 600 });
+        }
+        const transcriptMatch = tMatches !== undefined && tMatches.length > 0;
+        if (transcriptMatch) {
+          contributions.push({ source: "transcript", value: 400 });
+        }
+        contributions.sort((a, b) => b.value - a.value);
+        const best = contributions[0];
+
         return {
           session: s,
           highlights,
           paneMatch: paneMatches.has(s.id),
-          transcriptMatch: tMatches !== undefined && tMatches.length > 0,
+          transcriptMatch,
           transcriptSnippet: tMatches?.[0]?.snippet,
+          score: best ? best.value + 50 * (contributions.length - 1) : 0,
+          matchSources: contributions.map((c) => c.source),
+          primarySource: best?.source,
         };
       });
+
+    rows.sort((a, b) => b.score - a.score);
+    return rows;
   });
 
   const flatItems = trackedMemo("flatItems", () => {

--- a/src/tui/utils/grouping.test.ts
+++ b/src/tui/utils/grouping.test.ts
@@ -509,6 +509,44 @@ describe("sortGroups", () => {
     const sorted = sortGroups(groups, ["nonexistent", "alpha"]);
     expect(sorted.map((g) => g.key)).toEqual(["alpha"]);
   });
+
+  const scored = (key: string, ...scores: number[]): GroupEntry => ({
+    key,
+    members: scores.map((score, i) => ({
+      ...toFiltered(mockSession({ id: `${key}-${i}` })),
+      score,
+    })),
+  });
+
+  it("orders groups by best member score during search", () => {
+    const groups = [scored("alpha", 400), scored("bravo", 3200, 100)];
+    const sorted = sortGroups(groups, [], true);
+    // bravo's single strong match (3200) beats alpha despite alphabetical
+    // order; the weak second member does not dilute it (max, not sum).
+    expect(sorted.map((g) => g.key)).toEqual(["bravo", "alpha"]);
+  });
+
+  it("lets relevance override pinning during search", () => {
+    const groups = [scored("pinned-proj", 600), scored("zeta", 3200)];
+    const sorted = sortGroups(groups, ["pinned-proj"], true);
+    expect(sorted.map((g) => g.key)).toEqual(["zeta", "pinned-proj"]);
+  });
+
+  it("breaks score ties with the pinned-then-alphabetical order", () => {
+    const groups = [
+      scored("bravo", 1000),
+      scored("alpha", 1000),
+      scored("pinned-proj", 1000),
+    ];
+    const sorted = sortGroups(groups, ["pinned-proj"], true);
+    expect(sorted.map((g) => g.key)).toEqual(["pinned-proj", "alpha", "bravo"]);
+  });
+
+  it("keeps pin/alphabetical order when not searching, even with scores present", () => {
+    const groups = [scored("zeta", 3200), scored("alpha", 400)];
+    const sorted = sortGroups(groups, [], false);
+    expect(sorted.map((g) => g.key)).toEqual(["alpha", "zeta"]);
+  });
 });
 
 describe("toVisualLine", () => {

--- a/src/tui/utils/grouping.ts
+++ b/src/tui/utils/grouping.ts
@@ -30,6 +30,10 @@ export const WAITING_SUBTYPES: ReadonlyArray<{
   { key: "waitingGeneric", attention: null },
 ];
 
+/** Which search source matched a session, in tier order: identity
+ * (project/branch/group key) > cwd > content (prompt > pane > transcript). */
+export type MatchSource = "identity" | "cwd" | "prompt" | "pane" | "transcript";
+
 /** A session in the filtered list with optional search highlights */
 export interface FilteredSession {
   session: EnrichedSession;
@@ -48,6 +52,14 @@ export interface FilteredSession {
   transcriptMatch?: boolean;
   /** First transcript match snippet, shown to explain why the row matched. */
   transcriptSnippet?: string;
+  /** Composite relevance score while a query is active (issue #50): the best
+   * source's tier score plus a small cross-source bonus. Absent on the
+   * empty-query path, where no ranking applies. */
+  score?: number;
+  /** Every source that matched, strongest first. */
+  matchSources?: MatchSource[];
+  /** The source whose tier produced `score`; drives the row's match cue. */
+  primarySource?: MatchSource;
 }
 
 /** Discriminated union for items in the flat render list */
@@ -193,10 +205,17 @@ export function headerGroupKeys(items: FlatItem[]): string[] {
 /**
  * Sort groups: pinned groups first (in pinned order), then unpinned
  * groups sorted alphabetically.
+ *
+ * With `byScore` (search active), groups order by their best member's
+ * relevance score instead, descending, and pinning yields: a strong match in
+ * an unpinned group outranks a weakly-matching pinned one (same precedent as
+ * search force-expanding collapsed groups). The stable sort keeps the
+ * pinned-then-alphabetical order as the tiebreak between equal scores.
  */
 export function sortGroups(
   groups: GroupEntry[],
   pinnedGroups: string[],
+  byScore = false,
 ): GroupEntry[] {
   const pinnedSet = new Set(pinnedGroups);
   const pinned: GroupEntry[] = [];
@@ -218,7 +237,13 @@ export function sortGroups(
   // Unpinned: alphabetical (stable order unaffected by session status changes)
   unpinned.sort((a, b) => a.key.localeCompare(b.key));
 
-  return [...pinned, ...unpinned];
+  const ordered = [...pinned, ...unpinned];
+  if (byScore) {
+    const best = (g: GroupEntry) =>
+      g.members.reduce((acc, m) => Math.max(acc, m.score ?? 0), 0);
+    ordered.sort((a, b) => best(b) - best(a));
+  }
+  return ordered;
 }
 
 /**
@@ -241,7 +266,11 @@ export function buildFlatItems(
     }));
   }
 
-  const sorted = sortGroups(groupSessions(filtered, groupBy), pinnedGroups);
+  const sorted = sortGroups(
+    groupSessions(filtered, groupBy),
+    pinnedGroups,
+    isSearching,
+  );
 
   const items: FlatItem[] = [];
   for (const { key, members } of sorted) {


### PR DESCRIPTION
## Summary

Search was a filter, not a ranker: matching rows kept the picker's waiting-first/recency sort, so searching for a project by name could bury the real match under an unrelated session that happened to contain the query in its transcript. While a query is active, rows now sort by a composite relevance score and the old status/recency order only breaks ties. Empty-query ordering is completely unchanged.

- **Identity tier** (base 3000 + 1000x fuzzysort score): `project`, `gitBranch`, and the group key, added as a new search field, so tmux session/window names are now searchable
- **Location tier** (2000 + 500x): `cwd`
- **Content tier**: prompt substring matches scored by recency (1000-1500), pane 600, transcript 400
- **Cross-source bonus**: +50 per extra matched source; the max total bonus (200) stays below the smallest tier gap so bonuses can never jump a tier (comment pins the invariant)
- Groups order by max member score during search and pinned groups yield to relevance (same precedent as search force-expanding collapsed groups); members sort by their own score, insertion order keeps them under the header
- Rows whose match is otherwise invisible render a dim `[pane]`/`[transcript]`/`[cwd]` tag, which also puts the previously dead `paneMatch` flag to work
- Daemon transcript snippets now rank user turns before assistant turns, newest first, instead of returning the first 5 in file order; the candidate pool is every match in the 2MB tail (a count cap would bias the pool toward the oldest matches)
- Fixes a latent bug where a bare JSON primitive line in a transcript threw into the outer catch and dropped the whole session's matches

Scores are a pure function of query + caches, and selection stays pinned by session id, so the ~250ms async pane/transcript re-ranks don't reintroduce the #45 sort-churn problem.

## Related issue

Closes #50

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (3004 tests, 19 new: tier separation vs bonus, stable tiebreak, empty-query untouched, group-key searchability, selection pinned across late transcript re-rank, group max-score order, pin yield, >25-match snippet regression, indicator show/suppress)
- [x] Verified the affected TUI surface (picker / sidebar) in a detached tmux session (if this touches the TUI, columns, layout, theming, or the daemon → TUI data path)
- [x] Verified end to end with a real agent session (if this touches detection, state, the daemon, or the CLI)

Live checks against real sessions: searching `cameo` ranks the Cameo group (identity) above a 33s-old `working` session with a pane hit, which the old sort put on top; searching `flash` ranks FlashJump above an alphabetically-earlier transcript-only match, tag rendered:

```
 ▼ FlashJump (1)
 1 ● idle    FlashJump:feat/scroll-enter-to-labels  /clear
 ▼ .dotfiles (1)
 2 ● idle    ~/.dotfiles:master  [transcript] …flash.lua, harpoon.lua…
```

Snippet ranking probed directly against real transcripts: for `merge`, a July 9 user match ranks above a July 20 assistant match.

## Notes for reviewers

- Two independent review passes (Claude + Codex) before this went up. Codex caught the one real bug: the original 25-candidate cap filled oldest-first and starved recent user prompts; fixed with a regression test proven to fail against the old logic.
- Deliberate leftovers, agreed non-blocking: `matchSources` is consumed only by tests (documents intent for future UI), and the tag-reduced prompt budget is not applied to the highlight paths (unreachable while the tag-suppression rule holds).
- Pin-yield and waiting-demotion are unit-tested but weren't observable live (no pinned groups or waiting sessions existed during verification).
- Fuzzysort v3.1.0 scores are already normalized 0..1; the 0.3 threshold is unchanged.