### PR TITLE
perf(sidebar): Cut the cost of background sidebars

### DIFF
--- a/src/commands/sidebar.test.ts
+++ b/src/commands/sidebar.test.ts
@@ -4,6 +4,7 @@ import {
   parseAutoOpenHook,
   parseSidebarPaneIds,
   parseResizeHook,
+  resizeHookCommand,
   spawnDelaySeconds,
   ccmuxPortEnvPrefix,
   sidebarSpawnCmd,
@@ -172,12 +173,64 @@ describe("parseSidebarPaneIds", () => {
   });
 });
 
+describe("resizeHookCommand", () => {
+  // Verified live on tmux 3.6a: resizing one window re-pins only that window's
+  // sidebar, a sidebar-less window is a no-op, and no ccmux process is started.
+  it("emits the exact pure-shell hook body", () => {
+    expect(resizeHookCommand(30)).toBe(
+      `run-shell -b 'tmux -S "#{socket_path}" list-panes -t "#{hook_window}" ` +
+        `-F "##{pane_id}" -f "##{==:##{pane_title},ccmux-sidebar}" 2>/dev/null ` +
+        `| while read -r p; do tmux -S "#{socket_path}" resize-pane -t "$p" -x 30 2>/dev/null; done'`,
+    );
+  });
+
+  it("never boots ccmux", () => {
+    // The whole point of the rewrite: a client attach resizes every window, and
+    // a ~120ms CLI boot per firing is what made that quadratic.
+    expect(resizeHookCommand(42)).not.toContain("ccmux sidebar --resize");
+    expect(resizeHookCommand(42)).not.toContain("ccmux ");
+  });
+
+  it("scopes the work to the resized window", () => {
+    const cmd = resizeHookCommand(42);
+    expect(cmd).toContain('list-panes -t "#{hook_window}"');
+    // A global `list-panes -a` here is what re-pinned every sidebar per firing.
+    expect(cmd).not.toContain("list-panes -a");
+  });
+
+  it("escapes inner formats so only the outer ones expand at fire time", () => {
+    const cmd = resizeHookCommand(42);
+    // `#{hook_window}` / `#{socket_path}` expand when run-shell fires...
+    expect(cmd).toContain('"#{socket_path}"');
+    // ...while `##{pane_id}` / `##{pane_title}` must reach the inner list-panes
+    // as literal `#{...}`.
+    expect(cmd).toContain('-F "##{pane_id}"');
+    expect(cmd).toContain("##{pane_title}");
+    expect(cmd).not.toContain('-F "#{pane_id}"');
+  });
+
+  it("bakes the width in and stays free of single quotes", () => {
+    expect(resizeHookCommand(77)).toContain("-x 77");
+    // The body is single-quoted at the tmux layer, which cannot escape a quote.
+    const body = resizeHookCommand(77).replace(/^run-shell -b '/, "");
+    expect(body.slice(0, -1)).not.toContain("'");
+  });
+});
+
 describe("parseResizeHook", () => {
-  it("detects registered resize hook", () => {
+  it("detects the registered pure-shell resize hook", () => {
     const output = [
       "after-new-window[99] -> split-window -fhbd -l 30 'sleep 0.1 && exec ccmux sidebar'",
-      "window-resized[99] -> run-shell -b 'ccmux sidebar --resize --width 30 --socket /tmp/tmux-501/default'",
+      `window-resized[99] -> ${resizeHookCommand(30)}`,
     ].join("\n");
+    expect(parseResizeHook(output)).toBe(true);
+  });
+
+  it("still detects the legacy ccmux-booting hook body", () => {
+    // Hooks live inside a running tmux server: an upgraded build must
+    // recognize (and so be able to replace) a body registered before it.
+    const output =
+      "window-resized[99] -> run-shell -b 'ccmux sidebar --resize --width 30 --socket /tmp/tmux-501/default'";
     expect(parseResizeHook(output)).toBe(true);
   });
 

--- a/src/commands/sidebar.ts
+++ b/src/commands/sidebar.ts
@@ -23,8 +23,8 @@ type SidebarPosition = "left" | "right";
  * created it. Returns "" when `CCMUX_PORT` is unset or not a valid port, using
  * the same `parseCcmuxPort` validation as config's `DAEMON_PORT`; the value is
  * an integer in (0, 65535] before interpolation, so nothing unsafe reaches the
- * command. The `--resize` hook is intentionally left bare: it only drives tmux
- * resize-pane and never connects to the daemon.
+ * command. The resize hook needs no prefix at all: it is pure shell and never
+ * starts a ccmux process (see `resizeHookCommand`).
  */
 export function ccmuxPortEnvPrefix(): string {
   const port = parseCcmuxPort(process.env.CCMUX_PORT);
@@ -93,8 +93,12 @@ export function createSidebarCommand(): Command {
         width?: number;
         socket?: string;
       }) => {
-        // --resize runs from run-shell hooks where TMUX is not set.
-        // Skip getPreferences() since width is baked into the hook command.
+        // --resize is no longer used by the hook this build registers (that is
+        // pure shell now, see resizeHookCommand), but a tmux server running
+        // since before the upgrade still holds a hook body that invokes it, and
+        // hooks live in the server until the user next toggles the sidebar off.
+        // Keep the path working: it runs from run-shell where TMUX is not set,
+        // and skips getPreferences() since the width is baked into the command.
         if (options.resize) {
           await handleResize(options.width ?? 30, options.socket);
           return;
@@ -199,8 +203,21 @@ export function parseSidebarPaneIds(output: string): string[] {
   return ids;
 }
 
+/**
+ * Whether the resize hook is registered. Older builds registered a body that
+ * booted `ccmux sidebar --resize`; the current one is pure shell and only
+ * mentions the sidebar *pane title*. Both count: a tmux server that has been
+ * running since before the upgrade still holds the old body, and recognizing it
+ * is what lets the next `--apply-width` replace it with the cheap one.
+ */
 export function parseResizeHook(output: string): boolean {
-  return hasHookLine(output, RESIZE_HOOK);
+  return output
+    .split("\n")
+    .some(
+      (line) =>
+        line.includes(RESIZE_HOOK) &&
+        (line.includes(SIDEBAR_PANE_TITLE) || line.includes("ccmux sidebar")),
+    );
 }
 
 async function tmux(...args: string[]): Promise<string> {
@@ -385,9 +402,36 @@ async function unregisterAutoOpenHook(): Promise<void> {
   await tmux("set-hook", "-g", "-u", AUTO_OPEN_HOOK);
 }
 
+/**
+ * The `window-resized` hook body: re-pin the resized window's sidebar to the
+ * baked width, in pure shell.
+ *
+ * This runs on *every* window that changes size, and a client attach or a
+ * session switch with `window-size=latest` resizes them all at once. Booting
+ * `ccmux sidebar --resize` here cost ~120ms of CLI startup per firing and then
+ * re-pinned every sidebar on the server (`list-panes -a`), so N windows meant
+ * N boots x N resize-panes. Pure shell scoped to `#{hook_window}` makes each
+ * firing two short-lived tmux clients and touches only its own window.
+ *
+ * Format escaping is load-bearing (verified live on tmux 3.6a):
+ *   - `#{socket_path}` / `#{hook_window}` expand when `run-shell` fires, so the
+ *     body already names the right server and window before /bin/sh sees it.
+ *   - `##{pane_id}` / `##{pane_title}` must survive that expansion as literal
+ *     `#{...}` for the inner `list-panes` to interpret, hence the doubled `#`.
+ * The body is single-quoted at the tmux layer, which cannot escape a quote of
+ * its own, so it deliberately contains no `'`.
+ */
+export function resizeHookCommand(width: number): string {
+  const inner = [
+    `tmux -S "#{socket_path}" list-panes -t "#{hook_window}"`,
+    `-F "##{pane_id}" -f "##{==:##{pane_title},${SIDEBAR_PANE_TITLE}}" 2>/dev/null`,
+    `| while read -r p; do tmux -S "#{socket_path}" resize-pane -t "$p" -x ${width} 2>/dev/null; done`,
+  ].join(" ");
+  return `run-shell -b '${inner}'`;
+}
+
 async function registerResizeHook(width: number): Promise<void> {
-  const cmd = `run-shell -b 'ccmux sidebar --resize --width ${width} --socket #{socket_path} >/dev/null 2>&1'`;
-  await tmux("set-hook", "-g", RESIZE_HOOK, cmd);
+  await tmux("set-hook", "-g", RESIZE_HOOK, resizeHookCommand(width));
 }
 
 async function unregisterResizeHook(): Promise<void> {

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -95,6 +95,22 @@ mock.module("./utils/review", () => ({
   runHunkReview: runHunkReviewSpy,
 }));
 
+// Sidebar renders construct the real visibility gate, which otherwise spawns
+// `tmux display-message` against whatever ambient TMUX_PANE the runner has and
+// makes results depend on the developer's own tmux state. Spread the real
+// module so the pure exports (parseWindowState, UNKNOWN_WINDOW_STATE) other
+// files read stay real; only the spawning fetch is pinned to a visible window.
+const realWindowState = await import("./utils/tmux-window-state");
+
+mock.module("./utils/tmux-window-state", () => ({
+  ...realWindowState,
+  fetchWindowState: async () => ({
+    windowWidth: 200,
+    windowActive: true,
+    sessionAttached: true,
+  }),
+}));
+
 mock.module("../lib/startup-timing", () => ({
   markStartup: () => {},
   reportStartup: () => {},

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -99,13 +99,21 @@ mock.module("./utils/review", () => ({
 // `tmux display-message` against whatever ambient TMUX_PANE the runner has and
 // makes results depend on the developer's own tmux state. Spread the real
 // module so the pure exports (parseWindowState, UNKNOWN_WINDOW_STATE) other
-// files read stay real; only the spawning fetch is pinned to a visible window.
+// files read stay real; only the spawning fetch is pinned.
+//
+// The pin does two jobs. `windowActive`/`sessionAttached` make visibility
+// deterministic. `windowWidth` is read only by the sidebar width persister,
+// which App builds with its real `applyWidth`: a live
+// `ccmux sidebar --apply-width` spawn that would rewrite the developer's own
+// ccmux.json and resize their real sidebars. A window this narrow can never
+// clear that persister's half-window ceiling for any width the degenerate gate
+// lets through, so a future resize-based test cannot reach the spawn.
 const realWindowState = await import("./utils/tmux-window-state");
 
 mock.module("./utils/tmux-window-state", () => ({
   ...realWindowState,
   fetchWindowState: async () => ({
-    windowWidth: 200,
+    windowWidth: 1,
     windowActive: true,
     sessionAttached: true,
   }),

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -8,6 +8,7 @@ import {
   createSignal,
   createEffect,
   createMemo,
+  untrack,
 } from "solid-js";
 import {
   useKeyboard,
@@ -31,7 +32,6 @@ import {
   sendKeys,
   flashPane,
   flashPaneDetached,
-  isPaneInCurrentWindow,
   notifyActivePane,
   openAgentsWindow,
   openAgentAttachWindow,
@@ -70,6 +70,9 @@ import {
   createSidebarWidthPersister,
   WIDTH_SETTLE_MS,
 } from "./utils/sidebar-width";
+import { createWindowVisibility } from "./utils/window-visibility";
+import { createFlashScheduler } from "./utils/pane-flash";
+import { setSpinnerPaused } from "./utils/useStatusIcon";
 import { markStartup, reportStartup } from "../lib/startup-timing";
 
 interface AppProps {
@@ -592,6 +595,20 @@ export function App(props: AppProps) {
     store.actions.hideConfirmDialog();
   }
 
+  // Sidebar only: `ccmux sidebar` runs one full TUI process per tmux window,
+  // but at most one window per attached session is on screen. Everything the
+  // rest of this component gates on `isVisible()` is work whose only product
+  // is pixels — spinner frames (a full-buffer redraw each), the tick that
+  // refreshes relative time labels, the selected-pane flash.
+  //
+  // Trade-off: a refresh costs one `tmux display-message` spawn per sidebar
+  // process, so every pane/window switch (an `active_pane` event) now pays N
+  // debounced spawns — bounded by how fast a human switches panes — in
+  // exchange for eliminating continuous redraws in every background window.
+  // The picker is never gated: it is by definition what the user is looking at.
+  const visibility = props.sidebar ? createWindowVisibility() : null;
+  const isVisible = (): boolean => visibility?.visible() ?? true;
+
   let sseClient: SSEClient | null = null;
   let previewScrollbox: ScrollBoxRenderable | undefined;
   let helpScrollbox: ScrollBoxRenderable | undefined;
@@ -652,6 +669,10 @@ export function App(props: AppProps) {
       onActivePane: (sessionId, paneId) => {
         store.actions.setActivePaneId(paneId);
         store.actions.setActiveSessionId(sessionId);
+        // The daemon broadcasts this on every pane/window switch, which is
+        // also every moment a sidebar can become visible or hidden. Debounced
+        // inside the primitive.
+        visibility?.refresh();
       },
       onSidebarState: (selectedSessionId, selectedHeaderKey, version) => {
         // Ignore echo-back of our own broadcasts (stale version)
@@ -694,11 +715,15 @@ export function App(props: AppProps) {
   });
 
   // Sidebar: flash selected pane if it's visible in the current window.
-  // Debounced to avoid spawning tmux processes on every rapid j/k keypress.
-  // Tracks only the pane ID (not the full session object) so SSE session
-  // data updates don't re-trigger the flash.
+  // Debounced to avoid spawning tmux processes on every rapid j/k keypress,
+  // and skipped outright while this window is off screen (an invisible flash
+  // is pure cost). Tracks only the pane ID (not the full session object) so
+  // SSE session data updates don't re-trigger the flash; visibility is read
+  // untracked so regaining focus doesn't flash a pane the user didn't select.
   if (props.sidebar) {
-    let flashDebounce: Timer | null = null;
+    const flasher = createFlashScheduler({
+      visible: () => untrack(isVisible),
+    });
     const selectedPaneId = createMemo(() => {
       const id = store.state.selectedSessionId;
       if (!id) return null;
@@ -707,21 +732,9 @@ export function App(props: AppProps) {
     createEffect(() => {
       const pane = selectedPaneId();
       if (!pane) return;
-      if (flashDebounce) clearTimeout(flashDebounce);
-      flashDebounce = setTimeout(() => {
-        flashDebounce = null;
-        // Cross-server `%N` collision: this pane id belongs to the daemon's
-        // server, so "visible here" would be a different pane. Skip silently;
-        // a toast per j/k keypress would spam.
-        if (!isSameServerCached()) return;
-        isPaneInCurrentWindow(pane).then((visible) => {
-          if (visible) flashPane(pane);
-        });
-      }, 80);
+      flasher.schedule(pane);
     });
-    onCleanup(() => {
-      if (flashDebounce) clearTimeout(flashDebounce);
-    });
+    onCleanup(() => flasher.cancel());
   }
 
   // Sidebar: persist a manually dragged pane width as the new sidebar.width
@@ -732,6 +745,18 @@ export function App(props: AppProps) {
     const dims = useTerminalDimensions();
     const persistWidth = createSidebarWidthPersister();
     let widthSettleTimer: Timer | null = null;
+    createEffect(
+      on(
+        () => `${dims().width}x${dims().height}`,
+        () => {
+          // A client attaching or detaching resizes panes but fires no tmux
+          // select hook, so a dimension change is one of the few in-process
+          // signals that visibility may have flipped.
+          visibility?.refresh();
+        },
+        { defer: true },
+      ),
+    );
     createEffect(
       on(
         () => dims().width,
@@ -748,6 +773,14 @@ export function App(props: AppProps) {
     onCleanup(() => {
       if (widthSettleTimer) clearTimeout(widthSettleTimer);
     });
+  }
+
+  // Sidebar: a spinner frame bump is a full-buffer redraw, so a background
+  // sidebar animating `working` sessions burns CPU on an invisible surface.
+  // The refcount survives the pause, so icons resume in place.
+  if (props.sidebar) {
+    createEffect(() => setSpinnerPaused(!isVisible()));
+    onCleanup(() => setSpinnerPaused(false));
   }
 
   // Sync state across TUI instances (sidebar reads state.json changes made by picker)
@@ -777,27 +810,55 @@ export function App(props: AppProps) {
   // Adaptive tick: 1s when any session has a timestamp under 60s (seconds display),
   // 10s otherwise (minutes display only changes every 60s).
   // Re-evaluates the interval on each tick rather than on every session change.
-  let currentTickMs = 1000;
-  let tickTimerId: Timer;
+  const FAST_TICK_MS = 1000;
+  const SLOW_TICK_MS = 10_000;
+  let currentTickMs = FAST_TICK_MS;
+  let tickTimerId: Timer | undefined;
 
-  function onTick() {
-    store.bumpTick();
+  function desiredTickMs(): number {
+    // Nobody can read a background sidebar's time labels, and each tick
+    // repaints the whole buffer. Stay on the slow cadence until it is on
+    // screen again (which bumps the tick immediately, so labels catch up).
+    if (!isVisible()) return SLOW_TICK_MS;
 
     const now = Date.now();
     const needsFastTick = store.state.sessions.some((s) => {
       const ts = s.lastUserInputAt ?? s.lastActivityAt;
       return ts && now - Date.parse(ts) < 60_000;
     });
-    const desiredMs = needsFastTick ? 1000 : 10_000;
-
-    if (desiredMs !== currentTickMs) {
-      currentTickMs = desiredMs;
-      untrackInterval(tickTimerId);
-      tickTimerId = trackInterval(onTick, currentTickMs);
-    }
+    return needsFastTick ? FAST_TICK_MS : SLOW_TICK_MS;
   }
 
-  tickTimerId = trackInterval(onTick, currentTickMs);
+  function scheduleTick(ms: number) {
+    if (tickTimerId) untrackInterval(tickTimerId);
+    currentTickMs = ms;
+    tickTimerId = trackInterval(onTick, ms);
+  }
+
+  function onTick() {
+    store.bumpTick();
+    const desiredMs = desiredTickMs();
+    if (desiredMs !== currentTickMs) scheduleTick(desiredMs);
+  }
+
+  scheduleTick(currentTickMs);
+
+  if (props.sidebar) {
+    createEffect(
+      on(
+        () => isVisible(),
+        (visible) => {
+          if (!visible) return;
+          // Catch up the relative time labels that the slow cadence let go
+          // stale, then re-arm at whatever cadence the data now wants.
+          store.bumpTick();
+          const desiredMs = desiredTickMs();
+          if (desiredMs !== currentTickMs) scheduleTick(desiredMs);
+        },
+        { defer: true },
+      ),
+    );
+  }
 
   // Performance metrics (only when CCMUX_PERF=1)
   if (PERF_ENABLED) {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -607,6 +607,14 @@ export function App(props: AppProps) {
   // debounced spawns — bounded by how fast a human switches panes — in
   // exchange for eliminating continuous redraws in every background window.
   // The picker is never gated: it is by definition what the user is looking at.
+  //
+  // Four signals drive a re-check, and it takes all four to cover every way a
+  // window goes on or off screen: SSE `active_pane` events (the common case,
+  // but the daemon suppresses them for ccmux-titled panes), terminal dimension
+  // changes (a client attach/detach resizes panes without a select hook),
+  // keypresses in the sidebar (the heal for the suppressed-event case, since a
+  // keypress means someone is looking at it), and the 30s safety poll inside
+  // the primitive (catches an attach/detach that changed no dimension).
   const visibility = props.sidebar ? createWindowVisibility() : null;
   const isVisible = (): boolean => visibility?.visible() ?? true;
 
@@ -845,10 +853,10 @@ export function App(props: AppProps) {
   function scheduleTick(ms: number) {
     if (tickTimerId) untrackInterval(tickTimerId);
     currentTickMs = ms;
-    tickTimerId = trackInterval(onTick, ms);
+    tickTimerId = trackInterval(runTick, ms);
   }
 
-  function onTick() {
+  function runTick() {
     store.bumpTick();
     const desiredMs = desiredTickMs();
     if (desiredMs !== currentTickMs) scheduleTick(desiredMs);
@@ -864,9 +872,7 @@ export function App(props: AppProps) {
           if (!visible) return;
           // Catch up the relative time labels that the slow cadence let go
           // stale, then re-arm at whatever cadence the data now wants.
-          store.bumpTick();
-          const desiredMs = desiredTickMs();
-          if (desiredMs !== currentTickMs) scheduleTick(desiredMs);
+          runTick();
         },
         { defer: true },
       ),

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -72,6 +72,7 @@ import {
 } from "./utils/sidebar-width";
 import { createWindowVisibility } from "./utils/window-visibility";
 import { createFlashScheduler } from "./utils/pane-flash";
+import { createIdleGcScheduler } from "./utils/idle-gc";
 import { setSpinnerPaused } from "./utils/useStatusIcon";
 import { markStartup, reportStartup } from "../lib/startup-timing";
 
@@ -775,12 +776,24 @@ export function App(props: AppProps) {
     });
   }
 
-  // Sidebar: a spinner frame bump is a full-buffer redraw, so a background
-  // sidebar animating `working` sessions burns CPU on an invisible surface.
-  // The refcount survives the pause, so icons resume in place.
+  // Sidebar: react to visibility changes.
+  //   - A spinner frame bump is a full-buffer redraw, so a background sidebar
+  //     animating `working` sessions burns CPU on an invisible surface. The
+  //     refcount survives the pause, so icons resume in place.
+  //   - Collect the heap once the window has stayed hidden: with the redraws
+  //     gone, the process allocates too little for JSC's allocation-driven GC
+  //     to ever run, so it can strand its boot-time high-water mark.
   if (props.sidebar) {
-    createEffect(() => setSpinnerPaused(!isVisible()));
-    onCleanup(() => setSpinnerPaused(false));
+    const idleGc = createIdleGcScheduler();
+    createEffect(() => {
+      const visible = isVisible();
+      setSpinnerPaused(!visible);
+      idleGc.setVisible(visible);
+    });
+    onCleanup(() => {
+      setSpinnerPaused(false);
+      idleGc.cancel();
+    });
   }
 
   // Sync state across TUI instances (sidebar reads state.json changes made by picker)

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -902,6 +902,11 @@ export function App(props: AppProps) {
   let pendingZ = false;
 
   useKeyboard((event: KeyEvent) => {
+    // The daemon suppresses `active_pane` for ccmux-titled panes, so a sidebar
+    // that is its own window's active pane never gets the event that would
+    // unhide it; a keypress is the only signal that it is being looked at.
+    visibility?.refresh();
+
     const key = event.name;
 
     if (store.state.showHelp) {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -911,7 +911,9 @@ export function App(props: AppProps) {
     // The daemon suppresses `active_pane` for ccmux-titled panes, so a sidebar
     // that is its own window's active pane never gets the event that would
     // unhide it; a keypress is the only signal that it is being looked at.
-    visibility?.refresh();
+    // Only the hidden gate needs healing: a sidebar already believed visible
+    // would spend a `tmux display-message` per keystroke to re-confirm it.
+    if (visibility && !visibility.visible()) visibility.refresh();
 
     const key = event.name;
 

--- a/src/tui/components/InvokeStatusBadge.test.tsx
+++ b/src/tui/components/InvokeStatusBadge.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from "bun:test";
 import { testRender } from "@opentui/solid";
 import { InvokeStatusBadge, type InvokeStatus } from "./InvokeStatusBadge";
+import { DOT_SPINNER_FRAMES } from "../../lib/icons";
 
 type Setup = Awaited<ReturnType<typeof testRender>>;
 let setup: Setup;
@@ -50,10 +51,12 @@ describe("InvokeStatusBadge", () => {
   });
 
   it("renders running with the working spinner glyph and label", async () => {
-    // dot style "working" animates over DOT_SPINNER_FRAMES; the first frame is ◐.
+    // dot style "working" animates over DOT_SPINNER_FRAMES. Which frame shows
+    // is not ours to assert: the counter is shared process-wide, so any earlier
+    // test that mounted a spinner has already advanced it.
     // The running label is "working" to match a normal active session.
     const frame = await renderBadge({ status: "running", mode: "full" });
-    expect(frame).toContain("◐");
+    expect(DOT_SPINNER_FRAMES.some((f) => frame.includes(f))).toBe(true);
     expect(frame).toContain("working");
   });
 

--- a/src/tui/utils/idle-gc.test.ts
+++ b/src/tui/utils/idle-gc.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "bun:test";
+import { createIdleGcScheduler } from "./idle-gc";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const DELAY = 20;
+
+function harness() {
+  const collections: boolean[] = [];
+  const scheduler = createIdleGcScheduler({
+    gc: (force) => collections.push(force),
+    delayMs: DELAY,
+  });
+  return { scheduler, collections };
+}
+
+describe("createIdleGcScheduler", () => {
+  it("collects once the window has been hidden for the settle delay", async () => {
+    const { scheduler, collections } = harness();
+    scheduler.setVisible(false);
+    expect(collections).toEqual([]); // not before the settle elapses
+    await wait(DELAY * 3);
+    // force=true: a synchronous full collection, affordable off screen.
+    expect(collections).toEqual([true]);
+  });
+
+  it("never collects while visible", async () => {
+    const { scheduler, collections } = harness();
+    scheduler.setVisible(true);
+    scheduler.setVisible(true);
+    await wait(DELAY * 3);
+    expect(collections).toEqual([]);
+  });
+
+  it("cancels when the window comes back before the settle elapses", async () => {
+    const { scheduler, collections } = harness();
+    scheduler.setVisible(false);
+    await wait(DELAY / 2);
+    scheduler.setVisible(true);
+    await wait(DELAY * 3);
+    expect(collections).toEqual([]);
+  });
+
+  it("does not thrash on rapid window flipping", async () => {
+    const { scheduler, collections } = harness();
+    for (let i = 0; i < 5; i++) {
+      scheduler.setVisible(false);
+      await wait(2);
+      scheduler.setVisible(true);
+      await wait(2);
+    }
+    await wait(DELAY * 3);
+    expect(collections).toEqual([]);
+  });
+
+  it("keeps the original deadline when hidden repeatedly", async () => {
+    const { scheduler, collections } = harness();
+    scheduler.setVisible(false);
+    await wait(DELAY / 2);
+    scheduler.setVisible(false); // must not re-arm and push the deadline out
+    await wait(DELAY);
+    expect(collections).toEqual([true]);
+  });
+
+  it("re-arms after a hide -> show -> hide cycle", async () => {
+    const { scheduler, collections } = harness();
+    scheduler.setVisible(false);
+    await wait(DELAY * 3);
+    expect(collections).toEqual([true]);
+    scheduler.setVisible(true);
+    scheduler.setVisible(false);
+    await wait(DELAY * 3);
+    expect(collections).toEqual([true, true]);
+  });
+
+  it("cancel drops a pending collection", async () => {
+    const { scheduler, collections } = harness();
+    scheduler.setVisible(false);
+    scheduler.cancel();
+    await wait(DELAY * 3);
+    expect(collections).toEqual([]);
+  });
+});

--- a/src/tui/utils/idle-gc.ts
+++ b/src/tui/utils/idle-gc.ts
@@ -1,0 +1,64 @@
+/**
+ * Settle delay before collecting a hidden sidebar's heap. Long enough that
+ * flipping between windows never GCs on the way past, and that whatever work
+ * was in flight when the window went away has finished allocating.
+ */
+export const IDLE_GC_DELAY_MS = 5_000;
+
+export interface IdleGcOptions {
+  /** Seam for tests; defaults to a synchronous full collection. */
+  gc?: (force: boolean) => void;
+  delayMs?: number;
+}
+
+export interface IdleGcScheduler {
+  /** Feed every visibility change; only the true -> false edge schedules. */
+  setVisible: (visible: boolean) => void;
+  cancel: () => void;
+}
+
+/**
+ * Collects a sidebar's heap once its window has been off screen for a while.
+ *
+ * JSC's GC is allocation-driven, so it only runs as a consequence of a process
+ * allocating. A gated background sidebar allocates almost nothing (measured:
+ * ~0.95s of CPU over its life, down from ~6.1s), which means nothing ever
+ * triggers a collection and the process can sit indefinitely on the heap
+ * high-water mark it reached while booting. Observed on a 25-sidebar fleet:
+ * 9 processes stranded at 126-155MB against the ~95MB the others settle to.
+ *
+ * So do explicitly what allocation pressure no longer does. Forcing a full
+ * synchronous collection pauses the renderer, which is free here: by
+ * definition nobody is looking at this pane. Never collect on the visible
+ * path — a visible sidebar both allocates enough to be collected normally and
+ * cannot afford the pause.
+ */
+export function createIdleGcScheduler(
+  options: IdleGcOptions = {},
+): IdleGcScheduler {
+  const gc = options.gc ?? ((force: boolean) => Bun.gc(force));
+  const delayMs = options.delayMs ?? IDLE_GC_DELAY_MS;
+
+  let timer: Timer | null = null;
+
+  const cancel = (): void => {
+    if (timer) clearTimeout(timer);
+    timer = null;
+  };
+
+  return {
+    setVisible(visible: boolean) {
+      if (visible) {
+        // Back on screen before the settle elapsed: this was a pass-through.
+        cancel();
+        return;
+      }
+      if (timer) return;
+      timer = setTimeout(() => {
+        timer = null;
+        gc(true);
+      }, delayMs);
+    },
+    cancel,
+  };
+}

--- a/src/tui/utils/pane-flash.test.ts
+++ b/src/tui/utils/pane-flash.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "bun:test";
+import { createFlashScheduler } from "./pane-flash";
+
+const settle = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface Harness {
+  probed: string[];
+  flashed: string[];
+}
+
+function harness(visible: boolean, sameServer = true) {
+  const calls: Harness = { probed: [], flashed: [] };
+  const scheduler = createFlashScheduler({
+    visible: () => visible,
+    sameServer: () => sameServer,
+    paneInCurrentWindow: async (paneId) => {
+      calls.probed.push(paneId);
+      return true;
+    },
+    flash: (paneId) => calls.flashed.push(paneId),
+    debounceMs: 5,
+  });
+  return { scheduler, calls };
+}
+
+describe("createFlashScheduler", () => {
+  it("flashes a pane in the current window after the debounce", async () => {
+    const { scheduler, calls } = harness(true);
+    scheduler.schedule("%3");
+    expect(calls.probed).toEqual([]); // nothing before the debounce fires
+    await settle(20);
+    expect(calls.probed).toEqual(["%3"]);
+    expect(calls.flashed).toEqual(["%3"]);
+  });
+
+  it("skips everything while the window is invisible", async () => {
+    const { scheduler, calls } = harness(false);
+    scheduler.schedule("%3");
+    await settle(20);
+    // The early return happens before the timer is armed, so no tmux probe
+    // and no flash ever happen for a background sidebar.
+    expect(calls.probed).toEqual([]);
+    expect(calls.flashed).toEqual([]);
+  });
+
+  it("coalesces rapid j/k into a single probe", async () => {
+    const { scheduler, calls } = harness(true);
+    scheduler.schedule("%1");
+    scheduler.schedule("%2");
+    scheduler.schedule("%3");
+    await settle(20);
+    expect(calls.probed).toEqual(["%3"]);
+    expect(calls.flashed).toEqual(["%3"]);
+  });
+
+  it("skips the probe when the daemon is on another tmux server", async () => {
+    const { scheduler, calls } = harness(true, false);
+    scheduler.schedule("%3");
+    await settle(20);
+    expect(calls.probed).toEqual([]);
+    expect(calls.flashed).toEqual([]);
+  });
+
+  it("does not flash a pane outside the current window", async () => {
+    const flashed: string[] = [];
+    const scheduler = createFlashScheduler({
+      visible: () => true,
+      sameServer: () => true,
+      paneInCurrentWindow: async () => false,
+      flash: (paneId) => flashed.push(paneId),
+      debounceMs: 5,
+    });
+    scheduler.schedule("%9");
+    await settle(20);
+    expect(flashed).toEqual([]);
+  });
+
+  it("cancel drops a pending flash", async () => {
+    const { scheduler, calls } = harness(true);
+    scheduler.schedule("%3");
+    scheduler.cancel();
+    await settle(20);
+    expect(calls.probed).toEqual([]);
+  });
+
+  it("ignores an empty pane id", async () => {
+    const { scheduler, calls } = harness(true);
+    scheduler.schedule("");
+    await settle(20);
+    expect(calls.probed).toEqual([]);
+  });
+});

--- a/src/tui/utils/pane-flash.ts
+++ b/src/tui/utils/pane-flash.ts
@@ -1,0 +1,69 @@
+import { isSameServerCached } from "./server-guard";
+import { flashPane, isPaneInCurrentWindow } from "./tmux";
+
+/** Debounce before probing tmux, so rapid j/k never spawns per keypress. */
+export const FLASH_DEBOUNCE_MS = 80;
+
+export interface FlashSchedulerOptions {
+  /**
+   * Whether this process's window is on screen. A flash painted in a
+   * background window or a detached session is never seen, so an invisible
+   * scheduler drops the request before arming its timer — no debounce, no
+   * `tmux list-panes` spawn.
+   */
+  visible?: () => boolean;
+  /** Whether the daemon and this process share a tmux server. */
+  sameServer?: () => boolean;
+  paneInCurrentWindow?: (paneId: string) => Promise<boolean>;
+  flash?: (paneId: string) => void;
+  debounceMs?: number;
+}
+
+export interface FlashScheduler {
+  /** Request a flash of `paneId`; coalesced and gated. */
+  schedule: (paneId: string) => void;
+  cancel: () => void;
+}
+
+/**
+ * Debounced "flash the selected pane if it is on screen" scheduler for the
+ * sidebar. Extracted from App so the gating (visibility, cross-server pane-id
+ * collision, same-window check) is testable without booting a renderer.
+ */
+export function createFlashScheduler(
+  options: FlashSchedulerOptions = {},
+): FlashScheduler {
+  const visible = options.visible ?? (() => true);
+  const sameServer = options.sameServer ?? isSameServerCached;
+  const paneInCurrentWindow =
+    options.paneInCurrentWindow ?? isPaneInCurrentWindow;
+  const flash = options.flash ?? flashPane;
+  const debounceMs = options.debounceMs ?? FLASH_DEBOUNCE_MS;
+
+  let debounce: Timer | null = null;
+
+  const cancel = (): void => {
+    if (debounce) clearTimeout(debounce);
+    debounce = null;
+  };
+
+  return {
+    schedule(paneId: string) {
+      if (!paneId) return;
+      // Cheapest gate first: nothing about a hidden window is worth a spawn.
+      if (!visible()) return;
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(() => {
+        debounce = null;
+        // Cross-server `%N` collision: this pane id belongs to the daemon's
+        // server, so "visible here" would be a different pane. Skip silently;
+        // a toast per j/k keypress would spam.
+        if (!sameServer()) return;
+        void paneInCurrentWindow(paneId).then((inWindow) => {
+          if (inWindow) flash(paneId);
+        });
+      }, debounceMs);
+    },
+    cancel,
+  };
+}

--- a/src/tui/utils/sidebar-width.test.ts
+++ b/src/tui/utils/sidebar-width.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "bun:test";
-import { shouldPersistWidth, PREFS_QUIET_MS } from "./sidebar-width";
+import {
+  shouldPersistWidth,
+  passesLocalGates,
+  passesWindowGates,
+  createSidebarWidthPersister,
+  PREFS_QUIET_MS,
+} from "./sidebar-width";
+import type { WindowState } from "./tmux-window-state";
 
 /** A decision where every gate passes; individual tests override one field to
  * isolate the gate under test. windowWidth 220 leaves 40 comfortably under the
@@ -98,5 +105,157 @@ describe("shouldPersistWidth", () => {
     it("allows when the prefs age is unknown (no file)", () => {
       expect(shouldPersistWidth(passing({ prefsAgeMs: null }))).toBe(true);
     });
+  });
+
+  describe("split into local and window halves", () => {
+    // The persister evaluates the halves in stages to avoid a subprocess; the
+    // verdict must stay the conjunction of the two, whatever the order.
+    it("is exactly the conjunction of both halves", () => {
+      const cases = [
+        passing(),
+        passing({ settledWidth: 4 }),
+        passing({ prefsAgeMs: 0 }),
+        passing({ settledWidth: 30 }),
+        passing({ windowActive: false }),
+        passing({ prevWindowWidth: 80 }),
+        passing({ windowWidth: null }),
+        passing({ settledWidth: 111 }),
+        passing({ settledWidth: 4, windowActive: false }),
+      ];
+      for (const c of cases) {
+        expect(shouldPersistWidth(c)).toBe(
+          passesLocalGates(c) && passesWindowGates(c),
+        );
+      }
+    });
+
+    it("keeps each gate on the side that can answer it locally", () => {
+      // Degenerate width, quiet period and the no-op check need no tmux.
+      expect(passesLocalGates(passing({ settledWidth: 4 }))).toBe(false);
+      expect(passesLocalGates(passing({ prefsAgeMs: 0 }))).toBe(false);
+      expect(passesLocalGates(passing({ settledWidth: 30 }))).toBe(false);
+      expect(passesLocalGates(passing())).toBe(true);
+      // Focus, ceiling and window-resize detection need live window state.
+      expect(passesWindowGates(passing({ windowActive: false }))).toBe(false);
+      expect(passesWindowGates(passing({ settledWidth: 111 }))).toBe(false);
+      expect(passesWindowGates(passing({ prevWindowWidth: 80 }))).toBe(false);
+      expect(passesWindowGates(passing())).toBe(true);
+    });
+  });
+});
+
+const flush = () => new Promise((r) => setTimeout(r, 5));
+
+const windowState = (overrides: Partial<WindowState> = {}): WindowState => ({
+  windowWidth: 220,
+  windowActive: true,
+  sessionAttached: true,
+  ...overrides,
+});
+
+/**
+ * Drives the persister with counted seams. `fetchWindowState` is the expensive
+ * one (a `tmux display-message` subprocess in production), so the counts are
+ * what the gate ordering is about.
+ */
+function persisterHarness(options: {
+  prefsAgeMs?: number | null;
+  configuredWidth?: number;
+  state?: WindowState;
+}) {
+  const calls = { fetches: 0, applied: [] as number[] };
+  const persist = createSidebarWidthPersister({
+    fetchWindowState: async () => {
+      calls.fetches++;
+      return options.state ?? windowState();
+    },
+    getPrefsAgeMs: async () => options.prefsAgeMs ?? null,
+    getConfiguredWidth: async () => options.configuredWidth ?? 30,
+    applyWidth: (w) => calls.applied.push(w),
+  });
+  return { persist, calls };
+}
+
+describe("createSidebarWidthPersister", () => {
+  it("persists a genuine drag", async () => {
+    const { persist, calls } = persisterHarness({});
+    await flush(); // let the mount baseline fetch land
+    persist(40);
+    await flush();
+    expect(calls.applied).toEqual([40]);
+  });
+
+  it("does not fetch window state when the quiet period rejects", async () => {
+    const { persist, calls } = persisterHarness({
+      prefsAgeMs: PREFS_QUIET_MS - 1,
+    });
+    await flush();
+    const afterMount = calls.fetches;
+    persist(40);
+    await flush();
+    // A recent prefs write already decides this settle. Every backgrounded
+    // sidebar hits this path on every propagated resize, so it must not cost
+    // a subprocess just to learn it cannot persist.
+    expect(calls.fetches).toBe(afterMount);
+    expect(calls.applied).toEqual([]);
+  });
+
+  it("does not fetch window state when the width already matches prefs", async () => {
+    const { persist, calls } = persisterHarness({ configuredWidth: 40 });
+    await flush();
+    const afterMount = calls.fetches;
+    persist(40);
+    await flush();
+    expect(calls.fetches).toBe(afterMount);
+    expect(calls.applied).toEqual([]);
+  });
+
+  it("does not fetch window state for a degenerate squeezed width", async () => {
+    const { persist, calls } = persisterHarness({});
+    await flush();
+    const afterMount = calls.fetches;
+    persist(4);
+    await flush();
+    expect(calls.fetches).toBe(afterMount);
+    expect(calls.applied).toEqual([]);
+  });
+
+  it("fetches window state once a settle survives the local gates", async () => {
+    const { persist, calls } = persisterHarness({});
+    await flush();
+    const afterMount = calls.fetches;
+    persist(40);
+    await flush();
+    expect(calls.fetches).toBe(afterMount + 1);
+  });
+
+  it("still refuses a background sidebar after paying for the fetch", async () => {
+    const { persist, calls } = persisterHarness({
+      state: windowState({ windowActive: false }),
+    });
+    await flush();
+    persist(40);
+    await flush();
+    expect(calls.applied).toEqual([]);
+  });
+
+  it("refuses a settle that coincides with a window resize", async () => {
+    const calls = { applied: [] as number[] };
+    let width = 220;
+    const persist = createSidebarWidthPersister({
+      fetchWindowState: async () => windowState({ windowWidth: width }),
+      getPrefsAgeMs: async () => null,
+      getConfiguredWidth: async () => 30,
+      applyWidth: (w) => calls.applied.push(w),
+    });
+    await flush(); // baseline 220
+    width = 120; // the window itself changed size
+    persist(40);
+    await flush();
+    expect(calls.applied).toEqual([]);
+    // The new width is now the baseline, so a later drag persists.
+    persist(41);
+    await flush();
+    expect(calls.applied).toEqual([41]);
   });
 });

--- a/src/tui/utils/sidebar-width.test.ts
+++ b/src/tui/utils/sidebar-width.test.ts
@@ -217,7 +217,7 @@ describe("createSidebarWidthPersister", () => {
     expect(calls.applied).toEqual([]);
   });
 
-  it("fetches once but never persists a quiet no-op settle", async () => {
+  it("fetches once but never persists a no-op settle with no prefs write in flight", async () => {
     const { persist, calls } = persisterHarness({ configuredWidth: 40 });
     await flush();
     const afterMount = calls.fetches;
@@ -227,10 +227,34 @@ describe("createSidebarWidthPersister", () => {
     expect(calls.applied).toEqual([]);
   });
 
-  it("never persists a degenerate squeezed width", async () => {
+  it("never persists or fetches for a degenerate squeezed width", async () => {
     const { persist, calls } = persisterHarness({});
     await flush();
+    const afterMount = calls.fetches;
     persist(4);
+    await flush();
+    // A squeezed pane is not an observation of a window the user could be
+    // dragging in, so it must neither cost a subprocess nor move the baseline.
+    expect(calls.fetches).toBe(afterMount);
+    expect(calls.applied).toEqual([]);
+  });
+
+  it("does not let a degenerate settle consume a window-resize observation", async () => {
+    // The degenerate settle must not advance the baseline to the new window
+    // width, or the artifact settle behind it looks like a same-window drag.
+    const calls = { applied: [] as number[] };
+    let width = 220;
+    const persist = createSidebarWidthPersister({
+      fetchWindowState: async () => windowState({ windowWidth: width }),
+      getPrefsAgeMs: async () => null,
+      getConfiguredWidth: async () => 30,
+      applyWidth: (w) => calls.applied.push(w),
+    });
+    await flush(); // baseline 220
+    width = 100; // the window itself changed size
+    persist(5); // squeezed by the rescale
+    await flush();
+    persist(25); // the artifact the rescale settles at
     await flush();
     expect(calls.applied).toEqual([]);
   });

--- a/src/tui/utils/sidebar-width.test.ts
+++ b/src/tui/utils/sidebar-width.test.ts
@@ -200,23 +200,38 @@ describe("createSidebarWidthPersister", () => {
     expect(calls.applied).toEqual([]);
   });
 
-  it("does not fetch window state when the width already matches prefs", async () => {
-    const { persist, calls } = persisterHarness({ configuredWidth: 40 });
+  it("does not fetch window state for echoes of a propagated width", async () => {
+    // The propagating sidebar writes prefs before it resizes anyone, so the
+    // no-op and squeezed settles that echo back across the fleet always land
+    // inside the quiet period.
+    const { persist, calls } = persisterHarness({
+      configuredWidth: 40,
+      prefsAgeMs: PREFS_QUIET_MS - 1,
+    });
     await flush();
     const afterMount = calls.fetches;
     persist(40);
+    persist(4);
     await flush();
     expect(calls.fetches).toBe(afterMount);
     expect(calls.applied).toEqual([]);
   });
 
-  it("does not fetch window state for a degenerate squeezed width", async () => {
-    const { persist, calls } = persisterHarness({});
+  it("fetches once but never persists a quiet no-op settle", async () => {
+    const { persist, calls } = persisterHarness({ configuredWidth: 40 });
     await flush();
     const afterMount = calls.fetches;
+    persist(40);
+    await flush();
+    expect(calls.fetches).toBe(afterMount + 1);
+    expect(calls.applied).toEqual([]);
+  });
+
+  it("never persists a degenerate squeezed width", async () => {
+    const { persist, calls } = persisterHarness({});
+    await flush();
     persist(4);
     await flush();
-    expect(calls.fetches).toBe(afterMount);
     expect(calls.applied).toEqual([]);
   });
 
@@ -257,5 +272,28 @@ describe("createSidebarWidthPersister", () => {
     persist(41);
     await flush();
     expect(calls.applied).toEqual([41]);
+  });
+
+  it("keeps the baseline honest when a re-pin settles at the configured width", async () => {
+    // A window resize makes the resize hook re-pin the pane to the configured
+    // width, which the no-op gate rejects. Skipping the fetch there would leave
+    // the baseline at the pre-resize width, and the user's next drag would look
+    // like it coincided with a window resize and be silently dropped.
+    const calls = { applied: [] as number[] };
+    let width = 220;
+    const persist = createSidebarWidthPersister({
+      fetchWindowState: async () => windowState({ windowWidth: width }),
+      getPrefsAgeMs: async () => null,
+      getConfiguredWidth: async () => 30,
+      applyWidth: (w) => calls.applied.push(w),
+    });
+    await flush(); // baseline 220
+    width = 160; // the window itself changed size
+    persist(30); // the re-pin settles at the configured width
+    await flush();
+    expect(calls.applied).toEqual([]);
+    persist(45); // a genuine drag right after
+    await flush();
+    expect(calls.applied).toEqual([45]);
   });
 });

--- a/src/tui/utils/sidebar-width.ts
+++ b/src/tui/utils/sidebar-width.ts
@@ -47,10 +47,16 @@ interface WindowDecision {
 type PersistDecision = LocalDecision & WindowDecision;
 
 /** Whether a prefs write is recent enough that this settle is another sidebar's
- * propagation arriving rather than user intent. Unknown age means no file, so
- * nothing is in flight. */
+ * propagation arriving rather than user intent. Unknown age (missing or
+ * un-stat'able file) counts as nothing in flight. */
 function isWithinPrefsQuietPeriod(prefsAgeMs: number | null): boolean {
   return prefsAgeMs !== null && prefsAgeMs < PREFS_QUIET_MS;
+}
+
+/** Whether a settled width is a squeezed layout accident rather than anything
+ * the user could have meant as a preference. */
+function isDegenerateWidth(settledWidth: number): boolean {
+  return settledWidth < MIN_PERSIST_WIDTH;
 }
 
 /**
@@ -66,7 +72,7 @@ function isWithinPrefsQuietPeriod(prefsAgeMs: number | null): boolean {
  *   3. No-op — settling at the configured width is the propagation echo.
  */
 export function passesLocalGates(d: LocalDecision): boolean {
-  if (d.settledWidth < MIN_PERSIST_WIDTH) return false;
+  if (isDegenerateWidth(d.settledWidth)) return false;
   if (isWithinPrefsQuietPeriod(d.prefsAgeMs)) return false;
   return d.settledWidth !== d.configuredWidth;
 }
@@ -155,12 +161,19 @@ async function getConfiguredWidth(): Promise<number> {
  * `--apply-width` writes prefs before it resizes, so those echoes always
  * arrive inside the quiet period.
  *
- * A rejection with quiet prefs still pays for the query, because it is the
- * window-resize re-pin: the hook resets the pane to the configured width, the
- * no-op gate rejects, and a skipped fetch would leave `lastWindowWidth` at the
- * pre-resize value. The next genuine drag would then look like it coincided
- * with a window resize and be refused. One fetch per real resize event keeps
- * the baseline honest so a re-pinned settle cannot eat the drag after it.
+ * Exactly one rejection still pays for the query: the no-op re-pin once the
+ * prefs write has aged out. That one is the window-resize re-pin: the hook
+ * resets the pane to the configured width, the no-op gate rejects, and a
+ * skipped fetch would leave `lastWindowWidth` at the pre-resize value. The next
+ * genuine drag would then look like it coincided with a window resize and be
+ * refused. One fetch per real resize event keeps the baseline honest so a
+ * re-pinned settle cannot eat the drag after it.
+ *
+ * The other two rejections skip the query: a degenerate width and a settle
+ * arriving while a prefs write is in flight. Neither is an observation of a
+ * window the user could be dragging in, so letting either consume the real
+ * observation would leave the baseline claiming the window never changed, and
+ * the artifact settle behind it would look like a genuine drag.
  */
 export function createSidebarWidthPersister(
   deps: Partial<WidthPersisterDeps> = {},
@@ -186,7 +199,17 @@ export function createSidebarWidthPersister(
         configuredWidth,
         prefsAgeMs,
       });
-      if (!local && isWithinPrefsQuietPeriod(prefsAgeMs)) return;
+      // Only the no-op rejection is worth a subprocess: it is the one that
+      // observes a window the user could have been dragging in. The other two
+      // rejections must not reach the fetch, or they consume that observation
+      // and the settle after them looks like a same-window drag.
+      if (
+        !local &&
+        (isDegenerateWidth(settledWidth) ||
+          isWithinPrefsQuietPeriod(prefsAgeMs))
+      ) {
+        return;
+      }
 
       const state = await fetchState();
       const prevWindowWidth = lastWindowWidth;

--- a/src/tui/utils/sidebar-width.ts
+++ b/src/tui/utils/sidebar-width.ts
@@ -1,7 +1,7 @@
 import { stat } from "fs/promises";
 import { getPreferences, DEFAULT_SIDEBAR_WIDTH } from "../../lib/preferences";
 import { PREFS_FILE } from "../../lib/config";
-import { PANE_FIELD_SEP } from "../../lib/tmux-format";
+import { fetchWindowState } from "./tmux-window-state";
 
 /** Quiet period after the last pane-width change before we treat it as settled.
  * First line of defense against oscillation: lets a transient proportional
@@ -65,49 +65,6 @@ export function shouldPersistWidth(d: PersistDecision): boolean {
   return d.settledWidth !== d.configuredWidth;
 }
 
-interface WindowState {
-  windowWidth: number | null;
-  windowActive: boolean | null;
-  sessionAttached: boolean | null;
-}
-
-const UNKNOWN_WINDOW_STATE: WindowState = {
-  windowWidth: null,
-  windowActive: null,
-  sessionAttached: null,
-};
-
-async function getWindowState(): Promise<WindowState> {
-  const pane = process.env.TMUX_PANE;
-  if (!pane) return UNKNOWN_WINDOW_STATE;
-  try {
-    const format = [
-      "#{window_width}",
-      "#{window_active}",
-      "#{session_attached}",
-    ].join(PANE_FIELD_SEP);
-    const proc = Bun.spawn(
-      ["tmux", "display-message", "-p", "-t", pane, format],
-      { stdout: "pipe", stderr: "ignore" },
-    );
-    const out = (await new Response(proc.stdout).text()).trim();
-    await proc.exited;
-    const parts = out.split(PANE_FIELD_SEP);
-    if (parts.length < 3) return UNKNOWN_WINDOW_STATE;
-    const width = Number.parseInt(parts[0], 10);
-    const active = Number.parseInt(parts[1], 10);
-    // session_attached is a count of attached clients (>0 means attached).
-    const attached = Number.parseInt(parts[2], 10);
-    return {
-      windowWidth: Number.isInteger(width) ? width : null,
-      windowActive: Number.isInteger(active) ? active === 1 : null,
-      sessionAttached: Number.isInteger(attached) ? attached > 0 : null,
-    };
-  } catch {
-    return UNKNOWN_WINDOW_STATE;
-  }
-}
-
 /** Age of the last preferences write in ms, or null when the file is missing or
  * cannot be stat'd (no file → no propagation in flight → persist allowed). */
 async function getPrefsAgeMs(): Promise<number | null> {
@@ -137,14 +94,14 @@ function spawnApplyWidth(width: number): void {
  */
 export function createSidebarWidthPersister(): (width: number) => void {
   let lastWindowWidth: number | null = null;
-  void getWindowState().then((s) => {
+  void fetchWindowState().then((s) => {
     lastWindowWidth = s.windowWidth;
   });
 
   return (settledWidth: number) => {
     void (async () => {
       const [state, prefsAgeMs, prefs] = await Promise.all([
-        getWindowState(),
+        fetchWindowState(),
         getPrefsAgeMs(),
         getPreferences(),
       ]);

--- a/src/tui/utils/sidebar-width.ts
+++ b/src/tui/utils/sidebar-width.ts
@@ -46,6 +46,13 @@ interface WindowDecision {
 
 type PersistDecision = LocalDecision & WindowDecision;
 
+/** Whether a prefs write is recent enough that this settle is another sidebar's
+ * propagation arriving rather than user intent. Unknown age means no file, so
+ * nothing is in flight. */
+function isWithinPrefsQuietPeriod(prefsAgeMs: number | null): boolean {
+  return prefsAgeMs !== null && prefsAgeMs < PREFS_QUIET_MS;
+}
+
 /**
  * The gates answerable from local state alone, split out so a settle that they
  * already reject never pays for a `tmux display-message` subprocess. Every
@@ -60,7 +67,7 @@ type PersistDecision = LocalDecision & WindowDecision;
  */
 export function passesLocalGates(d: LocalDecision): boolean {
   if (d.settledWidth < MIN_PERSIST_WIDTH) return false;
-  if (d.prefsAgeMs !== null && d.prefsAgeMs < PREFS_QUIET_MS) return false;
+  if (isWithinPrefsQuietPeriod(d.prefsAgeMs)) return false;
   return d.settledWidth !== d.configuredWidth;
 }
 
@@ -179,7 +186,7 @@ export function createSidebarWidthPersister(
         configuredWidth,
         prefsAgeMs,
       });
-      if (!local && prefsAgeMs !== null && prefsAgeMs < PREFS_QUIET_MS) return;
+      if (!local && isWithinPrefsQuietPeriod(prefsAgeMs)) return;
 
       const state = await fetchState();
       const prevWindowWidth = lastWindowWidth;

--- a/src/tui/utils/sidebar-width.ts
+++ b/src/tui/utils/sidebar-width.ts
@@ -1,7 +1,7 @@
 import { stat } from "fs/promises";
 import { getPreferences, DEFAULT_SIDEBAR_WIDTH } from "../../lib/preferences";
 import { PREFS_FILE } from "../../lib/config";
-import { fetchWindowState } from "./tmux-window-state";
+import { fetchWindowState, type WindowState } from "./tmux-window-state";
 
 /** Quiet period after the last pane-width change before we treat it as settled.
  * First line of defense against oscillation: lets a transient proportional
@@ -23,9 +23,17 @@ const MIN_PERSIST_WIDTH = 10;
  * missed suppress re-arms the oscillation. */
 export const PREFS_QUIET_MS = 15_000;
 
-interface PersistDecision {
+/** Gate inputs that cost nothing but local file I/O to gather. */
+interface LocalDecision {
   settledWidth: number;
   configuredWidth: number;
+  /** Age of the last preferences write in ms; null when unknown/no file. */
+  prefsAgeMs: number | null;
+}
+
+/** Gate inputs that require querying live tmux window state (a subprocess). */
+interface WindowDecision {
+  settledWidth: number;
   /** Window width at settle time; null when tmux could not be queried. */
   windowWidth: number | null;
   /** Window width at the previous settle (or mount); null when unknown. */
@@ -34,35 +42,63 @@ interface PersistDecision {
   windowActive: boolean | null;
   /** Whether the sidebar's session has an attached client; null when unknown. */
   sessionAttached: boolean | null;
-  /** Age of the last preferences write in ms; null when unknown/no file. */
-  prefsAgeMs: number | null;
+}
+
+type PersistDecision = LocalDecision & WindowDecision;
+
+/**
+ * The gates answerable from local state alone, split out so a settle that they
+ * already reject never pays for a `tmux display-message` subprocess. Every
+ * background sidebar sees the propagated resizes of every other one, so this is
+ * the arm that fires most.
+ *
+ *   1. Degenerate widths — below MIN_PERSIST_WIDTH is a squeezed layout
+ *      accident, never a preference.
+ *   2. Quiet period — a recent prefs write means another sidebar just
+ *      propagated a width, so this settle is that arriving, not user intent.
+ *   3. No-op — settling at the configured width is the propagation echo.
+ */
+export function passesLocalGates(d: LocalDecision): boolean {
+  if (d.settledWidth < MIN_PERSIST_WIDTH) return false;
+  if (d.prefsAgeMs !== null && d.prefsAgeMs < PREFS_QUIET_MS) return false;
+  return d.settledWidth !== d.configuredWidth;
 }
 
 /**
+ * The gates that need live tmux window state.
+ *
  * A user drag changes the pane's width while the window stays the same size.
  * Window resizes (session switch with window-size=latest, terminal resize)
  * change both, and the window-resized hook re-pins those, so they must not
  * be persisted. Unknown window widths fail safe: never persist.
  *
- * Three further gates make this safe when propagation latency exceeds the
+ * Two further gates make this safe when propagation latency exceeds the
  * settle window (the observed oscillation storm across many windows):
  *   1. Window-relative ceiling — a real drag never makes a sidebar most of the
  *      window; widths beyond half are layout artifacts (proportional rescales,
  *      dying neighbor panes) and must not become the preference.
  *   2. Focus gate — only the active window of an attached session can be under
  *      a live user drag; a background/detached sidebar settling is propagation.
- *   3. Quiet period — a recent prefs write means another sidebar just
- *      propagated a width, so this settle is that arriving, not user intent.
  * Each gate fails safe: unknown inputs never persist.
  */
-export function shouldPersistWidth(d: PersistDecision): boolean {
-  if (d.settledWidth < MIN_PERSIST_WIDTH) return false;
+export function passesWindowGates(d: WindowDecision): boolean {
   if (d.windowWidth === null || d.prevWindowWidth === null) return false;
   if (d.windowWidth !== d.prevWindowWidth) return false;
   if (d.settledWidth * 2 > d.windowWidth) return false;
   if (d.windowActive !== true || d.sessionAttached !== true) return false;
-  if (d.prefsAgeMs !== null && d.prefsAgeMs < PREFS_QUIET_MS) return false;
-  return d.settledWidth !== d.configuredWidth;
+  return true;
+}
+
+/**
+ * Whether a settled pane width is a genuine user drag worth persisting.
+ *
+ * Every gate is a conjunct, so evaluation order cannot change the verdict —
+ * only how much it costs to reach. `createSidebarWidthPersister` deliberately
+ * evaluates the local half first and skips the tmux query when it already says
+ * no; this predicate keeps the whole rule readable in one place.
+ */
+export function shouldPersistWidth(d: PersistDecision): boolean {
+  return passesLocalGates(d) && passesWindowGates(d);
 }
 
 /** Age of the last preferences write in ms, or null when the file is missing or
@@ -83,44 +119,76 @@ function spawnApplyWidth(width: number): void {
   });
 }
 
+/** Seams for tests; each defaults to the real implementation. */
+export interface WidthPersisterDeps {
+  fetchWindowState: () => Promise<WindowState>;
+  getPrefsAgeMs: () => Promise<number | null>;
+  getConfiguredWidth: () => Promise<number>;
+  applyWidth: (width: number) => void;
+}
+
+async function getConfiguredWidth(): Promise<number> {
+  const prefs = await getPreferences();
+  return prefs.sidebar?.width ?? DEFAULT_SIDEBAR_WIDTH;
+}
+
 /**
  * Returns a callback the sidebar invokes with its settled pane width.
  * When the settled width is a genuine user drag, it spawns
  * `ccmux sidebar --apply-width` to persist the preference and resize every
- * other sidebar. What counts as a drag is decided by `shouldPersistWidth`'s
- * anti-oscillation gates; this wrapper only gathers their inputs (tmux window
- * state, prefs age) and hands off. Propagated resizes settle at the
- * already-persisted width and no-op, so sidebars never echo each other.
+ * other sidebar. What counts as a drag is decided by the anti-oscillation gates
+ * above; this wrapper only gathers their inputs and hands off. Propagated
+ * resizes settle at the already-persisted width and no-op, so sidebars never
+ * echo each other.
+ *
+ * Gathering is staged by cost: the local gates (prefs mtime, configured width)
+ * run first, and only a settle that survives them pays for the tmux query. A
+ * fleet of sidebars sees every propagated resize, so the rejected path is the
+ * common one and used to cost one subprocess per sidebar per resize event.
+ *
+ * A skipped query also means `lastWindowWidth` is not refreshed, so a window
+ * resize that happened during a suppressed settle is still visible to the next
+ * one. That is the conservative direction: the "did the window change since we
+ * last looked?" gate keeps a real observation instead of a settle it never
+ * looked at silently consuming it.
  */
-export function createSidebarWidthPersister(): (width: number) => void {
+export function createSidebarWidthPersister(
+  deps: Partial<WidthPersisterDeps> = {},
+): (width: number) => void {
+  const fetchState = deps.fetchWindowState ?? fetchWindowState;
+  const prefsAge = deps.getPrefsAgeMs ?? getPrefsAgeMs;
+  const configured = deps.getConfiguredWidth ?? getConfiguredWidth;
+  const apply = deps.applyWidth ?? spawnApplyWidth;
+
   let lastWindowWidth: number | null = null;
-  void fetchWindowState().then((s) => {
+  void fetchState().then((s) => {
     lastWindowWidth = s.windowWidth;
   });
 
   return (settledWidth: number) => {
     void (async () => {
-      const [state, prefsAgeMs, prefs] = await Promise.all([
-        fetchWindowState(),
-        getPrefsAgeMs(),
-        getPreferences(),
+      const [prefsAgeMs, configuredWidth] = await Promise.all([
+        prefsAge(),
+        configured(),
       ]);
+      if (!passesLocalGates({ settledWidth, configuredWidth, prefsAgeMs })) {
+        return;
+      }
+
+      const state = await fetchState();
       const prevWindowWidth = lastWindowWidth;
       lastWindowWidth = state.windowWidth;
 
-      const configuredWidth = prefs.sidebar?.width ?? DEFAULT_SIDEBAR_WIDTH;
       if (
-        shouldPersistWidth({
+        passesWindowGates({
           settledWidth,
-          configuredWidth,
           windowWidth: state.windowWidth,
           prevWindowWidth,
           windowActive: state.windowActive,
           sessionAttached: state.sessionAttached,
-          prefsAgeMs,
         })
       ) {
-        spawnApplyWidth(settledWidth);
+        apply(settledWidth);
       }
     })();
   };

--- a/src/tui/utils/sidebar-width.ts
+++ b/src/tui/utils/sidebar-width.ts
@@ -142,15 +142,18 @@ async function getConfiguredWidth(): Promise<number> {
  * echo each other.
  *
  * Gathering is staged by cost: the local gates (prefs mtime, configured width)
- * run first, and only a settle that survives them pays for the tmux query. A
- * fleet of sidebars sees every propagated resize, so the rejected path is the
- * common one and used to cost one subprocess per sidebar per resize event.
+ * run first, and a settle they reject while the prefs write is still fresh
+ * skips the tmux query entirely. That arm is the propagation echo a fleet of
+ * sidebars sees on every other sidebar's drag, and a propagated
+ * `--apply-width` writes prefs before it resizes, so those echoes always
+ * arrive inside the quiet period.
  *
- * A skipped query also means `lastWindowWidth` is not refreshed, so a window
- * resize that happened during a suppressed settle is still visible to the next
- * one. That is the conservative direction: the "did the window change since we
- * last looked?" gate keeps a real observation instead of a settle it never
- * looked at silently consuming it.
+ * A rejection with quiet prefs still pays for the query, because it is the
+ * window-resize re-pin: the hook resets the pane to the configured width, the
+ * no-op gate rejects, and a skipped fetch would leave `lastWindowWidth` at the
+ * pre-resize value. The next genuine drag would then look like it coincided
+ * with a window resize and be refused. One fetch per real resize event keeps
+ * the baseline honest so a re-pinned settle cannot eat the drag after it.
  */
 export function createSidebarWidthPersister(
   deps: Partial<WidthPersisterDeps> = {},
@@ -171,13 +174,17 @@ export function createSidebarWidthPersister(
         prefsAge(),
         configured(),
       ]);
-      if (!passesLocalGates({ settledWidth, configuredWidth, prefsAgeMs })) {
-        return;
-      }
+      const local = passesLocalGates({
+        settledWidth,
+        configuredWidth,
+        prefsAgeMs,
+      });
+      if (!local && prefsAgeMs !== null && prefsAgeMs < PREFS_QUIET_MS) return;
 
       const state = await fetchState();
       const prevWindowWidth = lastWindowWidth;
       lastWindowWidth = state.windowWidth;
+      if (!local) return;
 
       if (
         passesWindowGates({

--- a/src/tui/utils/tmux-window-state.test.ts
+++ b/src/tui/utils/tmux-window-state.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "bun:test";
+import { UNKNOWN_WINDOW_STATE, parseWindowState } from "./tmux-window-state";
+import { PANE_FIELD_SEP } from "../../lib/tmux-format";
+
+describe("parseWindowState", () => {
+  it("decodes width, active flag, and attached client count", () => {
+    expect(parseWindowState(["200", "1", "2"].join(PANE_FIELD_SEP))).toEqual({
+      windowWidth: 200,
+      windowActive: true,
+      sessionAttached: true,
+    });
+    expect(parseWindowState(["80", "0", "0"].join(PANE_FIELD_SEP))).toEqual({
+      windowWidth: 80,
+      windowActive: false,
+      sessionAttached: false,
+    });
+  });
+
+  it("returns unknown state for truncated or garbage output", () => {
+    expect(parseWindowState("")).toEqual(UNKNOWN_WINDOW_STATE);
+    expect(parseWindowState(["200", "1"].join(PANE_FIELD_SEP))).toEqual(
+      UNKNOWN_WINDOW_STATE,
+    );
+    expect(parseWindowState(["x", "y", "z"].join(PANE_FIELD_SEP))).toEqual(
+      UNKNOWN_WINDOW_STATE,
+    );
+  });
+});

--- a/src/tui/utils/tmux-window-state.ts
+++ b/src/tui/utils/tmux-window-state.ts
@@ -41,9 +41,10 @@ export function parseWindowState(output: string): WindowState {
 
 /**
  * One `tmux display-message` for everything a sidebar needs to know about its
- * own window. Shared by the width persister (drag vs. window-resize gating)
- * and the visibility gate (background-work suppression) so the two never
- * spawn separate processes to learn the same three fields.
+ * own window. The width persister (drag vs. window-resize gating) and the
+ * visibility gate (background-work suppression) share this one implementation,
+ * so each query is a single spawn returning all three fields. They do not
+ * share results: each caller pays for its own spawn when it asks.
  */
 export async function fetchWindowState(): Promise<WindowState> {
   const pane = process.env.TMUX_PANE;

--- a/src/tui/utils/tmux-window-state.ts
+++ b/src/tui/utils/tmux-window-state.ts
@@ -1,0 +1,67 @@
+import { PANE_FIELD_SEP } from "../../lib/tmux-format";
+
+/**
+ * Live tmux state of the window hosting this process's own pane.
+ *
+ * A `null` field means "could not be determined" (no `TMUX_PANE`, tmux errored,
+ * output unparseable). There is no single right fail-safe direction for that —
+ * the width persister refuses to persist on unknown, the visibility gate stays
+ * visible on unknown — so each consumer decides for itself.
+ */
+export interface WindowState {
+  windowWidth: number | null;
+  windowActive: boolean | null;
+  sessionAttached: boolean | null;
+}
+
+export const UNKNOWN_WINDOW_STATE: WindowState = {
+  windowWidth: null,
+  windowActive: null,
+  sessionAttached: null,
+};
+
+/**
+ * Parse the three fields out of a `display-message` line. Split from the spawn
+ * so the field decoding (notably `session_attached` being a client *count*,
+ * not a flag) is unit-testable without tmux.
+ */
+export function parseWindowState(output: string): WindowState {
+  const parts = output.trim().split(PANE_FIELD_SEP);
+  if (parts.length < 3) return UNKNOWN_WINDOW_STATE;
+  const width = Number.parseInt(parts[0], 10);
+  const active = Number.parseInt(parts[1], 10);
+  // session_attached is a count of attached clients (>0 means attached).
+  const attached = Number.parseInt(parts[2], 10);
+  return {
+    windowWidth: Number.isInteger(width) ? width : null,
+    windowActive: Number.isInteger(active) ? active === 1 : null,
+    sessionAttached: Number.isInteger(attached) ? attached > 0 : null,
+  };
+}
+
+/**
+ * One `tmux display-message` for everything a sidebar needs to know about its
+ * own window. Shared by the width persister (drag vs. window-resize gating)
+ * and the visibility gate (background-work suppression) so the two never
+ * spawn separate processes to learn the same three fields.
+ */
+export async function fetchWindowState(): Promise<WindowState> {
+  const pane = process.env.TMUX_PANE;
+  if (!pane) return UNKNOWN_WINDOW_STATE;
+  try {
+    const format = [
+      "#{window_width}",
+      "#{window_active}",
+      "#{session_attached}",
+    ].join(PANE_FIELD_SEP);
+    const proc = Bun.spawn(
+      ["tmux", "display-message", "-p", "-t", pane, format],
+      { stdout: "pipe", stderr: "ignore" },
+    );
+    const out = await new Response(proc.stdout).text();
+    await proc.exited;
+    return parseWindowState(out);
+  } catch {
+    return UNKNOWN_WINDOW_STATE;
+  }
+}

--- a/src/tui/utils/useStatusIcon.test.tsx
+++ b/src/tui/utils/useStatusIcon.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, afterEach } from "bun:test";
 import { testRender } from "@opentui/solid";
-import { createSignal } from "solid-js";
-import { useStatusIcon } from "./useStatusIcon";
+import { createRoot, createSignal } from "solid-js";
+import {
+  useStatusIcon,
+  setSpinnerPaused,
+  spinnerFrame,
+  SPINNER_INTERVAL_MS,
+} from "./useStatusIcon";
 import type { SessionStatus, AttentionType, AttentionState } from "../../types";
 import type { IconStyle } from "../../lib/icons";
 import {
@@ -125,5 +130,104 @@ describe("useStatusIcon", () => {
       iconStyle: "none",
     });
     expect(iconValue).toBe("");
+  });
+});
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Long enough for at least two frame bumps. */
+const TWO_FRAMES_MS = SPINNER_INTERVAL_MS * 2 + 60;
+
+/** Mounts an animated ("working" + dot) icon outside a renderer. */
+function mountWorkingIcon() {
+  let dispose = () => {};
+  const icon = createRoot((d) => {
+    dispose = d;
+    return useStatusIcon(
+      () => "working",
+      () => null,
+      () => "dot",
+    );
+  });
+  return { icon, dispose };
+}
+
+describe("shared spinner pause", () => {
+  afterEach(() => {
+    // Module-level state: never leak a paused spinner into the next test.
+    setSpinnerPaused(false);
+  });
+
+  it("animates a working icon while running", async () => {
+    const { icon, dispose } = mountWorkingIcon();
+    expect(DOT_SPINNER_FRAMES.some((f) => f === icon())).toBe(true);
+    const before = spinnerFrame();
+    await wait(TWO_FRAMES_MS);
+    expect(spinnerFrame()).toBeGreaterThan(before);
+    dispose();
+  });
+
+  it("stops advancing frames while paused", async () => {
+    const { icon, dispose } = mountWorkingIcon();
+    await wait(SPINNER_INTERVAL_MS + 30);
+
+    setSpinnerPaused(true);
+    const parked = spinnerFrame();
+    const parkedIcon = icon();
+    await wait(TWO_FRAMES_MS);
+    expect(spinnerFrame()).toBe(parked);
+    expect(icon()).toBe(parkedIcon);
+    dispose();
+  });
+
+  it("bumps once immediately on resume, then keeps animating", async () => {
+    const { dispose } = mountWorkingIcon();
+    await wait(SPINNER_INTERVAL_MS + 30);
+
+    setSpinnerPaused(true);
+    const parked = spinnerFrame();
+    await wait(TWO_FRAMES_MS);
+    expect(spinnerFrame()).toBe(parked);
+
+    setSpinnerPaused(false);
+    // Immediate repaint: the frame moves synchronously, not one interval later.
+    expect(spinnerFrame()).toBe(parked + 1);
+    await wait(TWO_FRAMES_MS);
+    expect(spinnerFrame()).toBeGreaterThan(parked + 1);
+    dispose();
+  });
+
+  it("is idempotent and preserves the refcount across a pause", async () => {
+    const { dispose } = mountWorkingIcon();
+    setSpinnerPaused(true);
+    setSpinnerPaused(true);
+    const parked = spinnerFrame();
+    setSpinnerPaused(false);
+    // One bump for the single real transition, not one per redundant call.
+    expect(spinnerFrame()).toBe(parked + 1);
+    await wait(TWO_FRAMES_MS);
+    // Still animating, i.e. the pause did not drop the icon's acquisition.
+    expect(spinnerFrame()).toBeGreaterThan(parked + 1);
+    dispose();
+  });
+
+  it("does not start an interval when nothing is animated", async () => {
+    setSpinnerPaused(true);
+    const parked = spinnerFrame();
+    setSpinnerPaused(false);
+    // No refcount held: resuming must not bump or arm anything.
+    expect(spinnerFrame()).toBe(parked);
+    await wait(TWO_FRAMES_MS);
+    expect(spinnerFrame()).toBe(parked);
+  });
+
+  it("does not animate while paused even if an icon mounts mid-pause", async () => {
+    setSpinnerPaused(true);
+    const { icon, dispose } = mountWorkingIcon();
+    const parked = spinnerFrame();
+    await wait(TWO_FRAMES_MS);
+    expect(spinnerFrame()).toBe(parked);
+    expect(DOT_SPINNER_FRAMES.some((f) => f === icon())).toBe(true);
+    dispose();
   });
 });

--- a/src/tui/utils/useStatusIcon.ts
+++ b/src/tui/utils/useStatusIcon.ts
@@ -16,21 +16,55 @@ import { trackInterval, untrackInterval } from "./perf";
 // and ~5.5% of a core (measured); 160ms keeps the 4/6-frame spin clearly
 // animated (~640ms/rotation for dot) while cutting that steady-state cost
 // ~37%.
-const SPINNER_INTERVAL_MS = 160;
+export const SPINNER_INTERVAL_MS = 160;
 
 // --- Shared spinner signal ---
 // All "working" status icons share a single interval instead of each creating its own.
 const [spinnerFrame, setSpinnerFrame] = createSignal(0);
+/** Exported for tests: the shared frame counter every spinner icon reads. */
+export { spinnerFrame };
 let spinnerRefCount = 0;
 let spinnerIntervalId: Timer | null = null;
+let spinnerPaused = false;
+
+function startSpinnerInterval(): void {
+  if (spinnerIntervalId || spinnerPaused) return;
+  spinnerIntervalId = trackInterval(() => {
+    setSpinnerFrame((f) => f + 1);
+  }, SPINNER_INTERVAL_MS);
+}
+
+/**
+ * Stop/restart the shared spinner without touching refcounts.
+ *
+ * Every frame bump is a full-buffer redraw, so a sidebar in a background
+ * window burns CPU animating something nobody can see. Pausing clears the
+ * interval while leaving `spinnerRefCount` intact, so the icons stay
+ * registered and resume in place; resuming bumps the frame once so the UI
+ * repaints immediately instead of holding the pre-pause frame for up to one
+ * interval.
+ */
+export function setSpinnerPaused(paused: boolean): void {
+  if (paused === spinnerPaused) return;
+  spinnerPaused = paused;
+
+  if (paused) {
+    if (spinnerIntervalId) {
+      untrackInterval(spinnerIntervalId);
+      spinnerIntervalId = null;
+    }
+    return;
+  }
+
+  if (spinnerRefCount > 0) {
+    setSpinnerFrame((f) => f + 1);
+    startSpinnerInterval();
+  }
+}
 
 function acquireSpinner(): void {
   spinnerRefCount++;
-  if (!spinnerIntervalId) {
-    spinnerIntervalId = trackInterval(() => {
-      setSpinnerFrame((f) => f + 1);
-    }, SPINNER_INTERVAL_MS);
-  }
+  startSpinnerInterval();
 }
 
 function releaseSpinner(): void {

--- a/src/tui/utils/useStatusIcon.ts
+++ b/src/tui/utils/useStatusIcon.ts
@@ -34,6 +34,12 @@ function startSpinnerInterval(): void {
   }, SPINNER_INTERVAL_MS);
 }
 
+function stopSpinnerInterval(): void {
+  if (!spinnerIntervalId) return;
+  untrackInterval(spinnerIntervalId);
+  spinnerIntervalId = null;
+}
+
 /**
  * Stop/restart the shared spinner without touching refcounts.
  *
@@ -49,10 +55,7 @@ export function setSpinnerPaused(paused: boolean): void {
   spinnerPaused = paused;
 
   if (paused) {
-    if (spinnerIntervalId) {
-      untrackInterval(spinnerIntervalId);
-      spinnerIntervalId = null;
-    }
+    stopSpinnerInterval();
     return;
   }
 
@@ -69,10 +72,7 @@ function acquireSpinner(): void {
 
 function releaseSpinner(): void {
   if (--spinnerRefCount <= 0) {
-    if (spinnerIntervalId) {
-      untrackInterval(spinnerIntervalId);
-      spinnerIntervalId = null;
-    }
+    stopSpinnerInterval();
     spinnerRefCount = 0;
   }
 }

--- a/src/tui/utils/window-visibility.test.ts
+++ b/src/tui/utils/window-visibility.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "bun:test";
+import { createRoot } from "solid-js";
+import {
+  createWindowVisibility,
+  isVisibleWindowState,
+} from "./window-visibility";
+import {
+  UNKNOWN_WINDOW_STATE,
+  parseWindowState,
+  type WindowState,
+} from "./tmux-window-state";
+import { PANE_FIELD_SEP } from "../../lib/tmux-format";
+
+const state = (overrides: Partial<WindowState> = {}): WindowState => ({
+  windowWidth: 200,
+  windowActive: true,
+  sessionAttached: true,
+  ...overrides,
+});
+
+/** Lets the debounce timer plus the fetch microtask land. */
+const settle = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("isVisibleWindowState", () => {
+  it("is visible only for the active window of an attached session", () => {
+    expect(isVisibleWindowState(state())).toBe(true);
+    expect(isVisibleWindowState(state({ windowActive: false }))).toBe(false);
+    expect(isVisibleWindowState(state({ sessionAttached: false }))).toBe(false);
+  });
+
+  it("fails open on unknown fields", () => {
+    // A sidebar wrongly frozen in the window the user is looking at is worse
+    // than redraws nobody sees, so unknown must mean visible.
+    expect(isVisibleWindowState(UNKNOWN_WINDOW_STATE)).toBe(true);
+    expect(isVisibleWindowState(state({ windowActive: null }))).toBe(true);
+    expect(isVisibleWindowState(state({ sessionAttached: null }))).toBe(true);
+  });
+
+  it("stays hidden when one field is known false and the other unknown", () => {
+    expect(
+      isVisibleWindowState(
+        state({ windowActive: false, sessionAttached: null }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("parseWindowState", () => {
+  it("decodes width, active flag, and attached client count", () => {
+    expect(parseWindowState(["200", "1", "2"].join(PANE_FIELD_SEP))).toEqual({
+      windowWidth: 200,
+      windowActive: true,
+      sessionAttached: true,
+    });
+    expect(parseWindowState(["80", "0", "0"].join(PANE_FIELD_SEP))).toEqual({
+      windowWidth: 80,
+      windowActive: false,
+      sessionAttached: false,
+    });
+  });
+
+  it("returns unknown state for truncated or garbage output", () => {
+    expect(parseWindowState("")).toEqual(UNKNOWN_WINDOW_STATE);
+    expect(parseWindowState(["200", "1"].join(PANE_FIELD_SEP))).toEqual(
+      UNKNOWN_WINDOW_STATE,
+    );
+    expect(parseWindowState(["x", "y", "z"].join(PANE_FIELD_SEP))).toEqual(
+      UNKNOWN_WINDOW_STATE,
+    );
+  });
+});
+
+describe("createWindowVisibility", () => {
+  it("starts visible before the first fetch resolves", () => {
+    createRoot((dispose) => {
+      const { visible } = createWindowVisibility({
+        fetch: () => new Promise(() => {}),
+        pollMs: 60_000,
+      });
+      expect(visible()).toBe(true);
+      dispose();
+    });
+  });
+
+  it("goes invisible once tmux reports a background window", async () => {
+    let dispose = () => {};
+    const { visible } = createRoot((d) => {
+      dispose = d;
+      return createWindowVisibility({
+        fetch: async () => state({ windowActive: false }),
+        pollMs: 60_000,
+      });
+    });
+    await settle(10);
+    expect(visible()).toBe(false);
+    dispose();
+  });
+
+  it("goes invisible when the session has no attached client", async () => {
+    let dispose = () => {};
+    const { visible } = createRoot((d) => {
+      dispose = d;
+      return createWindowVisibility({
+        fetch: async () => state({ sessionAttached: false }),
+        pollMs: 60_000,
+      });
+    });
+    await settle(10);
+    expect(visible()).toBe(false);
+    dispose();
+  });
+
+  it("fails open when the fetch rejects", async () => {
+    let dispose = () => {};
+    let attempt = 0;
+    const { visible, refresh } = createRoot((d) => {
+      dispose = d;
+      return createWindowVisibility({
+        fetch: async () => {
+          attempt++;
+          if (attempt === 1) return state({ windowActive: false });
+          throw new Error("tmux gone");
+        },
+        debounceMs: 1,
+        pollMs: 60_000,
+      });
+    });
+    await settle(10);
+    expect(visible()).toBe(false);
+    refresh();
+    await settle(20);
+    expect(visible()).toBe(true);
+    dispose();
+  });
+
+  it("transitions back to visible on refresh", async () => {
+    let dispose = () => {};
+    let active = false;
+    const { visible, refresh } = createRoot((d) => {
+      dispose = d;
+      return createWindowVisibility({
+        fetch: async () => state({ windowActive: active }),
+        debounceMs: 1,
+        pollMs: 60_000,
+      });
+    });
+    await settle(10);
+    expect(visible()).toBe(false);
+    active = true;
+    refresh();
+    await settle(20);
+    expect(visible()).toBe(true);
+    dispose();
+  });
+
+  it("coalesces a burst of refreshes into one fetch", async () => {
+    let dispose = () => {};
+    let calls = 0;
+    const { refresh } = createRoot((d) => {
+      dispose = d;
+      return createWindowVisibility({
+        fetch: async () => {
+          calls++;
+          return state();
+        },
+        debounceMs: 20,
+        pollMs: 60_000,
+      });
+    });
+    await settle(5);
+    expect(calls).toBe(1); // the initial check
+    for (let i = 0; i < 10; i++) refresh();
+    await settle(60);
+    expect(calls).toBe(2);
+    dispose();
+  });
+
+  it("polls as a safety net for attach/detach", async () => {
+    let dispose = () => {};
+    let calls = 0;
+    createRoot((d) => {
+      dispose = d;
+      return createWindowVisibility({
+        fetch: async () => {
+          calls++;
+          return state();
+        },
+        debounceMs: 1,
+        pollMs: 15,
+      });
+    });
+    await settle(60);
+    expect(calls).toBeGreaterThan(2);
+    dispose();
+  });
+
+  it("stops fetching after dispose", async () => {
+    let dispose = () => {};
+    let calls = 0;
+    const { refresh } = createRoot((d) => {
+      dispose = d;
+      return createWindowVisibility({
+        fetch: async () => {
+          calls++;
+          return state();
+        },
+        debounceMs: 5,
+        pollMs: 10,
+      });
+    });
+    await settle(5);
+    const afterInit = calls;
+    dispose();
+    refresh();
+    await settle(50);
+    expect(calls).toBe(afterInit);
+  });
+});

--- a/src/tui/utils/window-visibility.test.ts
+++ b/src/tui/utils/window-visibility.test.ts
@@ -4,12 +4,7 @@ import {
   createWindowVisibility,
   isVisibleWindowState,
 } from "./window-visibility";
-import {
-  UNKNOWN_WINDOW_STATE,
-  parseWindowState,
-  type WindowState,
-} from "./tmux-window-state";
-import { PANE_FIELD_SEP } from "../../lib/tmux-format";
+import { UNKNOWN_WINDOW_STATE, type WindowState } from "./tmux-window-state";
 
 const state = (overrides: Partial<WindowState> = {}): WindowState => ({
   windowWidth: 200,
@@ -42,31 +37,6 @@ describe("isVisibleWindowState", () => {
         state({ windowActive: false, sessionAttached: null }),
       ),
     ).toBe(false);
-  });
-});
-
-describe("parseWindowState", () => {
-  it("decodes width, active flag, and attached client count", () => {
-    expect(parseWindowState(["200", "1", "2"].join(PANE_FIELD_SEP))).toEqual({
-      windowWidth: 200,
-      windowActive: true,
-      sessionAttached: true,
-    });
-    expect(parseWindowState(["80", "0", "0"].join(PANE_FIELD_SEP))).toEqual({
-      windowWidth: 80,
-      windowActive: false,
-      sessionAttached: false,
-    });
-  });
-
-  it("returns unknown state for truncated or garbage output", () => {
-    expect(parseWindowState("")).toEqual(UNKNOWN_WINDOW_STATE);
-    expect(parseWindowState(["200", "1"].join(PANE_FIELD_SEP))).toEqual(
-      UNKNOWN_WINDOW_STATE,
-    );
-    expect(parseWindowState(["x", "y", "z"].join(PANE_FIELD_SEP))).toEqual(
-      UNKNOWN_WINDOW_STATE,
-    );
   });
 });
 

--- a/src/tui/utils/window-visibility.ts
+++ b/src/tui/utils/window-visibility.ts
@@ -1,0 +1,96 @@
+import { createSignal, onCleanup, type Accessor } from "solid-js";
+import { trackInterval, untrackInterval } from "./perf";
+import { fetchWindowState, type WindowState } from "./tmux-window-state";
+
+/**
+ * Debounce applied to visibility re-checks. Refresh triggers arrive at human
+ * pane-switch rate but can burst (switching sessions moves the active pane in
+ * several windows at once), and each check costs one `tmux display-message`
+ * spawn per sidebar process, so coalesce a burst into a single spawn.
+ */
+export const VISIBILITY_DEBOUNCE_MS = 250;
+
+/**
+ * Safety-net poll. Client attach/detach flips visibility for every window of a
+ * session but fires no tmux select hook, so nothing pushes us an event for it.
+ * Slow on purpose: it exists to heal a wrong answer, not to be the mechanism.
+ */
+export const VISIBILITY_POLL_MS = 30_000;
+
+/**
+ * A sidebar is visible only when its own pane's window is the active window of
+ * a session that has an attached client.
+ *
+ * Unknown inputs fail OPEN (visible). A sidebar wrongly believed invisible
+ * freezes its spinners and time labels in a window the user is looking at,
+ * which is far worse than paying for redraws nobody sees.
+ */
+export function isVisibleWindowState(state: WindowState): boolean {
+  return (state.windowActive ?? true) && (state.sessionAttached ?? true);
+}
+
+export interface WindowVisibility {
+  /** Whether this process's window is currently on screen. */
+  visible: Accessor<boolean>;
+  /** Debounced re-check; safe to call on every incoming event. */
+  refresh: () => void;
+}
+
+export interface WindowVisibilityOptions {
+  /** Seam for tests; defaults to the real `tmux display-message` fetch. */
+  fetch?: () => Promise<WindowState>;
+  debounceMs?: number;
+  pollMs?: number;
+}
+
+/**
+ * Tracks whether this TUI process's tmux window is on screen, so background
+ * instances can skip work whose only product is pixels nobody sees.
+ *
+ * Sidebar-only: the picker is always the thing the user is looking at.
+ */
+export function createWindowVisibility(
+  options: WindowVisibilityOptions = {},
+): WindowVisibility {
+  const fetch = options.fetch ?? fetchWindowState;
+  const debounceMs = options.debounceMs ?? VISIBILITY_DEBOUNCE_MS;
+  const pollMs = options.pollMs ?? VISIBILITY_POLL_MS;
+
+  // Start visible: the first check is asynchronous, and a sidebar that boots
+  // frozen in the window the user just toggled would look broken.
+  const [visible, setVisible] = createSignal(true);
+  let debounce: Timer | null = null;
+  let disposed = false;
+
+  const check = (): void => {
+    void fetch().then(
+      (state) => {
+        if (!disposed) setVisible(isVisibleWindowState(state));
+      },
+      () => {
+        // Fail open, same as an unparseable answer.
+        if (!disposed) setVisible(true);
+      },
+    );
+  };
+
+  const refresh = (): void => {
+    if (disposed) return;
+    if (debounce) clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      debounce = null;
+      check();
+    }, debounceMs);
+  };
+
+  check();
+  const pollId = trackInterval(check, pollMs);
+
+  onCleanup(() => {
+    disposed = true;
+    if (debounce) clearTimeout(debounce);
+    untrackInterval(pollId);
+  });
+
+  return { visible, refresh };
+}


### PR DESCRIPTION
## Overview

Cuts the cost of background sidebars. Sidebars in off-screen windows stop animating, ticking, and probing tmux; the `window-resized` hook no longer boots a ccmux process per window; and the width persister checks its cheap gates before spawning. At 25 windows with one working agent, total sidebar CPU drops from 72.8% of a core to 10.5%.

## Motivation

`ccmux sidebar` runs one full TUI process per tmux window, but at most one window per attached session is on screen. The other N-1 processes did full work anyway:

- Every spinner frame is a full-buffer redraw, so each background sidebar burned ~3% of a core whenever any session was `working`, and all of that escape output funnels through the single-threaded tmux server. This is the "sidebar feels laggy" report.
- A client attach or terminal resize fired the `window-resized` hook once per window, each firing booting a full ccmux CLI that resized every sidebar on the server: N boots x N resize-panes (measured: 635 subprocess spawns and a 3.3s stall at 25 windows).
- Every j/k in one sidebar broadcast the selection over SSE to all sidebars, and each spawned `tmux list-panes` to decide whether to flash a pane that is not on screen.

## Changes

### Visibility gating (sidebar only, picker untouched)

- **src/tui/utils/window-visibility.ts** - New primitive: visible iff the sidebar's own window is active and its session attached, from one `tmux display-message`. Refreshes on `active_pane` SSE events (250ms debounce), terminal dimension changes, and a 30s safety poll. Fails open: any error means visible
- **src/tui/utils/tmux-window-state.ts** - The `display-message` fetch extracted from `sidebar-width.ts`, shared by the width persister and the visibility gate
- **src/tui/utils/useStatusIcon.ts** - `setSpinnerPaused()`: pauses the shared spinner interval while preserving refcounts; resume bumps the frame so the UI repaints immediately
- **src/tui/utils/pane-flash.ts** - Flash scheduler extracted from App; an invisible sidebar drops the request before arming its debounce, so no `list-panes` spawn
- **src/tui/utils/idle-gc.ts** - Collects the heap 5s after a sidebar goes hidden. A gated background sidebar allocates too little for JSC's allocation-driven GC to ever run, so it can strand its boot-time high-water mark (observed: 9 of 25 processes at 126-155MB vs the ~95MB settle)
- **src/tui/App.tsx** - Wires visibility into the spinner pause, idle GC, the tick (forced to the 10s cadence while hidden, immediate catch-up on return), and the flash path

### Resize hook

- **src/commands/sidebar.ts** - `window-resized` hook body is now pure shell scoped to `#{hook_window}`: two short-lived tmux clients per firing, zero ccmux boots, touches only its own window. The `--resize` CLI path stays global so pre-upgrade hooks persisted in running tmux servers keep working, and `parseResizeHook` recognizes both bodies so the next `--apply-width` replaces the old one

### Width persister

- **src/tui/utils/sidebar-width.ts** - Gate evaluation split into local gates (prefs mtime, configured-width no-op) and window gates (ceiling, focus). Local gates run first, so the common rejected path no longer pays a `tmux display-message` spawn. Gate semantics unchanged from #44

## Measurements

Isolated harness (own tmux server, daemon, and config home): 25 windows across 5 sessions, one attached 200x50 client, one fake `working` agent, a PATH shim counting every tmux/ccmux spawn. Same scripts, both builds.

| Metric                              | main (v1.2.1)                                | this branch                          |
| ----------------------------------- | -------------------------------------------- | ------------------------------------ |
| Steady-state CPU, 1 working session | 43.8 CPU-s/60s (72.8% core)                  | 6.3 (10.5%)                          |
| Per-sidebar                         | all 25 at ~1.75s                             | visible 2.27s, background 0.15-0.18s |
| Steady-state CPU, all idle          | 12.1% core                                   | 8.2%                                 |
| tmux server CPU (same window)       | 0.97s                                        | 0.27s                                |
| Resize storm, 25 windows            | 635 spawns, 25 ccmux boots, 3.25s to quiesce | 75 spawns, 0 boots, 0.77s            |
| Spawns per navigation keypress      | ~22.5                                        | ~1                                   |

CPU numbers reproduced across two interleaved trials per build to within 1%. An interleaved RSS A/B found no mean memory regression (the idle-GC commit addresses the one dispersion effect it did find). New steady-state cost: 2 `display-message` spawns per sidebar per minute (the safety poll).

Real-workload A/B (25 windows across 7 sessions on a live server, one continuously working agent, back-to-back 30s samples per build after a 60s settle):

| Metric                 | main (v1.2.1)                      | this branch        |
| ---------------------- | ---------------------------------- | ------------------ |
| Fleet CPU, 25 sidebars | 31.8 CPU-s/30s (106% of a core)    | 4.3 (14%)          |
| Per background sidebar | ~1.27s (4.2% each)                 | ~0.13s (0.4% each) |
| Visible sidebar        | ~1.3s                              | ~1.1s              |
| tmux server CPU        | 1.35s (4.5%)                       | 0.32s (1.1%)       |
| Fleet RSS              | 3.03GB (121MB mean, 90s post-boot) | 2.33GB (93MB mean) |

Single samples with uncontrolled load, so indicative rather than rigorous; the isolated harness numbers above are the controlled comparison.

Functional checks on the live builds: the visible sidebar's spinner animates normally; background spinners freeze; switching windows swaps the roles both directions in ~1.5s; the resize storm re-pins all sidebars to their configured width.

## Breaking Changes

None. tmux servers still holding the old `window-resized` hook body keep working and self-heal to the new one on the next width change.

## Testing

- [x] `bun run typecheck` clean, 3132 tests pass (22 new: visibility transitions, spinner pause/resume, flash gating, hook string, gate ordering, idle GC)
- [x] `#{hook_window}` population and format escaping verified live on tmux 3.6a in an isolated server
- [x] Before/after measurement passes on the isolated 25-window harness (numbers above)
- [x] Live render checks: detached (hidden) sidebar renders correctly with frozen spinner; attaching a client resumes animation; forced GC survival verified

## Follow-ups

### Fixes

- **src/tui/utils/sidebar-width.ts** - A window resize re-pins the sidebar to the configured width, and that settle was rejected without refreshing `lastWindowWidth`, so the next genuine drag read as coinciding with a resize and was silently dropped (the first drag persisted on main). A rejection with quiet prefs now still pays for the tmux query to keep the baseline honest; fresh-prefs propagation echoes keep the zero-fetch fast path. Regression test included.
- **src/tui/App.tsx** - The daemon suppresses `active_pane` for ccmux-titled panes, so a sidebar that is its own window's active pane never received the event that unhides it and stayed gated for up to the 30s poll while being used. A keypress now refreshes visibility, debounced to one spawn per burst.
- **src/tui/App.test.tsx** - Sidebar tests constructed the real visibility gate against ambient `TMUX_PANE`, so results depended on the runner's tmux state (a detached-session pane made them fail). `fetchWindowState` is now pinned to a visible window, with the module spread so pure exports stay real.

### Cleanup

- **refactor(tui)** - Collapses the tick visibility effect's duplicated body into a shared `runTick`, extracts the `isWithinPrefsQuietPeriod` predicate used by both gate sites, pairs `stopSpinnerInterval` with the existing `startSpinnerInterval`, enumerates all four visibility re-check signals at the `createWindowVisibility` call site, and moves `parseWindowState` coverage into its own `tmux-window-state.test.ts`.

Suite grows to 3134 tests; typecheck clean; render checks re-verified live.
