### PR TITLE
fix(tui): Account for wrapped content in dialog and menu heights

### DIFF
--- a/src/tui/components/ContextMenu.test.tsx
+++ b/src/tui/components/ContextMenu.test.tsx
@@ -139,9 +139,8 @@ describe("ContextMenu sizing", () => {
     const items = itemSpies(["Attach", LONG, "Kill"]);
     const { frame } = await renderMenu({ items });
 
-    expectFrameIntegrity(frame);
-    const { height, lines, top } = boxBounds(frame);
-    expect(height).toBe(items.length + 2);
+    expectFrameIntegrity(frame, items.length + 2);
+    const { lines, top } = boxBounds(frame);
     // Legibly cut rather than merely clipped, and still beside its hint.
     const row = lines[top + 2]!;
     expect(row).toContain("Move changes to");
@@ -160,7 +159,7 @@ describe("ContextMenu sizing", () => {
     ];
     const { frame } = await renderMenu({ items });
 
-    expectFrameIntegrity(frame);
+    expectFrameIntegrity(frame, items.length + 2);
     for (const item of items) expect(frame).toContain(item.label);
     expect(frame).not.toContain("…");
   });
@@ -172,10 +171,12 @@ describe("ContextMenu sizing", () => {
     const size = { width: 40, height: 10 };
     const { frame } = await renderMenu({ items, x: 9999, y: 9999, size });
 
-    expectFrameIntegrity(frame);
-    const { top, bottom, height } = boxBounds(frame);
+    // The height assertion is the one that fails pre-fix here: a box taller
+    // than `menuHeight()` loses its bottom border off the viewport, so there
+    // is no `└` to measure to.
+    expectFrameIntegrity(frame, items.length + 2);
+    const { top, bottom } = boxBounds(frame);
     expect(top).toBeGreaterThanOrEqual(0);
-    expect(height).toBe(items.length + 2);
     // Flush against the bottom row of the viewport, not past it.
     expect(bottom).toBe(size.height - 1);
     // Every item is still on screen, first and last included.

--- a/src/tui/components/ContextMenu.test.tsx
+++ b/src/tui/components/ContextMenu.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, mock } from "bun:test";
 import { testRender } from "@opentui/solid";
 import { MouseButtons } from "@opentui/core/testing";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+import { expectFrameIntegrity } from "./test-helpers";
 import { theme } from "../theme";
 
 type Setup = Awaited<ReturnType<typeof testRender>>;
@@ -48,6 +49,14 @@ async function renderMenu(
   );
   await setup.renderOnce();
   return { frame: setup.captureCharFrame(), items, onClose };
+}
+
+/** The box's own rows, border included, from a captured frame. */
+function boxBounds(frame: string) {
+  const lines = frame.split("\n");
+  const top = lines.findIndex((l) => l.includes("┌"));
+  const bottom = lines.findIndex((l) => l.includes("└"));
+  return { top, bottom, height: bottom - top + 1, lines };
 }
 
 function locate(frame: string, label: string) {
@@ -111,6 +120,65 @@ describe("ContextMenu", () => {
       y: 9999,
       size: { width: 40, height: 10 },
     });
+    expect(frame).toContain("Attach");
+    expect(frame).toContain("Restart");
+  });
+});
+
+/**
+ * Issue #82. The menu is a fixed 22 columns and sizes itself as
+ * `items.length + 2`. A label long enough to wrap rendered two rows while
+ * still counting as one item, so the box height — and with it the viewport
+ * clamp that keeps the menu on screen — was wrong for the whole menu,
+ * silently: content assertions pass on a wrapped label just the same.
+ */
+describe("ContextMenu sizing", () => {
+  const LONG = "Move changes to a new worktree";
+
+  it("keeps an over-long label to one row, and the height to the item count", async () => {
+    const items = itemSpies(["Attach", LONG, "Kill"]);
+    const { frame } = await renderMenu({ items });
+
+    expectFrameIntegrity(frame);
+    const { height, lines, top } = boxBounds(frame);
+    expect(height).toBe(items.length + 2);
+    // Legibly cut rather than merely clipped, and still beside its hint.
+    const row = lines[top + 2]!;
+    expect(row).toContain("Move changes to");
+    expect(row).toContain("…");
+    expect(row).toContain("m");
+    expect(frame).not.toContain("worktree");
+  });
+
+  it("leaves the labels that fit alone", async () => {
+    // The longest labels the app actually authors, each with its hint.
+    const items: ContextMenuItem[] = [
+      { label: "New session here", hint: "n", color: theme.text, action() {} },
+      { label: "Attach agent", hint: "enter", color: theme.text, action() {} },
+      { label: "Prune Worktrees", hint: "W", color: theme.text, action() {} },
+      { label: "Open agent view", hint: "", color: theme.text, action() {} },
+    ];
+    const { frame } = await renderMenu({ items });
+
+    expectFrameIntegrity(frame);
+    for (const item of items) expect(frame).toContain(item.label);
+    expect(frame).not.toContain("…");
+  });
+
+  it("keeps the whole box on screen at the bottom edge", async () => {
+    // A wrapping label used to make the real box taller than the height the
+    // clamp was computed from, so the bottom border fell off the screen.
+    const items = itemSpies(["Attach", LONG, "Kill", "Restart"]);
+    const size = { width: 40, height: 10 };
+    const { frame } = await renderMenu({ items, x: 9999, y: 9999, size });
+
+    expectFrameIntegrity(frame);
+    const { top, bottom, height } = boxBounds(frame);
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(height).toBe(items.length + 2);
+    // Flush against the bottom row of the viewport, not past it.
+    expect(bottom).toBe(size.height - 1);
+    // Every item is still on screen, first and last included.
     expect(frame).toContain("Attach");
     expect(frame).toContain("Restart");
   });

--- a/src/tui/components/ContextMenu.tsx
+++ b/src/tui/components/ContextMenu.tsx
@@ -2,6 +2,7 @@ import type { Component } from "solid-js";
 import { createSignal, For } from "solid-js";
 import { useTerminalDimensions } from "@opentui/solid";
 import { MouseButton } from "@opentui/core";
+import { truncateText } from "../utils/format";
 import { theme } from "../theme";
 
 export interface ContextMenuItem {
@@ -19,11 +20,30 @@ interface ContextMenuProps {
 }
 
 const MENU_WIDTH = 22;
+/** Columns an item row actually has: the width less its border and padding. */
+const CONTENT_WIDTH = MENU_WIDTH - 4;
+
+/**
+ * The label as it fits beside its key hint, with the hint's own columns (and
+ * one of air) spent first.
+ *
+ * A label wide enough to wrap used to render two rows while still counting as
+ * one item, which made `menuHeight` — and with it the viewport clamp — wrong
+ * for the whole menu, silently. The rows are pinned to one row each so the
+ * height stays honest by construction; truncating here is what keeps an
+ * over-long label legible instead of merely clipped.
+ */
+function fittedLabel(label: string, hint: string): string {
+  const spent = hint ? hint.length + 1 : 0;
+  return truncateText(label, Math.max(1, CONTENT_WIDTH - spent));
+}
 
 export const ContextMenu: Component<ContextMenuProps> = (props) => {
   const dims = useTerminalDimensions();
   const [hovered, setHovered] = createSignal<number | null>(null);
 
+  /** One row per item plus the border. True by construction: every item row
+   *  is pinned to a single row below. */
   const menuHeight = () => props.items.length + 2;
 
   const clampedX = () => {
@@ -41,6 +61,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
       left={clampedX()}
       top={clampedY()}
       width={MENU_WIDTH}
+      height={menuHeight()}
       backgroundColor={theme.surface}
       borderStyle="single"
       borderColor={theme.border}
@@ -50,6 +71,8 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
         {(item, i) => (
           <box
             flexDirection="row"
+            height={1}
+            flexShrink={0}
             paddingLeft={1}
             paddingRight={1}
             backgroundColor={hovered() === i() ? theme.border : theme.surface}
@@ -61,7 +84,7 @@ export const ContextMenu: Component<ContextMenuProps> = (props) => {
             }}
           >
             <box flexGrow={1}>
-              <text fg={item.color}>{item.label}</text>
+              <text fg={item.color}>{fittedLabel(item.label, item.hint)}</text>
             </box>
             <text fg={theme.overlay}>{item.hint}</text>
           </box>

--- a/src/tui/components/NewSessionDialog.test.tsx
+++ b/src/tui/components/NewSessionDialog.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from "bun:test";
 import { testRender } from "@opentui/solid";
-import { NewSessionDialog, optionWindow } from "./NewSessionDialog";
+import { NewSessionDialog, optionWindow, wrapText } from "./NewSessionDialog";
+import { expectFrameIntegrity, squish } from "./test-helpers";
 import type { SpawnableAgent } from "../../lib/spawnable-agents";
 import type { NewSessionDraft } from "../store";
 
@@ -85,6 +86,32 @@ describe("optionWindow", () => {
       const { start, end } = optionWindow(9, selected, 4);
       expect(selected >= start && selected < end).toBe(true);
     }
+  });
+});
+
+describe("wrapText", () => {
+  it("breaks on words and keeps every line within the width", () => {
+    const lines = wrapText("Daemon is out of date - run restart", 13);
+    expect(lines).toEqual(["Daemon is out", "of date - run", "restart"]);
+    for (const line of lines) expect(line.length).toBeLessThanOrEqual(13);
+  });
+
+  it("breaks a word that cannot fit a line of its own", () => {
+    expect(wrapText("run ccmuxdaemonrestart now", 8)).toEqual([
+      "run",
+      "ccmuxdae",
+      "monresta",
+      "rt now",
+    ]);
+  });
+
+  it("always yields at least one line", () => {
+    expect(wrapText("", 10)).toEqual([""]);
+    expect(wrapText("   ", 10)).toEqual([""]);
+  });
+
+  it("gives up rather than looping when there is no width to wrap into", () => {
+    expect(wrapText("anything", 0)).toEqual(["anything"]);
   });
 });
 
@@ -221,6 +248,54 @@ describe("NewSessionDialog", () => {
     expect(frame).toContain("bad regex");
   });
 
+  /**
+   * Issue #85. The Agent field was budgeted one row for its error, so a
+   * message that wrapped left the dialog that many rows short and its last
+   * rows fell outside the border — at a sidebar width the third placement
+   * and the whole Where field disappeared.
+   */
+  it("keeps every row inside the border when the agent error wraps", async () => {
+    const error = "Daemon is out of date - run `ccmux daemon restart`";
+    const frame = await renderDialog({
+      agents: [],
+      agentsError: error,
+      width: 34,
+      height: 30,
+    });
+
+    expectFrameIntegrity(frame);
+    // The whole message survived, wherever the wrap fell.
+    expect(squish(frame)).toContain(squish(error));
+    // And so did every row budgeted below it, down to the last one.
+    expect(frame).toContain("New window");
+    expect(frame).toContain("Split right");
+    expect(frame).toContain("Split down");
+    expect(frame).toContain("Where");
+    expect(frame).toContain("Here");
+    expect(frame).toContain("Worktree");
+    expect(frame).toContain("Directory");
+    expect(frame).toContain("enter");
+  });
+
+  /** An error too tall for the screen cannot be shown whole; what it must
+   *  not do is push the fields below it off the dialog. */
+  it("caps an error taller than the screen instead of clipping the fields", async () => {
+    const frame = await renderDialog({
+      agents: [],
+      agentsError: "spawnable agents could not be resolved ".repeat(20),
+      width: 34,
+      height: 22,
+    });
+
+    expectFrameIntegrity(frame);
+    expect(frame).toContain("…");
+    expect(frame).toContain("Split down");
+    expect(frame).toContain("Directory");
+    expect(
+      frame.split("\n").filter((l) => l.includes("│")).length,
+    ).toBeLessThan(22);
+  });
+
   it("shortens a home-relative directory", async () => {
     const home = process.env.HOME ?? "/Users/dev";
     const frame = await renderDialog({
@@ -316,14 +391,7 @@ describe("NewSessionDialog destination", () => {
     const frame = setup.captureCharFrame();
     expect(frame).toContain("New worktree: fix-sidebar-");
     // Every row of the box still ends with its border.
-    const boxRows = frame
-      .split("\n")
-      .filter((row) => row.includes("│"))
-      .map((row) => row.trimEnd());
-    expect(boxRows.length).toBeGreaterThan(0);
-    for (const row of boxRows) {
-      expect(row.endsWith("│")).toBe(true);
-    }
+    expectFrameIntegrity(frame);
   });
 
   /**
@@ -337,12 +405,7 @@ describe("NewSessionDialog destination", () => {
     expect(frame).toContain("[New worktree (add a prompt)]");
     expect(frame).not.toContain("New worktree:");
     // The hint is budgeted like the name is; the border still closes.
-    for (const row of frame
-      .split("\n")
-      .filter((row) => row.includes("│"))
-      .map((row) => row.trimEnd())) {
-      expect(row.endsWith("│")).toBe(true);
-    }
+    expectFrameIntegrity(frame);
   });
 
   it("keeps the hint off the unselected row, where it is only noise", async () => {

--- a/src/tui/components/NewSessionDialog.test.tsx
+++ b/src/tui/components/NewSessionDialog.test.tsx
@@ -238,6 +238,12 @@ describe("NewSessionDialog", () => {
   it("reports an empty agent list instead of rendering nothing", async () => {
     const frame = await renderDialog({ agents: [] });
     expect(frame).toContain("No agents found on PATH");
+    setup.renderer.destroy();
+
+    // The daemon's error text is passed through as it comes, so an empty one
+    // reaches here and must not render as a blank red row.
+    const blank = await renderDialog({ agents: [], agentsError: "" });
+    expect(blank).toContain("No agents found on PATH");
   });
 
   it("surfaces the daemon's error when the list could not be resolved", async () => {

--- a/src/tui/components/NewSessionDialog.tsx
+++ b/src/tui/components/NewSessionDialog.tsx
@@ -71,6 +71,10 @@ export const DESTINATION_OPTIONS: readonly DestinationOption[] = [
  * here (it breaks mid-word at the tail of a line, and a space landing on the
  * boundary moves to the next row). Lines produced here already fit, so
  * nothing can wrap a second time and the budget cannot be wrong.
+ *
+ * Widths are UTF-16 code units, not display columns, so a line of wide
+ * glyphs (CJK) over-fills its column — the same limitation `truncateText`
+ * has, tracked in issue #91, whose real fix is a shared display-width helper.
  */
 export function wrapText(text: string, width: number): string[] {
   if (width <= 0) return [text];
@@ -256,7 +260,10 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
    * the same clipping.
    */
   const agentErrorLines = createMemo(() => {
-    const text = props.agentsError ?? "No agents found on PATH";
+    // `||`, not `??`: the daemon's own error text is passed straight through
+    // (App.tsx takes `body?.error` at its word), and a `{"error": ""}` body
+    // would otherwise render an empty red row that says nothing at all.
+    const text = props.agentsError || "No agents found on PATH";
     const lines = wrapText(text, contentWidth());
     const room = agentRoom();
     if (lines.length <= room) return lines;

--- a/src/tui/components/NewSessionDialog.tsx
+++ b/src/tui/components/NewSessionDialog.tsx
@@ -62,6 +62,43 @@ export const DESTINATION_OPTIONS: readonly DestinationOption[] = [
 ];
 
 /**
+ * Greedy word-wrap into lines of at most `width` columns, breaking a word
+ * that cannot fit on a line of its own.
+ *
+ * The dialog wraps its agent error itself rather than handing a long string
+ * to the renderer, because the height budget below has to know the row count
+ * BEFORE layout and the renderer's own wrapping cannot be predicted from
+ * here (it breaks mid-word at the tail of a line, and a space landing on the
+ * boundary moves to the next row). Lines produced here already fit, so
+ * nothing can wrap a second time and the budget cannot be wrong.
+ */
+export function wrapText(text: string, width: number): string[] {
+  if (width <= 0) return [text];
+  const lines: string[] = [];
+  let line = "";
+  for (const word of text.split(/\s+/).filter(Boolean)) {
+    let rest = word;
+    // Longer than the whole column: it can only be broken mid-word.
+    while (rest.length > width) {
+      if (line) {
+        lines.push(line);
+        line = "";
+      }
+      lines.push(rest.slice(0, width));
+      rest = rest.slice(width);
+    }
+    if (!line) line = rest;
+    else if (line.length + 1 + rest.length <= width) line += ` ${rest}`;
+    else {
+      lines.push(line);
+      line = rest;
+    }
+  }
+  if (line) lines.push(line);
+  return lines.length > 0 ? lines : [""];
+}
+
+/**
  * Slice of a longer option list to show, keeping the selection visible and
  * centered where it can be. Exported for its own tests: an off-by-one here
  * hides the row the user is on.
@@ -148,11 +185,14 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
    * constant type-checked fine and silently clipped the bottom row instead.
    */
   const fieldRows: Record<NewSessionField, () => number> = {
-    // Declared before `visibleAgents` but never CALLED before it exists:
-    // `otherFieldRows("agent")` is the only caller during that window and
-    // it filters this entry out. createMemo runs eagerly, so the ordering
-    // is load-bearing, not stylistic.
-    agent: () => Math.max(1, visibleAgents().length),
+    // Declared before `visibleAgents` and `agentErrorLines` but never CALLED
+    // before they exist: `otherFieldRows("agent")` is the only caller during
+    // that window and it filters this entry out. createMemo runs eagerly, so
+    // the ordering is load-bearing, not stylistic.
+    agent: () =>
+      showAgentError()
+        ? agentErrorLines().length
+        : Math.max(1, visibleAgents().length),
     placement: () => (stacked() ? PLACEMENT_OPTIONS.length : 1),
     destination: () => (stacked() ? DESTINATION_OPTIONS.length : 1),
     prompt: () => 1,
@@ -166,19 +206,24 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
       0,
     );
 
+  /** Rows the agent field may claim before the dialog outgrows the screen:
+   *  everything the other fields and the chrome have not already spent. */
+  const agentRoom = createMemo(() =>
+    Math.max(
+      1,
+      dims().height - FIXED_CHROME_ROWS - hintRows() - otherFieldRows("agent"),
+    ),
+  );
+
   /** Where the visible slice of the agent list starts. Split from the slice
    *  itself so the rows can derive their absolute number from it without the
    *  slice having to carry a wrapper object per entry (see below). */
   const agentWindowStart = createMemo(() => {
     const list = agents();
-    const room = Math.max(
-      1,
-      dims().height - FIXED_CHROME_ROWS - hintRows() - otherFieldRows("agent"),
-    );
     return optionWindow(
       list.length,
       selectedAgentIndex(),
-      Math.min(room, list.length),
+      Math.min(agentRoom(), list.length),
     ).start;
   });
 
@@ -193,12 +238,36 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
    */
   const visibleAgents = createMemo(() => {
     const list = agents();
-    const room = Math.max(
-      1,
-      dims().height - FIXED_CHROME_ROWS - hintRows() - otherFieldRows("agent"),
-    );
     const start = agentWindowStart();
-    return list.slice(start, start + Math.min(room, list.length));
+    return list.slice(start, start + Math.min(agentRoom(), list.length));
+  });
+
+  /** The agent field carries an error instead of a list: the daemon answered
+   *  with one, or answered with nothing to spawn. */
+  const showAgentError = () => props.agents !== null && agents().length === 0;
+
+  /**
+   * The agent error, pre-wrapped to the content column and capped at the rows
+   * the field actually has. Budgeting this field as one row was what clipped
+   * the dialog's bottom rows outside its border whenever the message wrapped
+   * (issue #85) — the stale-daemon message is three rows at a sidebar width.
+   * Capping matters too: an error longer than the screen would otherwise push
+   * the height past `dims().height`, where the clamp below re-creates exactly
+   * the same clipping.
+   */
+  const agentErrorLines = createMemo(() => {
+    const text = props.agentsError ?? "No agents found on PATH";
+    const lines = wrapText(text, contentWidth());
+    const room = agentRoom();
+    if (lines.length <= room) return lines;
+    // Say that it was cut, rather than ending mid-sentence: the last visible
+    // row carries as much of the remainder as fits, with an ellipsis.
+    const kept = lines.slice(0, room);
+    kept[room - 1] = truncateText(
+      lines.slice(room - 1).join(" "),
+      contentWidth(),
+    );
+    return kept;
   });
 
   const height = () =>
@@ -291,14 +360,28 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
         <box flexDirection="column" flexGrow={1}>
           <Show
             when={props.agents !== null}
-            fallback={<text fg={theme.overlay}>Loading agents...</text>}
+            fallback={
+              <box height={1}>
+                <text fg={theme.overlay}>
+                  {truncateText("Loading agents...", contentWidth())}
+                </text>
+              </box>
+            }
           >
             <Show
               when={agents().length > 0}
               fallback={
-                <text fg={theme.red}>
-                  {props.agentsError ?? "No agents found on PATH"}
-                </text>
+                /* One row per pre-wrapped line, which is the same count the
+                   height was budgeted from. Left to the renderer instead,
+                   a long message wrapped past its single budgeted row and
+                   pushed the dialog's last rows outside the border. */
+                <For each={agentErrorLines()}>
+                  {(line) => (
+                    <box height={1}>
+                      <text fg={theme.red}>{line}</text>
+                    </box>
+                  )}
+                </For>
               }
             >
               <For each={visibleAgents()}>

--- a/src/tui/components/test-helpers.tsx
+++ b/src/tui/components/test-helpers.tsx
@@ -1,3 +1,4 @@
+import { expect } from "bun:test";
 import type { EnrichedSession, Session } from "../../types";
 import type { FilteredSession, StatusSummary } from "../utils/grouping";
 
@@ -95,6 +96,25 @@ export function membersFromSummary(summary: StatusSummary): FilteredSession[] {
   add(summary.waitingGeneric, { status: "waiting", attentionType: null });
   add(summary.idle, { status: "idle" });
   return members;
+}
+
+/**
+ * Assert every row of a rendered single-border box closes with its border.
+ *
+ * The check that catches content wrapping past the rows its container
+ * budgeted for it: the content assertions still pass in that case (the text
+ * is all there), while the box is drawn wrong. Live captures, not tests, are
+ * what caught the last two instances of it.
+ */
+export function expectFrameIntegrity(frame: string): void {
+  const boxRows = frame
+    .split("\n")
+    .filter((row) => row.includes("│"))
+    .map((row) => row.trimEnd());
+  expect(boxRows.length).toBeGreaterThan(0);
+  for (const row of boxRows) {
+    expect(row.endsWith("│")).toBe(true);
+  }
 }
 
 // Strip single-border box chars and whitespace from a captured frame so an

--- a/src/tui/components/test-helpers.tsx
+++ b/src/tui/components/test-helpers.tsx
@@ -99,22 +99,41 @@ export function membersFromSummary(summary: StatusSummary): FilteredSession[] {
 }
 
 /**
- * Assert every row of a rendered single-border box closes with its border.
+ * Assert a rendered single-border box is structurally intact: every row that
+ * carries a border character closes with one, and — when `expectedHeight` is
+ * given — the box spans exactly that many rows, its own borders included.
  *
- * The check that catches content wrapping past the rows its container
- * budgeted for it: the content assertions still pass in that case (the text
- * is all there), while the box is drawn wrong. Live captures, not tests, are
- * what caught the last two instances of it.
+ * Be clear about what the first half does NOT catch, because it reads like a
+ * general overflow detector and is not one. It only inspects rows that
+ * already contain `│`, so content that spills past the rows its container
+ * budgeted for it passes untouched: the overflowing rows have no border
+ * character to check, and garbling INSIDE the box leaves the borders intact.
+ * Run against the frames from both bugs this helper's tests cover (#85, #82)
+ * it passed on both. Treat it as a cheap structural check and let the height
+ * and content assertions carry the real weight — `expectedHeight` is here so
+ * that the one line that does catch a box drawn taller than it claims can
+ * ride along with it.
  */
-export function expectFrameIntegrity(frame: string): void {
-  const boxRows = frame
-    .split("\n")
+export function expectFrameIntegrity(
+  frame: string,
+  expectedHeight?: number,
+): void {
+  const lines = frame.split("\n");
+  const boxRows = lines
     .filter((row) => row.includes("│"))
     .map((row) => row.trimEnd());
   expect(boxRows.length).toBeGreaterThan(0);
   for (const row of boxRows) {
     expect(row.endsWith("│")).toBe(true);
   }
+  if (expectedHeight === undefined) return;
+  // Corners, not the `│` rows: a box whose bottom fell off the viewport has
+  // no `└` to find, which is exactly the failure worth reporting.
+  const top = lines.findIndex((row) => row.includes("┌"));
+  const bottom = lines.findIndex((row) => row.includes("└"));
+  expect(top).toBeGreaterThanOrEqual(0);
+  expect(bottom).toBeGreaterThanOrEqual(0);
+  expect(bottom - top + 1).toBe(expectedHeight);
 }
 
 // Strip single-border box chars and whitespace from a captured frame so an


### PR DESCRIPTION
## Overview

Fixes the two wrapped-content sizing bugs in the TUI: the new-session dialog clipping its bottom rows when the Agent field shows a wrapped error, and the context menu's height and viewport clamp silently breaking when a label wraps.

Resolves #85
Resolves #82

## Motivation

Both surfaces sized themselves from a row count that assumed their content fit on one row. At 34 columns the stale-daemon error left the dialog three rows short, so `3 Split down` and the entire `Where` field (the worktree destination) fell outside the border. The menu's `items.length + 2` fed the viewport clamp while a wrapping label rendered two rows, pushing the bottom border off screen near the bottom edge. Both failed silently: content assertions pass because the text is all there, so only live captures caught them.

## Changes

### New-session dialog (#85)

- **NewSessionDialog.tsx** - Adds `wrapText()` (greedy word wrap) and pre-wraps the agent error to the content width, one pinned row per line, capped at the rows the field actually has (with an ellipsis when cut). `fieldRows.agent` budgets from that same line count, so the height is derived from what is drawn rather than estimated. `Loading agents...` now goes through `truncateText` like every other string in the dialog.
- **NewSessionDialog.test.tsx** - Error state at 34 columns asserting frame integrity plus every row below the error (`Split down`, `Where`, `Worktree`, `Directory`); error-taller-than-screen cap; `wrapText` unit tests.

> [!NOTE]
> The issue suggested estimating wrapped rows with `Math.ceil(len / width)`. That was probed against opentui's native wrapping over a 121-case corpus and no char-count formula was a reliable upper bound (it word-wraps, carries boundary spaces to the next row, and sometimes hard-breaks a word early). An under-prediction is exactly the clip being fixed, so the dialog wraps the text itself: pre-fitted lines cannot wrap again, making the budget honest by construction.

### Context menu (#82)

- **ContextMenu.tsx** - Labels truncate to the space left beside their key hint, item rows are pinned to one row, and the outer box now sets `height={menuHeight()}` so the clamp's input matches the real box. No label authored today changes; a test pins the four longest real label/hint pairs and asserts none gain an ellipsis.
- **ContextMenu.test.tsx** - Net-new border/clamp coverage: over-long label keeps `items.length + 2` height with a legible ellipsis, and a bottom-edge placement keeps both borders on screen.

### Shared test machinery

- **test-helpers.tsx** - `expectFrameIntegrity()` (every box row closes with `│`), replacing two inline copies and guarding this class of bug for future components.

## Breaking Changes

None

## Testing

- [x] Full `bun test`: 3756 pass / 0 fail; `bun run typecheck` clean (verified independently)
- [x] Pre-fix repro confirmed for both: with the fix stashed, the new dialog assertions catch the missing `Split down` and `Where` rows at 34 columns, and the menu test catches the collided label and lost bottom border
- [x] Live capture of the error state via a stub daemon 404ing `/agents`: the wrapped stale-daemon message renders across 4 rows at 34 columns with every field present and the border intact (also clean at 30 and 40 columns)
- [x] Live capture of the context menu via injected SGR right-click: full labels, bottom-edge clamp flush with the last row
- [x] Live picker capture of the healthy dialog at 200 and 60 columns from this branch's build

One pre-existing cosmetic issue observed while verifying, untouched here: at 30 columns the `Where` row's compact option label clips as `Worktre` because `optionLabel` has no truncation of its own. The border stays intact; candidate follow-up.
