### PR TITLE
fix(tui): Move selection with arrow keys in search mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,11 +324,11 @@ Other skills-capable agents (Codex, Cursor, OpenCode, and others) can use the sa
 <details>
 <summary><strong>Search mode keys</strong></summary>
 
-| Action           | Key                                   |
-| :--------------- | :------------------------------------ |
-| Navigate results | <kbd>Ctrl+N</kbd> / <kbd>Ctrl+P</kbd> |
-| Select           | <kbd>Enter</kbd>                      |
-| Cancel           | <kbd>Esc</kbd>                        |
+| Action           | Key                                                                  |
+| :--------------- | :------------------------------------------------------------------- |
+| Navigate results | <kbd>↑</kbd> / <kbd>↓</kbd> or <kbd>Ctrl+N</kbd> / <kbd>Ctrl+P</kbd> |
+| Select           | <kbd>Enter</kbd>                                                     |
+| Cancel           | <kbd>Esc</kbd>                                                       |
 
 </details>
 

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -1600,6 +1600,67 @@ describe("App pane-switch feedback and server scoping", () => {
       restoreTmux();
     }
   });
+
+  // Search mode hands every printable key to the input, so navigation is
+  // limited to the keys it can't consume. ^n/^p always worked; the arrows
+  // used to fall through to the input and leave the selection stuck on the
+  // first match. Enter is the observable side of "which row is selected".
+  describe("arrow navigation while searching", () => {
+    async function renderTwoSessions() {
+      await renderApp(120, 20, { groupBy: "none", persistent: true });
+      sseCallbacks!.onInit(
+        [
+          mockEnrichedSession({
+            id: "s1",
+            project: "alpha",
+            cwd: "/code/alpha",
+            tmuxPane: "%10",
+          }),
+          mockEnrichedSession({
+            id: "s2",
+            project: "beta",
+            cwd: "/code/beta",
+            tmuxPane: "%20",
+          }),
+        ],
+        null,
+      );
+      await setup.renderOnce();
+      setup.mockInput.pressKey("/");
+      await setup.renderOnce();
+    }
+
+    it("selects the next match on down arrow", async () => {
+      const restoreFetch = withServerInfo(null); // fail-open: guard passes
+      try {
+        await renderTwoSessions();
+        setup.mockInput.pressArrow("down");
+        await setup.renderOnce();
+        setup.mockInput.pressEnter();
+        await settle();
+        expect(switchToPaneSpy).toHaveBeenCalledWith("%20");
+      } finally {
+        restoreFetch();
+      }
+    });
+
+    it("selects the previous match on up arrow", async () => {
+      const restoreFetch = withServerInfo(null);
+      try {
+        await renderTwoSessions();
+        // Move down with ^n so the up arrow is the only key under test.
+        setup.mockInput.pressKey("n", { ctrl: true });
+        await setup.renderOnce();
+        setup.mockInput.pressArrow("up");
+        await setup.renderOnce();
+        setup.mockInput.pressEnter();
+        await settle();
+        expect(switchToPaneSpy).toHaveBeenCalledWith("%10");
+      } finally {
+        restoreFetch();
+      }
+    });
+  });
 });
 
 describe("App invoke row rendering", () => {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -957,12 +957,14 @@ export function App(props: AppProps) {
     }
 
     if (store.state.searchMode) {
-      if (key === "n" && event.ctrl) {
+      // The search input owns the text keys, so selection movement is limited
+      // to the keys it does not consume: ctrl-n/ctrl-p and the arrows.
+      if (key === "down" || (key === "n" && event.ctrl)) {
         store.actions.moveSelection(1);
         event.preventDefault();
         return;
       }
-      if (key === "p" && event.ctrl) {
+      if (key === "up" || (key === "p" && event.ctrl)) {
         store.actions.moveSelection(-1);
         event.preventDefault();
         return;

--- a/src/tui/components/Footer.tsx
+++ b/src/tui/components/Footer.tsx
@@ -36,7 +36,7 @@ export const Footer: Component<FooterProps> = (props) => {
         </Match>
         <Match when={props.searchMode}>
           <text fg={theme.overlay}>
-            type to search · ^n/^p nav · enter{" "}
+            type to search · ↑/↓ or ^n/^p nav · enter{" "}
             {props.persistent ? "switch" : "select"} · esc cancel
           </text>
         </Match>


### PR DESCRIPTION
## Summary

In search mode the picker only moved the selection on `^n`/`^p`. Arrow keys fell through to the focused search input, which ignores vertical arrows on a single-line field, so the selection stayed pinned to the first match and the only way to move was a chord.

`up`/`down` now move the selection alongside `^n`/`^p`, with `preventDefault()` so the input never sees them. The footer hint says so: `type to search · ↑/↓ or ^n/^p nav · enter select · esc cancel`.

## Related issue

<!-- none -->

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (3190 pass / 0 fail)
- [x] Verified the affected TUI surface (picker / sidebar) in a detached tmux session (if this touches the TUI, columns, layout, theming, or the daemon → TUI data path)
- [ ] Verified end to end with a real agent session (n/a: pure TUI key handling, no detection/daemon/CLI path touched)

Two regression tests in `App.test.tsx` assert which row Enter switches to after arrow navigation. The up-arrow test moves down with `^n` first so each arrow is exercised in isolation. Both fail on the pre-fix handler (77 pass / 2 fail) and pass after.

Live check in a detached 200x50 tmux session running this branch's build, query `c` active: Down walked group header → session → next group header, Up walked back, and the query text was untouched throughout.

## Notes for reviewers

Group headers are selectable rows in search results, so a single arrow press can land on a header rather than a session. That is the existing `moveSelection` behavior shared with `j`/`k` and `^n`/`^p`, unchanged here.