### PR TITLE
fix(daemon): Classify shells by exact basename, not comm substring

### DIFF
--- a/src/daemon/process-tree-test-helpers.ts
+++ b/src/daemon/process-tree-test-helpers.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared fixtures for building canned `ps -axo pid,ppid,comm` output to feed
+ * `ProcessTree.fromPsOutput()` in tests, without spawning a real `ps`.
+ *
+ * Used by process-tree.test.ts and state-reconciler.test.ts.
+ */
+
+/** Header row `fromPsOutput` discards (mirrors real `ps -axo pid,ppid,comm`). */
+export const PS_HEADER = "  PID  PPID COMM";
+
+/** One `ps` output line for the given pid/ppid/comm. */
+export function psLine(pid: number, ppid: number, comm: string): string {
+  return `${pid} ${ppid} ${comm}`;
+}

--- a/src/daemon/process-tree.test.ts
+++ b/src/daemon/process-tree.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { ProcessTree } from "./process-tree";
+import { ProcessTree, shellCommKey } from "./process-tree";
 
 describe("ProcessTree", () => {
   test("build() creates a tree from ps output", async () => {
@@ -72,34 +72,113 @@ describe("ProcessTree", () => {
     expect(shells).toEqual([]);
   });
 
-  test("findShellDescendants() finds shell processes in descendants", async () => {
-    const tree = await ProcessTree.build();
-    // PID 1 (launchd on macOS) should have some shell descendants
-    const shells = tree.findShellDescendants(1);
-
-    expect(Array.isArray(shells)).toBe(true);
-    for (const pid of shells) {
-      expect(typeof pid).toBe("number");
-      const proc = tree.getProcess(pid);
-      expect(proc).toBeDefined();
-      expect(ProcessTree.SHELL_NAMES.some((s) => proc!.comm.includes(s))).toBe(
-        true,
-      );
-    }
-  });
-
-  test("findShellDescendants() returns empty for process with no shell children", async () => {
-    const tree = await ProcessTree.build();
-    // Current test process likely doesn't have shell children
-    const shells = tree.findShellDescendants(process.pid);
-    expect(Array.isArray(shells)).toBe(true);
-    // May or may not have shells depending on test runner
-  });
-
   test("SHELL_NAMES includes common shells", () => {
     expect(ProcessTree.SHELL_NAMES).toContain("bash");
     expect(ProcessTree.SHELL_NAMES).toContain("sh");
     expect(ProcessTree.SHELL_NAMES).toContain("zsh");
     expect(ProcessTree.SHELL_NAMES).toContain("fish");
+    expect(ProcessTree.SHELL_NAMES).toContain("dash");
+    expect(ProcessTree.SHELL_NAMES).toContain("ksh");
+    expect(ProcessTree.SHELL_NAMES).toContain("csh");
+    expect(ProcessTree.SHELL_NAMES).toContain("tcsh");
+    expect(ProcessTree.SHELL_NAMES).toContain("ash");
+  });
+
+  describe("shellCommKey()", () => {
+    // Positive fixtures: real shells, in the various forms macOS/Linux `comm`
+    // reports them (login-dash, bare path, path+args, bare name+args).
+    test.each([
+      ["-zsh", "zsh"],
+      ["-/bin/zsh", "zsh"],
+      ["/bin/zsh", "zsh"],
+      ["/bin/bash --noprofile --norc", "bash"],
+      ["/opt/homebrew/bin/fish", "fish"],
+      ["sh -c echo hi", "sh"],
+    ])("derives %j -> %j", (comm, expected) => {
+      expect(shellCommKey(comm)).toBe(expected);
+    });
+
+    // Negative fixtures: processes the old substring rule misclassified as
+    // shells purely because their path or name contains a shell name as a
+    // substring (e.g. ".local/share" contains "sh").
+    test.each([
+      "~/.local/share/mise/installs/node/26.3.0/bin/node",
+      "/usr/bin/login -flp user /bin/bash -c exec -l /bin/zsh",
+      "sshd-session: user [priv]",
+      "/usr/libexec/sharingd",
+      "/System/Library/CoreServices/ReportCrash",
+    ])("derives %j -> a key not in SHELL_NAMES", (comm) => {
+      expect(ProcessTree.SHELL_NAMES).not.toContain(shellCommKey(comm));
+    });
+  });
+
+  describe("findShellDescendants() against fixture ps output", () => {
+    const PS_HEADER = "  PID  PPID COMM";
+
+    function psLine(pid: number, ppid: number, comm: string): string {
+      return `${pid} ${ppid} ${comm}`;
+    }
+
+    test("finds a real shell descendant, exact match only", () => {
+      const output = [
+        PS_HEADER,
+        psLine(100, 1, "/usr/bin/claude"),
+        psLine(101, 100, "-zsh"),
+        psLine(102, 100, "~/.local/share/mise/installs/node/26.3.0/bin/node"),
+      ].join("\n");
+
+      const tree = ProcessTree.fromPsOutput(output);
+      const shells = tree.findShellDescendants(100);
+
+      expect(shells).toEqual([101]);
+    });
+
+    test("returns empty when the only descendant is a language server under a path containing 'sh'", () => {
+      const output = [
+        PS_HEADER,
+        psLine(200, 1, "/usr/bin/claude"),
+        psLine(201, 200, "~/.local/share/mise/installs/node/26.3.0/bin/node"),
+        psLine(202, 200, "/usr/libexec/sharingd"),
+      ].join("\n");
+
+      const tree = ProcessTree.fromPsOutput(output);
+      const shells = tree.findShellDescendants(200);
+
+      expect(shells).toEqual([]);
+    });
+
+    test("does not match a login wrapper that merely execs a shell as an argument", () => {
+      const output = [
+        PS_HEADER,
+        psLine(300, 1, "/usr/bin/claude"),
+        psLine(
+          301,
+          300,
+          "/usr/bin/login -flp user /bin/bash -c exec -l /bin/zsh",
+        ),
+      ].join("\n");
+
+      const tree = ProcessTree.fromPsOutput(output);
+      const shells = tree.findShellDescendants(300);
+
+      expect(shells).toEqual([]);
+    });
+
+    test("finds shells across the expanded name set (dash, ksh, csh, tcsh, ash)", () => {
+      const output = [
+        PS_HEADER,
+        psLine(400, 1, "/usr/bin/claude"),
+        psLine(401, 400, "/bin/dash"),
+        psLine(402, 400, "/bin/ksh"),
+        psLine(403, 400, "/bin/csh"),
+        psLine(404, 400, "/bin/tcsh"),
+        psLine(405, 400, "/bin/ash"),
+      ].join("\n");
+
+      const tree = ProcessTree.fromPsOutput(output);
+      const shells = tree.findShellDescendants(400);
+
+      expect(shells.sort()).toEqual([401, 402, 403, 404, 405]);
+    });
   });
 });

--- a/src/daemon/process-tree.test.ts
+++ b/src/daemon/process-tree.test.ts
@@ -86,30 +86,55 @@ describe("ProcessTree", () => {
   });
 
   describe("shellCommKey()", () => {
-    // Positive fixtures: real shells, in the various forms macOS/Linux `comm`
-    // reports them (login-dash, bare path, path+args, bare name+args).
+    // Positive fixtures: real shells, in the forms macOS/Linux `comm` actually
+    // reports them (login-dash, bare path, path with embedded spaces from an
+    // app-bundle-style directory). `comm` is argv[0]/task name, never a
+    // space-separated argv list, so there is no "path+args" form to cover.
     test.each([
       ["-zsh", "zsh"],
       ["-/bin/zsh", "zsh"],
       ["/bin/zsh", "zsh"],
-      ["/bin/bash --noprofile --norc", "bash"],
+      ["/bin/bash", "bash"],
       ["/opt/homebrew/bin/fish", "fish"],
-      ["sh -c echo hi", "sh"],
+      // A real space-containing macOS comm path (a user directory with a
+      // space in it). The old first-whitespace-token split would have cut
+      // this at "a", missing the shell entirely; basename-only derivation
+      // resolves it correctly since it splits on "/", not spaces.
+      ["/Users/a b/bin/bash", "bash"],
     ])("derives %j -> %j", (comm, expected) => {
       expect(shellCommKey(comm)).toBe(expected);
     });
 
     // Negative fixtures: processes the old substring rule misclassified as
     // shells purely because their path or name contains a shell name as a
-    // substring (e.g. ".local/share" contains "sh").
+    // substring (e.g. ".local/share" contains "sh"). Paths use /Users/...
+    // rather than `~`, since `ps` always emits absolute paths.
     test.each([
-      "~/.local/share/mise/installs/node/26.3.0/bin/node",
-      "/usr/bin/login -flp user /bin/bash -c exec -l /bin/zsh",
+      "/Users/dev/.local/share/mise/installs/node/26.3.0/bin/node",
       "sshd-session: user [priv]",
       "/usr/libexec/sharingd",
       "/System/Library/CoreServices/ReportCrash",
+      // A real space-containing macOS comm path for a non-shell binary
+      // inside an app bundle's Helpers directory.
+      "/Applications/Elgato Stream Deck.app/Contents/Helpers/crashpad_handler",
     ])("derives %j -> a key not in SHELL_NAMES", (comm) => {
       expect(ProcessTree.SHELL_NAMES).not.toContain(shellCommKey(comm));
+    });
+
+    // Defensive-tolerance fixtures: `comm` is never actually argv-shaped
+    // (see the JSDoc on shellCommKey), but the function must not throw on
+    // command-style input if it's ever handed some by a caller. These are
+    // NOT representative of real ps output, and the derived key is
+    // incidental rather than a guarantee — in particular, the login-wrapper
+    // case below happens to end in "/bin/zsh" and so is (mis)classified as
+    // a real zsh shell, which is why every other fixture in this file is
+    // careful to stay comm-shaped rather than argv-shaped.
+    test.each([
+      ["/bin/bash --noprofile --norc", "bash --noprofile --norc"],
+      ["sh -c echo hi", "sh -c echo hi"],
+      ["/usr/bin/login -flp user /bin/bash -c exec -l /bin/zsh", "zsh"],
+    ])("tolerates command-style input %j -> %j", (comm, expected) => {
+      expect(shellCommKey(comm)).toBe(expected);
     });
   });
 
@@ -119,7 +144,11 @@ describe("ProcessTree", () => {
         PS_HEADER,
         psLine(100, 1, "/usr/bin/claude"),
         psLine(101, 100, "-zsh"),
-        psLine(102, 100, "~/.local/share/mise/installs/node/26.3.0/bin/node"),
+        psLine(
+          102,
+          100,
+          "/Users/dev/.local/share/mise/installs/node/26.3.0/bin/node",
+        ),
       ].join("\n");
 
       const tree = ProcessTree.fromPsOutput(output);
@@ -132,7 +161,11 @@ describe("ProcessTree", () => {
       const output = [
         PS_HEADER,
         psLine(200, 1, "/usr/bin/claude"),
-        psLine(201, 200, "~/.local/share/mise/installs/node/26.3.0/bin/node"),
+        psLine(
+          201,
+          200,
+          "/Users/dev/.local/share/mise/installs/node/26.3.0/bin/node",
+        ),
         psLine(202, 200, "/usr/libexec/sharingd"),
       ].join("\n");
 
@@ -142,7 +175,12 @@ describe("ProcessTree", () => {
       expect(shells).toEqual([]);
     });
 
-    test("does not match a login wrapper that merely execs a shell as an argument", () => {
+    test("tolerates a login-wrapper argv string fed in as comm (not representative of real ps output)", () => {
+      // Real `ps` comm is never argv-shaped (see shellCommKey's JSDoc), so
+      // this input can't occur in practice. It's kept here only to document
+      // the known trade-off: because the derivation no longer strips argv,
+      // a synthetic comm string that happens to end in "/bin/zsh" derives
+      // to "zsh" and is (mis)classified as a real shell descendant.
       const output = [
         PS_HEADER,
         psLine(300, 1, "/usr/bin/claude"),
@@ -156,7 +194,7 @@ describe("ProcessTree", () => {
       const tree = ProcessTree.fromPsOutput(output);
       const shells = tree.findShellDescendants(300);
 
-      expect(shells).toEqual([]);
+      expect(shells).toEqual([301]);
     });
 
     test("finds shells across the expanded name set (dash, ksh, csh, tcsh, ash)", () => {
@@ -173,7 +211,7 @@ describe("ProcessTree", () => {
       const tree = ProcessTree.fromPsOutput(output);
       const shells = tree.findShellDescendants(400);
 
-      expect(shells.sort()).toEqual([401, 402, 403, 404, 405]);
+      expect(shells.sort((a, b) => a - b)).toEqual([401, 402, 403, 404, 405]);
     });
   });
 });

--- a/src/daemon/process-tree.test.ts
+++ b/src/daemon/process-tree.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { ProcessTree, shellCommKey } from "./process-tree";
+import { PS_HEADER, psLine } from "./process-tree-test-helpers";
 
 describe("ProcessTree", () => {
   test("build() creates a tree from ps output", async () => {
@@ -113,12 +114,6 @@ describe("ProcessTree", () => {
   });
 
   describe("findShellDescendants() against fixture ps output", () => {
-    const PS_HEADER = "  PID  PPID COMM";
-
-    function psLine(pid: number, ppid: number, comm: string): string {
-      return `${pid} ${ppid} ${comm}`;
-    }
-
     test("finds a real shell descendant, exact match only", () => {
       const output = [
         PS_HEADER,

--- a/src/daemon/process-tree.ts
+++ b/src/daemon/process-tree.ts
@@ -2,6 +2,7 @@
  * ProcessTree - Build and query process hierarchy in a single pass.
  * Eliminates N pgrep calls by building tree from one ps command.
  */
+import { basename } from "path";
 import { DaemonPerf } from "./perf";
 
 export interface ProcessNode {
@@ -11,24 +12,19 @@ export interface ProcessNode {
 }
 
 /**
- * Derive the exact-match shell name from a raw `comm` value: take the first
- * whitespace-delimited token (drops any trailing argv, e.g. `sh -c ...` or
- * `/bin/bash --noprofile --norc`), strip one leading `-` (login shells report
- * `-zsh`), then take the text after the last `/` (the basename).
- *
- * On macOS `comm` is a full path, so a plain substring match against
- * SHELL_NAMES false-positives on any path containing a shell name as a
- * directory component (e.g. `~/.local/share/...` matches "sh" via "share").
- * Exact matching against this derived key avoids that; never match against
- * the raw `comm` string or the joined command line.
+ * Exact-match shell basename derived from a raw `comm` value: drop trailing
+ * argv, strip one leading `-` (login shells report `-zsh`), then take the
+ * path basename. Substring matching on raw `comm` false-positives on macOS,
+ * where `comm` is a full path (e.g. `~/.local/share/...` contains "sh").
  */
 export function shellCommKey(comm: string): string {
-  const firstToken = comm.trim().split(/\s+/)[0] ?? "";
+  const trimmed = comm.trim();
+  const spaceIndex = trimmed.indexOf(" ");
+  const firstToken = spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex);
   const unwrapped = firstToken.startsWith("-")
     ? firstToken.slice(1)
     : firstToken;
-  const slashIndex = unwrapped.lastIndexOf("/");
-  return slashIndex >= 0 ? unwrapped.slice(slashIndex + 1) : unwrapped;
+  return basename(unwrapped);
 }
 
 export class ProcessTree {
@@ -138,6 +134,9 @@ export class ProcessTree {
     "ash",
   ];
 
+  /** O(1) lookup mirror of `SHELL_NAMES`, checked per descendant in the BFS below. */
+  private static readonly SHELL_NAMES_SET = new Set(ProcessTree.SHELL_NAMES);
+
   /**
    * Find all shell descendant processes of a given root PID
    * Used to detect when a Bash tool is actively executing
@@ -153,7 +152,7 @@ export class ProcessTree {
       visited.add(pid);
 
       const proc = this.getProcess(pid);
-      if (proc && ProcessTree.SHELL_NAMES.includes(shellCommKey(proc.comm))) {
+      if (proc && ProcessTree.SHELL_NAMES_SET.has(shellCommKey(proc.comm))) {
         shellPids.push(pid);
       }
       queue.push(...this.getChildPids(pid));

--- a/src/daemon/process-tree.ts
+++ b/src/daemon/process-tree.ts
@@ -12,18 +12,22 @@ export interface ProcessNode {
 }
 
 /**
- * Exact-match shell basename derived from a raw `comm` value: drop trailing
- * argv, strip one leading `-` (login shells report `-zsh`), then take the
- * path basename. Substring matching on raw `comm` false-positives on macOS,
- * where `comm` is a full path (e.g. `~/.local/share/...` contains "sh").
+ * Exact-match shell basename derived from a raw `comm` value. `ps -axo comm`
+ * never carries a space-separated argument list: on macOS it reports
+ * argv[0] only (e.g. `/bin/zsh`, or `-zsh` for a login shell), and on Linux
+ * it reports the kernel's 15-char task name. The only spaces that
+ * legitimately appear are inside the path itself (e.g. an app-bundle path
+ * like `/Applications/Foo.app/Contents/MacOS/Foo`). Derivation: strip one
+ * leading `-` (login shells report `-zsh`), then take the path basename.
+ * Command-style input (e.g. `"sh -c echo hi"`) is tolerated defensively so
+ * the function never throws, but it is not real `comm` output and is not
+ * specially parsed. Substring matching on raw `comm` false-positives on
+ * macOS, where `comm` is a full path (e.g. `/Users/.../.local/share/...`
+ * contains "sh").
  */
 export function shellCommKey(comm: string): string {
   const trimmed = comm.trim();
-  const spaceIndex = trimmed.indexOf(" ");
-  const firstToken = spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex);
-  const unwrapped = firstToken.startsWith("-")
-    ? firstToken.slice(1)
-    : firstToken;
+  const unwrapped = trimmed.startsWith("-") ? trimmed.slice(1) : trimmed;
   return basename(unwrapped);
 }
 
@@ -120,7 +124,10 @@ export class ProcessTree {
   /**
    * Shell process names to detect running Bash commands. Matched by EXACT
    * equality against the derived basename (see `shellCommKey`), never by
-   * substring against the raw `comm` string.
+   * substring against the raw `comm` string. `as const` pins this as a
+   * fixed-length tuple so the `SHELL_NAMES_SET` static initializer below
+   * (which reads `SHELL_NAMES`) stays correct regardless of declaration
+   * order within the class body.
    */
   static readonly SHELL_NAMES = [
     "bash",
@@ -132,10 +139,11 @@ export class ProcessTree {
     "csh",
     "tcsh",
     "ash",
-  ];
+  ] as const;
 
   /** O(1) lookup mirror of `SHELL_NAMES`, checked per descendant in the BFS below. */
-  private static readonly SHELL_NAMES_SET = new Set(ProcessTree.SHELL_NAMES);
+  private static readonly SHELL_NAMES_SET: ReadonlySet<string> =
+    new Set<string>(ProcessTree.SHELL_NAMES);
 
   /**
    * Find all shell descendant processes of a given root PID

--- a/src/daemon/process-tree.ts
+++ b/src/daemon/process-tree.ts
@@ -10,6 +10,27 @@ export interface ProcessNode {
   comm: string;
 }
 
+/**
+ * Derive the exact-match shell name from a raw `comm` value: take the first
+ * whitespace-delimited token (drops any trailing argv, e.g. `sh -c ...` or
+ * `/bin/bash --noprofile --norc`), strip one leading `-` (login shells report
+ * `-zsh`), then take the text after the last `/` (the basename).
+ *
+ * On macOS `comm` is a full path, so a plain substring match against
+ * SHELL_NAMES false-positives on any path containing a shell name as a
+ * directory component (e.g. `~/.local/share/...` matches "sh" via "share").
+ * Exact matching against this derived key avoids that; never match against
+ * the raw `comm` string or the joined command line.
+ */
+export function shellCommKey(comm: string): string {
+  const firstToken = comm.trim().split(/\s+/)[0] ?? "";
+  const unwrapped = firstToken.startsWith("-")
+    ? firstToken.slice(1)
+    : firstToken;
+  const slashIndex = unwrapped.lastIndexOf("/");
+  return slashIndex >= 0 ? unwrapped.slice(slashIndex + 1) : unwrapped;
+}
+
 export class ProcessTree {
   private processes = new Map<number, ProcessNode>();
   /** Map of ppid -> child pids (parent->children index) */
@@ -21,8 +42,6 @@ export class ProcessTree {
   }
 
   static async build(): Promise<ProcessTree> {
-    const tree = new ProcessTree();
-
     try {
       DaemonPerf.incSubprocessSpawn("ps-tree");
       const proc = Bun.spawn(["ps", "-axo", "pid,ppid,comm"], {
@@ -33,27 +52,38 @@ export class ProcessTree {
       const output = await new Response(proc.stdout).text();
       await proc.exited;
 
-      const lines = output.trim().split("\n").slice(1);
-
-      for (const line of lines) {
-        const parts = line.trim().split(/\s+/);
-        if (parts.length < 3) continue;
-
-        const pid = parseInt(parts[0], 10);
-        const ppid = parseInt(parts[1], 10);
-        const comm = parts.slice(2).join(" ");
-
-        if (isNaN(pid) || isNaN(ppid)) continue;
-
-        const node: ProcessNode = { pid, ppid, comm };
-        tree.processes.set(pid, node);
-
-        const siblings = tree.children.get(ppid) ?? [];
-        siblings.push(pid);
-        tree.children.set(ppid, siblings);
-      }
+      return ProcessTree.fromPsOutput(output);
     } catch {
       // Return empty tree on error
+      return new ProcessTree();
+    }
+  }
+
+  /**
+   * Parse `ps -axo pid,ppid,comm` output (header row + one process per line)
+   * into a tree. Exposed so tests can build a tree from canned ps output
+   * instead of spawning a real `ps`.
+   */
+  static fromPsOutput(output: string): ProcessTree {
+    const tree = new ProcessTree();
+    const lines = output.trim().split("\n").slice(1);
+
+    for (const line of lines) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length < 3) continue;
+
+      const pid = parseInt(parts[0], 10);
+      const ppid = parseInt(parts[1], 10);
+      const comm = parts.slice(2).join(" ");
+
+      if (isNaN(pid) || isNaN(ppid)) continue;
+
+      const node: ProcessNode = { pid, ppid, comm };
+      tree.processes.set(pid, node);
+
+      const siblings = tree.children.get(ppid) ?? [];
+      siblings.push(pid);
+      tree.children.set(ppid, siblings);
     }
 
     return tree;
@@ -92,9 +122,21 @@ export class ProcessTree {
   }
 
   /**
-   * Shell process names to detect running Bash commands
+   * Shell process names to detect running Bash commands. Matched by EXACT
+   * equality against the derived basename (see `shellCommKey`), never by
+   * substring against the raw `comm` string.
    */
-  static readonly SHELL_NAMES = ["bash", "sh", "zsh", "fish"];
+  static readonly SHELL_NAMES = [
+    "bash",
+    "sh",
+    "zsh",
+    "fish",
+    "dash",
+    "ksh",
+    "csh",
+    "tcsh",
+    "ash",
+  ];
 
   /**
    * Find all shell descendant processes of a given root PID
@@ -111,7 +153,7 @@ export class ProcessTree {
       visited.add(pid);
 
       const proc = this.getProcess(pid);
-      if (proc && ProcessTree.SHELL_NAMES.some((s) => proc.comm.includes(s))) {
+      if (proc && ProcessTree.SHELL_NAMES.includes(shellCommKey(proc.comm))) {
         shellPids.push(pid);
       }
       queue.push(...this.getChildPids(pid));

--- a/src/daemon/state-reconciler.test.ts
+++ b/src/daemon/state-reconciler.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "os";
 import { BUILTIN_AGENTS, type AgentDef } from "../lib/agents";
 import type { ProcessInfo, Session, TmuxPane } from "../types/session";
 import type { PaneDetectionResult } from "./pane-classify";
+import { ProcessTree } from "./process-tree";
 
 /** Redirect STATE_FILE to a temp dir so tests don't touch real ~/.config/ccmux/state.json */
 const tempRoot = join(
@@ -1493,6 +1494,86 @@ describe("reconcileAll", () => {
           processes: [fakeProcess()],
           panes: [fakePane()],
           processTree: { findShellDescendants: () => [99999] },
+        }),
+      );
+
+      const session = sessionManager.getSession(id)!;
+      expect(session.status).toBe("working");
+    });
+  });
+
+  describe("shell classification (real ProcessTree, fixture ps output)", () => {
+    // Regression coverage for issue #52: detectToolExecution used to call
+    // findShellDescendants stubbed out, so it never exercised the real
+    // classification. These build an actual ProcessTree from canned ps
+    // output so the exact-basename fix is proven end to end through the
+    // reconciler, not just at the unit level.
+    const PS_HEADER = "  PID  PPID COMM";
+
+    function psLine(pid: number, ppid: number, comm: string): string {
+      return `${pid} ${ppid} ${comm}`;
+    }
+
+    it("stays waiting when the only Bash descendant is a language server (path contains 'sh')", async () => {
+      const id = makeSession(sessionManager, {
+        status: "waiting",
+        attentionType: "permission",
+        pendingTool: "Bash",
+        trackingMode: "native",
+        pid: 12345,
+        tmuxPane: "%1",
+        lastActivityAt: new Date().toISOString(),
+      });
+
+      const output = [
+        PS_HEADER,
+        psLine(12345, 1, "/usr/local/bin/claude"),
+        psLine(
+          54321,
+          12345,
+          "~/.local/share/mise/installs/node/26.3.0/bin/node",
+        ),
+      ].join("\n");
+      const processTree = ProcessTree.fromPsOutput(output);
+
+      await reconcileAll(
+        makeDeps(sessionManager),
+        makeSnapshot({
+          processes: [fakeProcess()],
+          panes: [fakePane()],
+          processTree,
+        }),
+      );
+
+      const session = sessionManager.getSession(id)!;
+      expect(session.status).toBe("waiting");
+      expect(session.attentionType).toBe("permission");
+    });
+
+    it("flips to working when a real shell (zsh) is a Bash descendant", async () => {
+      const id = makeSession(sessionManager, {
+        status: "waiting",
+        attentionType: "permission",
+        pendingTool: "Bash",
+        trackingMode: "native",
+        pid: 12345,
+        tmuxPane: "%1",
+        lastActivityAt: new Date().toISOString(),
+      });
+
+      const output = [
+        PS_HEADER,
+        psLine(12345, 1, "/usr/local/bin/claude"),
+        psLine(54322, 12345, "-zsh"),
+      ].join("\n");
+      const processTree = ProcessTree.fromPsOutput(output);
+
+      await reconcileAll(
+        makeDeps(sessionManager),
+        makeSnapshot({
+          processes: [fakeProcess()],
+          panes: [fakePane()],
+          processTree,
         }),
       );
 

--- a/src/daemon/state-reconciler.test.ts
+++ b/src/daemon/state-reconciler.test.ts
@@ -5,6 +5,7 @@ import { BUILTIN_AGENTS, type AgentDef } from "../lib/agents";
 import type { ProcessInfo, Session, TmuxPane } from "../types/session";
 import type { PaneDetectionResult } from "./pane-classify";
 import { ProcessTree } from "./process-tree";
+import { PS_HEADER, psLine } from "./process-tree-test-helpers";
 
 /** Redirect STATE_FILE to a temp dir so tests don't touch real ~/.config/ccmux/state.json */
 const tempRoot = join(
@@ -1505,81 +1506,56 @@ describe("reconcileAll", () => {
   describe("shell classification (real ProcessTree, fixture ps output)", () => {
     // Regression coverage for issue #52: detectToolExecution used to call
     // findShellDescendants stubbed out, so it never exercised the real
-    // classification. These build an actual ProcessTree from canned ps
-    // output so the exact-basename fix is proven end to end through the
-    // reconciler, not just at the unit level.
-    const PS_HEADER = "  PID  PPID COMM";
+    // classification. Build an actual ProcessTree from canned ps output so
+    // the exact-basename fix is proven end to end through the reconciler,
+    // not just at the unit level.
+    it.each([
+      {
+        name: "stays waiting when the only Bash descendant is a language server (path contains 'sh')",
+        descendantComm: "~/.local/share/mise/installs/node/26.3.0/bin/node",
+        expectedStatus: "waiting" as const,
+        expectedAttentionType: "permission" as Session["attentionType"],
+      },
+      {
+        name: "flips to working when a real shell (zsh) is a Bash descendant",
+        descendantComm: "-zsh",
+        expectedStatus: "working" as const,
+        expectedAttentionType: null as Session["attentionType"],
+      },
+    ])(
+      "$name",
+      async ({ descendantComm, expectedStatus, expectedAttentionType }) => {
+        const id = makeSession(sessionManager, {
+          status: "waiting",
+          attentionType: "permission",
+          pendingTool: "Bash",
+          trackingMode: "native",
+          pid: 12345,
+          tmuxPane: "%1",
+          lastActivityAt: new Date().toISOString(),
+        });
 
-    function psLine(pid: number, ppid: number, comm: string): string {
-      return `${pid} ${ppid} ${comm}`;
-    }
+        const output = [
+          PS_HEADER,
+          psLine(12345, 1, "/usr/local/bin/claude"),
+          psLine(54321, 12345, descendantComm),
+        ].join("\n");
+        const processTree = ProcessTree.fromPsOutput(output);
 
-    it("stays waiting when the only Bash descendant is a language server (path contains 'sh')", async () => {
-      const id = makeSession(sessionManager, {
-        status: "waiting",
-        attentionType: "permission",
-        pendingTool: "Bash",
-        trackingMode: "native",
-        pid: 12345,
-        tmuxPane: "%1",
-        lastActivityAt: new Date().toISOString(),
-      });
+        await reconcileAll(
+          makeDeps(sessionManager),
+          makeSnapshot({
+            processes: [fakeProcess()],
+            panes: [fakePane()],
+            processTree,
+          }),
+        );
 
-      const output = [
-        PS_HEADER,
-        psLine(12345, 1, "/usr/local/bin/claude"),
-        psLine(
-          54321,
-          12345,
-          "~/.local/share/mise/installs/node/26.3.0/bin/node",
-        ),
-      ].join("\n");
-      const processTree = ProcessTree.fromPsOutput(output);
-
-      await reconcileAll(
-        makeDeps(sessionManager),
-        makeSnapshot({
-          processes: [fakeProcess()],
-          panes: [fakePane()],
-          processTree,
-        }),
-      );
-
-      const session = sessionManager.getSession(id)!;
-      expect(session.status).toBe("waiting");
-      expect(session.attentionType).toBe("permission");
-    });
-
-    it("flips to working when a real shell (zsh) is a Bash descendant", async () => {
-      const id = makeSession(sessionManager, {
-        status: "waiting",
-        attentionType: "permission",
-        pendingTool: "Bash",
-        trackingMode: "native",
-        pid: 12345,
-        tmuxPane: "%1",
-        lastActivityAt: new Date().toISOString(),
-      });
-
-      const output = [
-        PS_HEADER,
-        psLine(12345, 1, "/usr/local/bin/claude"),
-        psLine(54322, 12345, "-zsh"),
-      ].join("\n");
-      const processTree = ProcessTree.fromPsOutput(output);
-
-      await reconcileAll(
-        makeDeps(sessionManager),
-        makeSnapshot({
-          processes: [fakeProcess()],
-          panes: [fakePane()],
-          processTree,
-        }),
-      );
-
-      const session = sessionManager.getSession(id)!;
-      expect(session.status).toBe("working");
-    });
+        const session = sessionManager.getSession(id)!;
+        expect(session.status).toBe(expectedStatus);
+        expect(session.attentionType).toBe(expectedAttentionType);
+      },
+    );
   });
 
   describe("waiting session protection", () => {


### PR DESCRIPTION
## Overview

Fixes shell-process classification in `findShellDescendants` to match the exact process basename instead of a substring against the raw `comm` path.

Resolves #52

## Motivation

`detectToolExecution` flips a Claude session stuck on a Bash permission prompt to `working` (clearing the attention indicator) once it sees a shell descendant of the pane's Claude process, on the assumption that the user already approved the command and it's running. The old check matched `SHELL_NAMES` with `String.includes` against `comm`, which on macOS is a full path, not a basename. Any process whose path contains a shell name as a substring, like a language server living under `~/.local/share/...` (matches "sh" via "share"), got classified as a shell. That silently hid real Bash permission waits for as long as the false-positive process lived, which for an LSP is effectively the lifetime of the editor.

## Changes

### Classification

- **src/daemon/process-tree.ts** - Adds `shellCommKey()`, which derives an exact-match key from `comm` (minus one leading `-` for login shells, minus path prefix via `path.basename`), and switches `findShellDescendants` from substring matching to exact set membership against an expanded `SHELL_NAMES` (adds `dash`, `ksh`, `csh`, `tcsh`, `ash`, which the old substring rule caught by accident). Also extracts `ProcessTree.fromPsOutput()` out of `build()` so the parsing half is testable without spawning a real `ps`. This is a deliberate narrowing versus the old substring rule, which also happened to match `mksh`, `ksh93`, `yash`, `xonsh`, `elvish`, and `osh`; the new exact set doesn't cover those, but a miss just fails conservatively (the row stays `waiting` with the attention indicator lit, never silently swallowed), and `detectToolExecution` only fires for Claude's Bash tool in the first place.

### Tests

- **src/daemon/process-tree.test.ts** - Replaces the old live-ps test (which asserted the implementation's own predicate against itself and could never fail) with fixture-driven cases: positive fixtures (`-zsh`, `-/bin/zsh`, `/bin/zsh`, `/bin/bash`, `/opt/homebrew/bin/fish`, and a real space-containing macOS path) and negative fixtures (the `.local/share` language server, `sshd-session:`, `sharingd`, `ReportCrash`, and a space-containing app-bundle Helpers path). A separate defensive-tolerance block documents that command-style (argv-shaped) input is not real `comm` output and is not specially parsed, including one known false positive on a synthetic argv string.
- **src/daemon/state-reconciler.test.ts** - Adds an end-to-end reconciler case: a Claude session waiting on a Bash permission prompt stays `waiting` when its only descendant is a language server, and flips to `working` when the descendant is a real `zsh`.
- **src/daemon/process-tree-test-helpers.ts** - Shared `PS_HEADER`/`psLine()` fixture builders for canned ps output, used by both test files.

## Breaking Changes

Sessions that were previously (incorrectly) silently flipped to `working` by the false-positive match now correctly hold `waiting` with the attention indicator lit. This is more visible attention, not less, and is the intended fix, but it is a user-visible behavior change for anyone whose false-positive process (e.g. an LSP under a path containing "sh") was masking a real Bash wait.

## Testing

- [x] `bun run typecheck` clean
- [x] `bun test` - 3029 pass, 0 fail
- [x] Fixture-driven unit tests for `shellCommKey()` and `findShellDescendants()` covering all positive/negative cases from the issue
- [x] End-to-end reconciler test covering the language-server-stays-waiting and real-shell-flips-to-working cases
- [ ] Live picker e2e against the shared daemon (handled separately per instructions; daemon not restarted from this branch)
