### PR TITLE
fix(spawn): Switch the client for cross-session --target

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ the end of your session, which leaves every existing window index alone; pass
 `--target` accepts any pane on the server, including one in a _different_ tmux
 session: ccmux creates the pane there and moves your client over to it, the
 same jump `ccmux switch` makes. Pass `--detach` to leave your view where it is.
+That jump needs a client of its own to move, so it only happens when you run
+`ccmux spawn` from inside the session you are attached to; run from outside
+tmux, or from a detached session, it creates the pane without switching (use
+`ccmux switch` afterwards).
 
 `--prompt` starts the agent interactively with the prompt already submitted.
 It is supported for the agents whose interactive-with-prompt invocation ccmux

--- a/README.md
+++ b/README.md
@@ -284,9 +284,9 @@ the end of your session, which leaves every existing window index alone; pass
 `--target <pane-id>` to insert one directly after that pane's window instead
 (tmux renumbers the windows after it), or `--target none` to let tmux place it.
 
-Targeting a pane in a _different_ tmux session creates the pane there but does
-not move you to it, so pair that with `--detach`
-(see [#75](https://github.com/epilande/ccmux/issues/75)).
+`--target` accepts any pane on the server, including one in a _different_ tmux
+session: ccmux creates the pane there and moves your client over to it, the
+same jump `ccmux switch` makes. Pass `--detach` to leave your view where it is.
 
 `--prompt` starts the agent interactively with the prompt already submitted.
 It is supported for the agents whose interactive-with-prompt invocation ccmux

--- a/src/commands/spawn.test.ts
+++ b/src/commands/spawn.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, afterEach } from "bun:test";
+import { describe, it, expect, mock, spyOn, afterEach } from "bun:test";
 
 // Neutralize ensureDaemon so the action never spawns/probes a real daemon.
 // Counted as well as neutralized: argument validation that runs BEFORE it is
@@ -23,6 +23,7 @@ interface SpawnBody {
   split: unknown;
   target?: string;
   callerPane?: string;
+  callerTty?: string;
   detach: boolean;
   worktree?: { name?: string; base?: string };
 }
@@ -224,6 +225,133 @@ describe("ccmux spawn caller pane", () => {
       expect(bodies[0]?.callerPane).toBeUndefined();
     } finally {
       restoreEnv();
+      restore();
+    }
+  });
+});
+
+describe("ccmux spawn caller client tty", () => {
+  // The daemon is attached to no tmux client, so a `--target` in another
+  // session can only be switched to by naming the caller's client with
+  // `switch-client -c <tty>` (issue #75). Only the CLI can find that tty.
+
+  const IN_TMUX = {
+    TMUX_PANE: "%12",
+    TMUX: "/tmp/tmux-501/default,123,0",
+    CCMUX_CALLER_PWD: "/caller/dir",
+  };
+
+  /**
+   * Stub the `tmux display-message` the tty lookup shells out to. `spyOn`
+   * rather than `mock.module`, which is process-wide and leaks into sibling
+   * test files.
+   */
+  function withTmuxClientTty(tty: string) {
+    const argv: string[][] = [];
+    const spy = spyOn(Bun, "spawn").mockImplementation(((spawned: string[]) => {
+      argv.push(spawned);
+      return {
+        exited: Promise.resolve(0),
+        stdout: new Blob([`${tty}\n`]).stream(),
+        stderr: new Blob([""]).stream(),
+      };
+    }) as unknown as typeof Bun.spawn);
+    return { argv, restore: () => spy.mockRestore() };
+  }
+
+  it("sends the attached client's tty alongside an explicit --target", async () => {
+    console.log = () => {};
+    const { bodies, restore } = withFetchCapture("/tmp/tmux-501/default");
+    const tmux = withTmuxClientTty("/dev/ttys085");
+    const restoreEnv = withEnv(IN_TMUX);
+    try {
+      await runSpawn(["--target", "%5"]);
+      expect(bodies[0]?.callerTty).toBe("/dev/ttys085");
+      // The CLIENT's tty, which is what `switch-client -c` takes — not the
+      // pane's own pty, which tmux would not resolve to a client at all.
+      expect(tmux.argv[0]).toEqual([
+        "tmux",
+        "display-message",
+        "-p",
+        "#{client_tty}",
+      ]);
+    } finally {
+      restoreEnv();
+      tmux.restore();
+      restore();
+    }
+  });
+
+  it("does not look one up without a --target", async () => {
+    // A spawn placed by `callerPane` lands in the caller's own session by
+    // construction, so there is never a client to move: paying for a tmux
+    // round-trip on every ordinary spawn would buy nothing.
+    console.log = () => {};
+    const { bodies, restore } = withFetchCapture("/tmp/tmux-501/default");
+    const tmux = withTmuxClientTty("/dev/ttys085");
+    const restoreEnv = withEnv(IN_TMUX);
+    try {
+      await runSpawn([]);
+      expect(bodies[0]?.callerTty).toBeUndefined();
+      expect(tmux.argv).toHaveLength(0);
+    } finally {
+      restoreEnv();
+      tmux.restore();
+      restore();
+    }
+  });
+
+  it("omits it under --detach, which asks for no switch at all", async () => {
+    console.log = () => {};
+    const { bodies, restore } = withFetchCapture("/tmp/tmux-501/default");
+    const tmux = withTmuxClientTty("/dev/ttys085");
+    const restoreEnv = withEnv(IN_TMUX);
+    try {
+      await runSpawn(["--target", "%5", "--detach"]);
+      expect(bodies[0]?.callerTty).toBeUndefined();
+      expect(bodies[0]?.detach).toBe(true);
+      expect(tmux.argv).toHaveLength(0);
+    } finally {
+      restoreEnv();
+      tmux.restore();
+      restore();
+    }
+  });
+
+  it("drops it when the daemon watches another tmux server", async () => {
+    // Same reason `callerPane` is dropped: the daemon would be switching a
+    // client on a server whose panes have nothing to do with ours.
+    console.log = () => {};
+    const { bodies, restore } = withFetchCapture("/tmp/tmux-501/other");
+    const tmux = withTmuxClientTty("/dev/ttys085");
+    const restoreEnv = withEnv(IN_TMUX);
+    try {
+      await runSpawn(["--target", "%5"]);
+      expect(bodies[0]?.callerTty).toBeUndefined();
+      expect(tmux.argv).toHaveLength(0);
+    } finally {
+      restoreEnv();
+      tmux.restore();
+      restore();
+    }
+  });
+
+  it("sends nothing when run outside tmux", async () => {
+    console.log = () => {};
+    const { bodies, restore } = withFetchCapture(null);
+    const tmux = withTmuxClientTty("/dev/ttys085");
+    const restoreEnv = withEnv({
+      TMUX: undefined,
+      TMUX_PANE: undefined,
+      CCMUX_CALLER_PWD: "/caller/dir",
+    });
+    try {
+      await runSpawn(["--target", "%5"]);
+      expect(bodies[0]?.callerTty).toBeUndefined();
+      expect(tmux.argv).toHaveLength(0);
+    } finally {
+      restoreEnv();
+      tmux.restore();
       restore();
     }
   });

--- a/src/commands/spawn.ts
+++ b/src/commands/spawn.ts
@@ -4,6 +4,7 @@ import { getDaemonUrl } from "../lib/config";
 import { ensureDaemon } from "./shared";
 import { PANE_ID_PATTERN, type SpawnSplit } from "../daemon/spawn-command";
 import { isSameTmuxServer } from "../lib/tmux-server";
+import { resolveCurrentTmuxClientTty } from "../lib/tmux-client";
 import { BUILTIN_AGENTS } from "../lib/agents";
 
 interface SpawnResponse {
@@ -54,6 +55,31 @@ function callerPane(daemonSocket: string | null): string | undefined {
   const pane = process.env.TMUX_PANE;
   if (!pane || !PANE_ID_PATTERN.test(pane)) return undefined;
   return isSameTmuxServer(daemonSocket) ? pane : undefined;
+}
+
+/**
+ * The tty of the tmux client the caller is attached with, so the daemon can
+ * move it to a pane in ANOTHER session: `select-window` only changes which
+ * window is current within the target's session, and the daemon has no client
+ * of its own to `switch-client` with. `src/commands/switch.ts` solves the same
+ * problem the same way.
+ *
+ * Resolved only when an explicit `--target` was given, because that is the
+ * only way a spawn can land outside the caller's session: without one the new
+ * pane goes wherever `callerPane` is, which IS the caller's session. Skipping
+ * it otherwise keeps an ordinary `ccmux spawn` at exactly the tmux round-trips
+ * it always made.
+ *
+ * Same cross-server gate as {@link callerPane}, and pointless when nothing
+ * will be switched (`--detach`, or running outside tmux with no client to
+ * name).
+ */
+async function callerClientTty(
+  daemonSocket: string | null,
+): Promise<string | undefined> {
+  if (!process.env.TMUX) return undefined;
+  if (!isSameTmuxServer(daemonSocket)) return undefined;
+  return (await resolveCurrentTmuxClientTty()) ?? undefined;
 }
 
 /**
@@ -166,6 +192,12 @@ export function createSpawnCommand(): Command {
                 base: options.base,
               };
 
+        // One `/server-info` round-trip for both placement fields, which have
+        // the same cross-server gate. Still skipped entirely when placement is
+        // opted out of, since neither field is sent then.
+        const daemonSocket = optedOut ? null : await daemonTmuxSocket();
+        const detach = options.detach ?? false;
+
         try {
           const response = await fetch(`${getDaemonUrl()}/spawn`, {
             method: "POST",
@@ -185,10 +217,14 @@ export function createSpawnCommand(): Command {
               prompt: options.prompt,
               split: options.split ?? false,
               target: explicitTarget,
-              callerPane: optedOut
-                ? undefined
-                : callerPane(await daemonTmuxSocket()),
-              detach: options.detach ?? false,
+              callerPane: optedOut ? undefined : callerPane(daemonSocket),
+              // What the daemon switches to the new pane with when that pane
+              // lands in another session; see `callerClientTty`.
+              callerTty:
+                explicitTarget && !detach
+                  ? await callerClientTty(daemonSocket)
+                  : undefined,
+              detach,
               worktree,
             }),
           });

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -3511,8 +3511,15 @@ describe("POST /spawn", () => {
    * Stub `Bun.spawn`, recording every argv. Outcomes are matched by tmux
    * subcommand so a test only has to describe the calls it cares about;
    * anything unlisted succeeds with empty output.
+   *
+   * `panes` overrides the pane probe per pane id (`%12` -> `"@9 $3"`), which
+   * a subcommand-keyed outcome cannot express: the cross-session cases probe
+   * two different panes and need two different answers.
    */
-  function withTmuxRecorder(outcomes: Record<string, TmuxOutcome> = {}) {
+  function withTmuxRecorder(
+    outcomes: Record<string, TmuxOutcome> = {},
+    panes: Record<string, string> = {},
+  ) {
     const original = Bun.spawn;
     const argv: string[][] = [];
     const defaults: Record<string, TmuxOutcome> = {
@@ -3522,7 +3529,14 @@ describe("POST /spawn", () => {
     Bun.spawn = ((spawned: string[]) => {
       argv.push(spawned);
       const key = spawned[1] ?? "";
-      const next = outcomes[key] ?? defaults[key] ?? { code: 0, out: "%99\n" };
+      // `display-message -p -t <pane> -F ...`
+      const probed =
+        key === "display-message" ? panes[spawned[4] ?? ""] : undefined;
+      const next = (probed === undefined
+        ? undefined
+        : { code: 0, out: `${probed}\n` }) ??
+        outcomes[key] ??
+        defaults[key] ?? { code: 0, out: "%99\n" };
       if ("throws" in next) {
         throw new Error("posix_spawn failed: E2BIG (Argument list too long)");
       }
@@ -3991,6 +4005,150 @@ describe("POST /spawn", () => {
     } finally {
       restore();
     }
+  });
+
+  describe("cross-session target (#75)", () => {
+    // `--target` accepts any pane on the server, so it can name one in a
+    // DIFFERENT session than the caller. `select-window` cannot move an
+    // attached client between sessions — it only changes which window is
+    // current inside the target's session — so the spawn used to report
+    // success and leave the user where they were. Verified by hand on an
+    // isolated tmux server: a client attached to A stayed on A across
+    // `select-window -t <pane in B>` and followed `switch-client -c <tty>`.
+    const twoSessions = { "%1": "@1 $1", "%2": "@2 $2" };
+
+    /** The tmux argv that was supposed to move the caller's view. */
+    function focusCall(argv: string[][]): string[] | undefined {
+      return argv.find(
+        (a) => a[1] === "select-window" || a[1] === "switch-client",
+      );
+    }
+
+    it("switches the caller's client to a target in another session", async () => {
+      const { internals } = serverForAgents([promptAgent]);
+      const { argv, restore } = withTmuxRecorder({}, twoSessions);
+      try {
+        const res = await internals.handleRequest(
+          spawnRequest({
+            agent: "prompty",
+            cwd,
+            target: "%2",
+            callerPane: "%1",
+            callerTty: "/dev/ttys004",
+          }),
+        );
+
+        expect(res.status).toBe(200);
+        expect(focusCall(argv)).toEqual([
+          "tmux",
+          "switch-client",
+          "-c",
+          "/dev/ttys004",
+          "-t",
+          "%99",
+        ]);
+      } finally {
+        restore();
+      }
+    });
+
+    it("still just selects the window when the target is in the caller's session", async () => {
+      // Byte-for-byte the pre-fix behavior, which is the whole safety
+      // property: a spawn in your own session must not touch your client.
+      const { internals } = serverForAgents([promptAgent]);
+      const { argv, restore } = withTmuxRecorder(
+        {},
+        { "%1": "@1 $1", "%2": "@2 $1" },
+      );
+      try {
+        await internals.handleRequest(
+          spawnRequest({
+            agent: "prompty",
+            cwd,
+            target: "%2",
+            callerPane: "%1",
+            callerTty: "/dev/ttys004",
+          }),
+        );
+
+        expect(focusCall(argv)).toEqual(["tmux", "select-window", "-t", "%99"]);
+        expect(argv.map((a) => a[1])).not.toContain("switch-client");
+      } finally {
+        restore();
+      }
+    });
+
+    it("suppresses the switch entirely when detached", async () => {
+      const { internals } = serverForAgents([promptAgent]);
+      const { argv, restore } = withTmuxRecorder({}, twoSessions);
+      try {
+        await internals.handleRequest(
+          spawnRequest({
+            agent: "prompty",
+            cwd,
+            target: "%2",
+            callerPane: "%1",
+            callerTty: "/dev/ttys004",
+            detach: true,
+          }),
+        );
+
+        expect(focusCall(argv)).toBeUndefined();
+        // And the caller's pane is not even probed: nothing downstream of
+        // `--detach` can use the answer.
+        expect(argv.filter((a) => a[1] === "display-message")).toHaveLength(1);
+      } finally {
+        restore();
+      }
+    });
+
+    it("selects the window when no client tty was sent", async () => {
+      // Older CLIs, and every caller that places by `callerPane` alone. The
+      // daemon has no client of its own, so with nothing to name it falls
+      // back rather than moving whichever client tmux would have picked.
+      const { internals } = serverForAgents([promptAgent]);
+      const { argv, restore } = withTmuxRecorder({}, twoSessions);
+      try {
+        await internals.handleRequest(
+          spawnRequest({
+            agent: "prompty",
+            cwd,
+            target: "%2",
+            callerPane: "%1",
+          }),
+        );
+
+        expect(focusCall(argv)).toEqual(["tmux", "select-window", "-t", "%99"]);
+        // The second probe is skipped too, so a spawn with no tty costs
+        // exactly the tmux round-trips it always did.
+        expect(argv.filter((a) => a[1] === "display-message")).toHaveLength(1);
+      } finally {
+        restore();
+      }
+    });
+
+    it("rejects a callerTty that is not a device path", async () => {
+      const { internals } = serverForAgents([promptAgent]);
+      const { argv, restore } = withTmuxRecorder({}, twoSessions);
+      try {
+        const res = await internals.handleRequest(
+          spawnRequest({
+            agent: "prompty",
+            cwd,
+            target: "%2",
+            callerTty: "not-a-tty",
+          }),
+        );
+
+        expect(res.status).toBe(400);
+        expect(((await res.json()) as { error: string }).error).toContain(
+          "callerTty",
+        );
+        expect(argv).toHaveLength(0);
+      } finally {
+        restore();
+      }
+    });
   });
 
   it("succeeds without killing the pane when select-window itself throws", async () => {

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -3505,26 +3505,33 @@ describe("POST /spawn", () => {
    * (E2BIG on macOS, a single over-128KiB argument on Linux) rather than
    * exiting non-zero.
    */
-  type TmuxOutcome = { code: number; out: string } | { throws: true };
+  type TmuxOutcome =
+    | { code: number; out: string; err?: string }
+    | { throws: true };
 
   /**
    * Stub `Bun.spawn`, recording every argv. Outcomes are matched by tmux
    * subcommand so a test only has to describe the calls it cares about;
    * anything unlisted succeeds with empty output.
    *
-   * `panes` overrides the pane probe per pane id (`%12` -> `"@9 $3"`), which
-   * a subcommand-keyed outcome cannot express: the cross-session cases probe
-   * two different panes and need two different answers.
+   * `panes` overrides the pane probe per pane id (`%12` -> `"@9 $3"`), and
+   * `clients` the attached-client probe per session id (`$3` -> ttys), neither
+   * of which a subcommand-keyed outcome can express: the cross-session cases
+   * probe two different panes and need two different answers, and an empty
+   * client list is a meaningful answer rather than a missing one.
    */
   function withTmuxRecorder(
     outcomes: Record<string, TmuxOutcome> = {},
     panes: Record<string, string> = {},
+    clients: Record<string, string[]> = {},
   ) {
     const original = Bun.spawn;
     const argv: string[][] = [];
     const defaults: Record<string, TmuxOutcome> = {
       // Pane probe: `#{window_id} #{session_id}` for a live pane.
       "display-message": { code: 0, out: "@9 $3\n" },
+      // Attached-client probe: a session with nobody looking at it.
+      "list-clients": { code: 0, out: "" },
     };
     Bun.spawn = ((spawned: string[]) => {
       argv.push(spawned);
@@ -3532,9 +3539,15 @@ describe("POST /spawn", () => {
       // `display-message -p -t <pane> -F ...`
       const probed =
         key === "display-message" ? panes[spawned[4] ?? ""] : undefined;
+      // `list-clients -t <session> -F ...`
+      const attached =
+        key === "list-clients" ? clients[spawned[3] ?? ""] : undefined;
       const next = (probed === undefined
         ? undefined
         : { code: 0, out: `${probed}\n` }) ??
+        (attached === undefined
+          ? undefined
+          : { code: 0, out: `${attached.join("\n")}\n` }) ??
         outcomes[key] ??
         defaults[key] ?? { code: 0, out: "%99\n" };
       if ("throws" in next) {
@@ -3543,7 +3556,7 @@ describe("POST /spawn", () => {
       return {
         exited: Promise.resolve(next.code),
         stdout: new Blob([next.out]).stream(),
-        stderr: new Blob([""]).stream(),
+        stderr: new Blob([next.err ?? ""]).stream(),
       };
     }) as unknown as typeof Bun.spawn;
     return { argv, restore: () => (Bun.spawn = original) };
@@ -4016,6 +4029,8 @@ describe("POST /spawn", () => {
     // isolated tmux server: a client attached to A stayed on A across
     // `select-window -t <pane in B>` and followed `switch-client -c <tty>`.
     const twoSessions = { "%1": "@1 $1", "%2": "@2 $2" };
+    /** The caller (session `$1`) has a terminal of its own attached. */
+    const callerAttached = { $1: ["/dev/ttys004"] };
 
     /** The tmux argv that was supposed to move the caller's view. */
     function focusCall(argv: string[][]): string[] | undefined {
@@ -4026,7 +4041,11 @@ describe("POST /spawn", () => {
 
     it("switches the caller's client to a target in another session", async () => {
       const { internals } = serverForAgents([promptAgent]);
-      const { argv, restore } = withTmuxRecorder({}, twoSessions);
+      const { argv, restore } = withTmuxRecorder(
+        {},
+        twoSessions,
+        callerAttached,
+      );
       try {
         const res = await internals.handleRequest(
           spawnRequest({
@@ -4073,6 +4092,73 @@ describe("POST /spawn", () => {
 
         expect(focusCall(argv)).toEqual(["tmux", "select-window", "-t", "%99"]);
         expect(argv.map((a) => a[1])).not.toContain("switch-client");
+        // Nothing to verify, so nothing is asked.
+        expect(argv.map((a) => a[1])).not.toContain("list-clients");
+      } finally {
+        restore();
+      }
+    });
+
+    it("refuses to move a client that is not in the caller's session", async () => {
+      // The bystander case, and the reason the tty alone is not enough:
+      // spawning from a DETACHED session makes tmux's `#{client_tty}` fall
+      // back to the most-recently-active client of ANY session, so the CLI
+      // honestly reports a terminal that belongs to someone else's work.
+      // Switching it would drag that user into a pane they never asked for —
+      // strictly worse than the `select-window` this replaced.
+      const { internals } = serverForAgents([promptAgent]);
+      const { argv, restore } = withTmuxRecorder({}, twoSessions, {
+        // The caller's session `$1` has nobody attached; the tty the CLI sent
+        // is a client of some third session entirely.
+        $1: [],
+      });
+      try {
+        const res = await internals.handleRequest(
+          spawnRequest({
+            agent: "prompty",
+            cwd,
+            target: "%2",
+            callerPane: "%1",
+            callerTty: "/dev/ttys004",
+          }),
+        );
+
+        expect(res.status).toBe(200);
+        expect(focusCall(argv)).toEqual(["tmux", "select-window", "-t", "%99"]);
+        expect(argv.map((a) => a[1])).not.toContain("switch-client");
+        // Membership is asked about the CALLER's session, not the target's.
+        expect(argv.find((a) => a[1] === "list-clients")).toEqual([
+          "tmux",
+          "list-clients",
+          "-t",
+          "$1",
+          "-F",
+          "#{client_tty}",
+        ]);
+      } finally {
+        restore();
+      }
+    });
+
+    it("refuses when the membership probe itself fails", async () => {
+      const { internals } = serverForAgents([promptAgent]);
+      const { argv, restore } = withTmuxRecorder(
+        { "list-clients": { code: 1, out: "" } },
+        twoSessions,
+      );
+      try {
+        const res = await internals.handleRequest(
+          spawnRequest({
+            agent: "prompty",
+            cwd,
+            target: "%2",
+            callerPane: "%1",
+            callerTty: "/dev/ttys004",
+          }),
+        );
+
+        expect(res.status).toBe(200);
+        expect(focusCall(argv)).toEqual(["tmux", "select-window", "-t", "%99"]);
       } finally {
         restore();
       }
@@ -4123,6 +4209,46 @@ describe("POST /spawn", () => {
         // exactly the tmux round-trips it always did.
         expect(argv.filter((a) => a[1] === "display-message")).toHaveLength(1);
       } finally {
+        restore();
+      }
+    });
+
+    it("logs a focus command tmux refused instead of dropping it", async () => {
+      // The response still says `success: true`, and honestly so — the pane
+      // exists and the agent is running. But a switch that silently did
+      // nothing would leave the user with a view that never moved and no
+      // trace anywhere of why. `can't find client` is the live failure mode
+      // now that the tty arrives from off-process.
+      const errors: string[] = [];
+      const errorSpy = spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => {
+          errors.push(args.join(" "));
+        },
+      );
+      const { internals } = serverForAgents([promptAgent]);
+      const { restore } = withTmuxRecorder(
+        { "switch-client": { code: 1, out: "", err: "can't find client\n" } },
+        twoSessions,
+        callerAttached,
+      );
+      try {
+        const res = await internals.handleRequest(
+          spawnRequest({
+            agent: "prompty",
+            cwd,
+            target: "%2",
+            callerPane: "%1",
+            callerTty: "/dev/ttys004",
+          }),
+        );
+
+        expect(res.status).toBe(200);
+        const logged = errors.join("\n");
+        expect(logged).toContain("switch-client");
+        expect(logged).toContain("%99");
+        expect(logged).toContain("can't find client");
+      } finally {
+        errorSpy.mockRestore();
         restore();
       }
     });

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -18,9 +18,11 @@ import {
 import {
   buildAgentForkCommand,
   buildAgentSpawnCommand,
+  buildSpawnFocusArgv,
   buildTmuxSpawnArgv,
   forkResumesByIdAlone,
   normalizeBoolean,
+  normalizeClientTty,
   normalizePrompt,
   normalizeSplit,
   normalizeTarget,
@@ -2323,6 +2325,7 @@ export class DaemonServer {
       split?: SpawnSplit;
       target?: string;
       callerPane?: string;
+      callerTty?: unknown;
       detach?: unknown;
       worktree?: unknown;
     };
@@ -2392,6 +2395,19 @@ export class DaemonServer {
       );
     }
     const callerPane = callerPaneResult.value;
+
+    // The tty of the tmux client the caller is attached with. Only the CLI
+    // knows it (the daemon has no client of its own), and it is only ever
+    // used to move that client to a pane in another session — see
+    // `buildSpawnFocusArgv`.
+    const callerTtyResult = normalizeClientTty(body.callerTty);
+    if (!callerTtyResult.ok) {
+      return Response.json(
+        { error: callerTtyResult.error },
+        { status: 400, headers },
+      );
+    }
+    const callerTty = callerTtyResult.value;
 
     const promptResult = normalizePrompt(body.prompt);
     if (!promptResult.ok) {
@@ -2554,6 +2570,12 @@ export class DaemonServer {
     // on the other.
     const placementPane = target ?? callerPane;
     let placement: SpawnPlacement | undefined;
+    // The session the new pane will land in, and the one the caller is
+    // looking at. Equal for every spawn that places by `callerPane`; they
+    // diverge only when an explicit `target` names a pane in another session,
+    // which is the case `buildSpawnFocusArgv` has to switch the client for.
+    let placementSessionId: string | undefined;
+    let callerSessionId: string | undefined;
     if (placementPane) {
       const location = await resolvePaneLocation(placementPane);
       if (!location) {
@@ -2562,6 +2584,8 @@ export class DaemonServer {
           { status: 400, headers },
         );
       }
+      placementSessionId = location.sessionId;
+      if (placementPane === callerPane) callerSessionId = location.sessionId;
       if (split) {
         placement = { kind: "pane", id: placementPane };
       } else if (target) {
@@ -2574,6 +2598,22 @@ export class DaemonServer {
         // break `select-window -t N` muscle memory and bindings.
         placement = { kind: "session", id: location.sessionId };
       }
+    }
+
+    // A second pane probe, deliberately narrow: it runs only when an explicit
+    // target decided the placement AND the caller sent a client to move, so
+    // an ordinary spawn costs exactly the tmux round-trips it always did.
+    // Best-effort — a caller pane that vanished between the request and here
+    // leaves the session unknown, which `buildSpawnFocusArgv` reads as "not
+    // provably cross-session" and answers with today's `select-window`.
+    if (
+      !detach &&
+      callerTty &&
+      callerPane &&
+      placementSessionId !== undefined &&
+      callerSessionId === undefined
+    ) {
+      callerSessionId = (await resolvePaneLocation(callerPane))?.sessionId;
     }
 
     // Creating the worktree is the handler's first side effect, so it comes
@@ -2709,17 +2749,22 @@ export class DaemonServer {
       // caller can already see in `tmux list-panes` would be reported as
       // failed and torn down out from under them. Best effort, log and
       // continue.
-      if (!detach) {
+      const focusArgv = buildSpawnFocusArgv({
+        paneId,
+        detach,
+        callerTty,
+        placementSessionId,
+        callerSessionId,
+      });
+      if (focusArgv) {
         try {
-          const selectProc = Bun.spawn(
-            ["tmux", "select-window", "-t", paneId],
-            { stdout: "pipe", stderr: "pipe" },
-          );
-          await selectProc.exited;
+          const focusProc = Bun.spawn(["tmux", ...focusArgv], {
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          await focusProc.exited;
         } catch (err: unknown) {
-          console.error(
-            `Failed to select window for pane ${paneId}: ${errorMessage(err)}`,
-          );
+          console.error(`Failed to focus pane ${paneId}: ${errorMessage(err)}`);
         }
       }
 

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -9,6 +9,7 @@ import {
   resolvedHomeDir,
 } from "../lib/config";
 import { getPreferences } from "../lib/preferences";
+import { listTmuxClientTtys } from "../lib/tmux-client";
 import {
   capturePane,
   resolvePaneLocation,
@@ -18,12 +19,12 @@ import {
 import {
   buildAgentForkCommand,
   buildAgentSpawnCommand,
-  buildSpawnFocusArgv,
   buildTmuxSpawnArgv,
   forkResumesByIdAlone,
   normalizeBoolean,
   normalizeClientTty,
   normalizePrompt,
+  resolveSpawnFocusArgv,
   normalizeSplit,
   normalizeTarget,
   normalizeWorktreeRequest,
@@ -2749,20 +2750,35 @@ export class DaemonServer {
       // caller can already see in `tmux list-panes` would be reported as
       // failed and torn down out from under them. Best effort, log and
       // continue.
-      const focusArgv = buildSpawnFocusArgv({
-        paneId,
-        detach,
-        callerTty,
-        placementSessionId,
-        callerSessionId,
-      });
+      const focusArgv = await resolveSpawnFocusArgv(
+        {
+          paneId,
+          detach,
+          callerTty,
+          placementSessionId,
+          callerSessionId,
+        },
+        listTmuxClientTtys,
+      );
       if (focusArgv) {
         try {
           const focusProc = Bun.spawn(["tmux", ...focusArgv], {
             stdout: "pipe",
             stderr: "pipe",
           });
-          await focusProc.exited;
+          const focusExit = await focusProc.exited;
+          // Reported rather than swallowed: the response still says
+          // `success: true` (it is), so a silently skipped switch would leave
+          // the user with a pane they were told about, a view that never
+          // moved, and nothing anywhere to explain it. `can't find client` is
+          // the live failure mode now that a tty arrives from off-process.
+          if (focusExit !== 0) {
+            const stderr = (await new Response(focusProc.stderr).text()).trim();
+            console.error(
+              `tmux ${focusArgv[0]} for pane ${paneId} exited ${focusExit}` +
+                (stderr ? `: ${stderr}` : ""),
+            );
+          }
         } catch (err: unknown) {
           console.error(`Failed to focus pane ${paneId}: ${errorMessage(err)}`);
         }

--- a/src/daemon/spawn-command.test.ts
+++ b/src/daemon/spawn-command.test.ts
@@ -7,11 +7,13 @@ import { getBuiltinAgent } from "../lib/agents-test-helpers";
 import {
   buildAgentForkCommand,
   buildAgentSpawnCommand,
+  buildSpawnFocusArgv,
   buildTmuxSpawnArgv,
   escapeSingleQuoted,
   MAX_SPAWN_COMMAND_BYTES,
   MAX_SPAWN_PROMPT_BYTES,
   normalizeBoolean,
+  normalizeClientTty,
   normalizePrompt,
   normalizeSplit,
   normalizeTarget,
@@ -67,6 +69,99 @@ describe("normalizeTarget", () => {
   it("rejects window ids, session names, and other target forms", () => {
     for (const bad of ["@3", "mysession:1.0", "0", "%", "%1a", 12]) {
       expect(normalizeTarget(bad).ok).toBe(false);
+    }
+  });
+});
+
+describe("normalizeClientTty", () => {
+  // `callerTty` reaches tmux as a `switch-client -c` argument. Nothing here
+  // touches a shell, so the risk is not injection but a nonsense value tmux
+  // would resolve as some other client (or none), leaving the caller's view
+  // wherever it was with a success reported.
+
+  it("accepts the device paths tmux reports on macOS and Linux", () => {
+    expect(normalizeClientTty("/dev/ttys004")).toEqual({
+      ok: true,
+      value: "/dev/ttys004",
+    });
+    expect(normalizeClientTty("/dev/pts/3")).toEqual({
+      ok: true,
+      value: "/dev/pts/3",
+    });
+  });
+
+  it("treats absent, null and empty as no client", () => {
+    for (const blank of [undefined, null, ""]) {
+      expect(normalizeClientTty(blank)).toEqual({ ok: true, value: undefined });
+    }
+  });
+
+  it("rejects anything that is not a device path", () => {
+    for (const bad of ["ttys004", "/etc/passwd", "/dev/", 4, {}]) {
+      const result = normalizeClientTty(bad);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("callerTty");
+    }
+  });
+});
+
+describe("buildSpawnFocusArgv", () => {
+  // The whole point of the split: `select-window` moves the active window
+  // WITHIN a session, so against a target in another session it changes that
+  // session and leaves the attached client exactly where it was. Verified by
+  // hand on an isolated tmux server (issue #75).
+
+  const base = { paneId: "%99", detach: false };
+
+  it("selects the window for a same-session spawn, tty or not", () => {
+    expect(
+      buildSpawnFocusArgv({
+        ...base,
+        callerTty: "/dev/ttys004",
+        placementSessionId: "$3",
+        callerSessionId: "$3",
+      }),
+    ).toEqual(["select-window", "-t", "%99"]);
+    expect(buildSpawnFocusArgv(base)).toEqual(["select-window", "-t", "%99"]);
+  });
+
+  it("switches the caller's own client for a cross-session spawn", () => {
+    expect(
+      buildSpawnFocusArgv({
+        ...base,
+        callerTty: "/dev/ttys004",
+        placementSessionId: "$7",
+        callerSessionId: "$3",
+      }),
+    ).toEqual(["switch-client", "-c", "/dev/ttys004", "-t", "%99"]);
+  });
+
+  it("runs nothing at all when detached, cross-session included", () => {
+    expect(
+      buildSpawnFocusArgv({
+        ...base,
+        detach: true,
+        callerTty: "/dev/ttys004",
+        placementSessionId: "$7",
+        callerSessionId: "$3",
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to select-window when the switch cannot be proven needed", () => {
+    // Each of these leaves a client that never asked to move: no tty to name
+    // it with, or a session pair we could not resolve both halves of.
+    const cases = [
+      { placementSessionId: "$7", callerSessionId: "$3" }, // no tty
+      { callerTty: "/dev/ttys004", callerSessionId: "$3" }, // no placement
+      { callerTty: "/dev/ttys004", placementSessionId: "$7" }, // no caller
+    ];
+    for (const extra of cases) {
+      expect(buildSpawnFocusArgv({ ...base, ...extra })).toEqual([
+        "select-window",
+        "-t",
+        "%99",
+      ]);
     }
   });
 });
@@ -151,7 +246,9 @@ describe("spawnCommandTooLarge", () => {
   });
 
   it("refuses one byte over, naming the size and the budget", () => {
-    const problem = spawnCommandTooLarge("a".repeat(MAX_SPAWN_COMMAND_BYTES + 1));
+    const problem = spawnCommandTooLarge(
+      "a".repeat(MAX_SPAWN_COMMAND_BYTES + 1),
+    );
     expect(problem).toContain(String(MAX_SPAWN_COMMAND_BYTES + 1));
     expect(problem).toContain(String(MAX_SPAWN_COMMAND_BYTES));
   });

--- a/src/daemon/spawn-command.test.ts
+++ b/src/daemon/spawn-command.test.ts
@@ -19,6 +19,8 @@ import {
   normalizeTarget,
   normalizeWorktreeRequest,
   quotedTemplateProblem,
+  resolveSpawnFocusArgv,
+  type ClientTtyProbe,
   spawnCommandTooLarge,
   substituteQuotedTemplate,
 } from "./spawn-command";
@@ -125,13 +127,14 @@ describe("buildSpawnFocusArgv", () => {
     expect(buildSpawnFocusArgv(base)).toEqual(["select-window", "-t", "%99"]);
   });
 
-  it("switches the caller's own client for a cross-session spawn", () => {
+  it("switches the caller's own client for a verified cross-session spawn", () => {
     expect(
       buildSpawnFocusArgv({
         ...base,
         callerTty: "/dev/ttys004",
         placementSessionId: "$7",
         callerSessionId: "$3",
+        ttyAttachedToCallerSession: true,
       }),
     ).toEqual(["switch-client", "-c", "/dev/ttys004", "-t", "%99"]);
   });
@@ -144,17 +147,25 @@ describe("buildSpawnFocusArgv", () => {
         callerTty: "/dev/ttys004",
         placementSessionId: "$7",
         callerSessionId: "$3",
+        ttyAttachedToCallerSession: true,
       }),
     ).toBeNull();
   });
 
   it("falls back to select-window when the switch cannot be proven needed", () => {
     // Each of these leaves a client that never asked to move: no tty to name
-    // it with, or a session pair we could not resolve both halves of.
+    // it with, a session pair we could not resolve both halves of, or a tty
+    // nobody confirmed is even looking at the caller's session.
     const cases = [
       { placementSessionId: "$7", callerSessionId: "$3" }, // no tty
       { callerTty: "/dev/ttys004", callerSessionId: "$3" }, // no placement
       { callerTty: "/dev/ttys004", placementSessionId: "$7" }, // no caller
+      {
+        // Everything present, membership never established.
+        callerTty: "/dev/ttys004",
+        placementSessionId: "$7",
+        callerSessionId: "$3",
+      },
     ];
     for (const extra of cases) {
       expect(buildSpawnFocusArgv({ ...base, ...extra })).toEqual([
@@ -163,6 +174,86 @@ describe("buildSpawnFocusArgv", () => {
         "%99",
       ]);
     }
+  });
+});
+
+describe("resolveSpawnFocusArgv", () => {
+  // The membership check. `#{client_tty}` is resolved by the CLI with tmux's
+  // `cmd_find_best_client`, which prefers a client of the caller's session but
+  // FALLS BACK to the most-recently-active client of any session when that
+  // session has none attached. So spawning from a DETACHED session hands the
+  // daemon a bystander's terminal, and switching it would drag a user with no
+  // stake in this spawn into the new pane. Verified live on tmux 3.6a:
+  // sessions A (attached), B and C detached, `--target <pane in C>` run from a
+  // pane in B resolved A's tty.
+
+  const crossSession = {
+    paneId: "%99",
+    detach: false,
+    callerTty: "/dev/ttys004",
+    placementSessionId: "$7",
+    callerSessionId: "$3",
+  };
+
+  it("switches when the tty is a client of the caller's session", async () => {
+    const asked: string[] = [];
+    const argv = await resolveSpawnFocusArgv(crossSession, async (session) => {
+      asked.push(session);
+      return ["/dev/ttys004"];
+    });
+
+    expect(argv).toEqual(["switch-client", "-c", "/dev/ttys004", "-t", "%99"]);
+    // The CALLER's session is what has to own the client, not the target's.
+    expect(asked).toEqual(["$3"]);
+  });
+
+  it("refuses a tty attached to some other session", async () => {
+    // The regression this guard exists for: without it the daemon yanks
+    // whichever client tmux happened to name.
+    const argv = await resolveSpawnFocusArgv(crossSession, async () => []);
+    expect(argv).toEqual(["select-window", "-t", "%99"]);
+  });
+
+  it("refuses when the session has clients, none of them ours", async () => {
+    const argv = await resolveSpawnFocusArgv(crossSession, async () => [
+      "/dev/ttys009",
+      "/dev/ttys012",
+    ]);
+    expect(argv).toEqual(["select-window", "-t", "%99"]);
+  });
+
+  it("falls back when the probe itself fails", async () => {
+    // An unanswerable probe is the same unproven state as an empty list, and
+    // the fallback is what this spawn would have done anyway.
+    const argv = await resolveSpawnFocusArgv(crossSession, async () => null);
+    expect(argv).toEqual(["select-window", "-t", "%99"]);
+  });
+
+  it("never probes for a same-session spawn or a detached one", async () => {
+    // The paths that were already correct must not pay a tmux round-trip for
+    // a question whose answer they would ignore.
+    let probes = 0;
+    const count: ClientTtyProbe = async () => {
+      probes++;
+      return null;
+    };
+
+    expect(
+      await resolveSpawnFocusArgv(
+        { ...crossSession, placementSessionId: "$3" },
+        count,
+      ),
+    ).toEqual(["select-window", "-t", "%99"]);
+    expect(
+      await resolveSpawnFocusArgv({ ...crossSession, detach: true }, count),
+    ).toBeNull();
+    expect(
+      await resolveSpawnFocusArgv(
+        { paneId: "%99", detach: false, callerSessionId: "$3" },
+        count,
+      ),
+    ).toEqual(["select-window", "-t", "%99"]);
+    expect(probes).toBe(0);
   });
 });
 

--- a/src/daemon/spawn-command.ts
+++ b/src/daemon/spawn-command.ts
@@ -67,6 +67,31 @@ export function normalizeTarget(
 }
 
 /**
+ * The only accepted shape for a tmux client tty (`callerTty`). tmux reports
+ * `#{client_tty}` as an absolute device path (`/dev/ttys004` on macOS,
+ * `/dev/pts/3` on Linux), and the value travels straight into a tmux argv, so
+ * anything outside that shape is a caller mistake worth naming rather than a
+ * flag to hand to tmux.
+ */
+export const CLIENT_TTY_PATTERN = /^\/dev\/[A-Za-z0-9._/-]{1,64}$/;
+
+/** Validate a wire tmux-client-tty field (`callerTty`). */
+export function normalizeClientTty(
+  value: unknown,
+  field = "callerTty",
+): BuildResult<string | undefined> {
+  if (value === undefined || value === null || value === "")
+    return { ok: true, value: undefined };
+  if (typeof value !== "string" || !CLIENT_TTY_PATTERN.test(value)) {
+    return {
+      ok: false,
+      error: `Invalid '${field}' field: expected a tmux client tty such as "/dev/ttys004"`,
+    };
+  }
+  return { ok: true, value };
+}
+
+/**
  * Validate a wire boolean field (`detach`). Every other spawn field goes
  * through a normalizer that rejects anything not in its accepted shape; this
  * one used to be an unchecked cast, so a truthy non-boolean like the string
@@ -757,6 +782,56 @@ export function buildTmuxSpawnArgv(input: TmuxSpawnArgvInput): string[] {
 
   argv.push("-c", cwd, "-P", "-F", "#{pane_id}");
   return argv;
+}
+
+export interface SpawnFocusInput {
+  /** The pane tmux just created. */
+  paneId: string;
+  /** `--detach`: leave the caller's view exactly where it is. */
+  detach: boolean;
+  /**
+   * tty of the tmux client that asked for the spawn, when the caller sent
+   * one. The daemon is attached to no client of its own, so this is the only
+   * handle it has on "the terminal the user is looking at".
+   */
+  callerTty?: string;
+  /** The session the new pane lands in, when placement resolved one. */
+  placementSessionId?: string;
+  /** The session the caller was in, when it named a pane to resolve it from. */
+  callerSessionId?: string;
+}
+
+/**
+ * argv for the tmux command that puts the caller's view on the new pane,
+ * minus the binary. `null` when nothing should run at all.
+ *
+ * Two shapes, because tmux has two different operations here and the wrong
+ * one silently does nothing:
+ *
+ * - Same session (or anything we cannot prove is cross-session):
+ *   `select-window`, which is what every spawn has always run.
+ * - A pane in a DIFFERENT session: `select-window` only changes which window
+ *   is current *within* that session; moving an attached client between
+ *   sessions needs `switch-client`, and since the daemon has no client of its
+ *   own it must name the caller's by tty (`-c`), the same way
+ *   `src/commands/switch.ts` does when it runs outside tmux.
+ *
+ * Anything unknown falls back to `select-window`: a missing tty or an
+ * unresolved session means we cannot show that a switch is needed, and
+ * guessing would move a client that never asked to be moved.
+ */
+export function buildSpawnFocusArgv(input: SpawnFocusInput): string[] | null {
+  const { paneId, detach, callerTty, placementSessionId, callerSessionId } =
+    input;
+  if (detach) return null;
+  const crossSession =
+    callerTty !== undefined &&
+    placementSessionId !== undefined &&
+    callerSessionId !== undefined &&
+    placementSessionId !== callerSessionId;
+  return crossSession
+    ? ["switch-client", "-c", callerTty, "-t", paneId]
+    : ["select-window", "-t", paneId];
 }
 
 /** A request to spawn into a worktree rather than the given cwd. */

--- a/src/daemon/spawn-command.ts
+++ b/src/daemon/spawn-command.ts
@@ -799,6 +799,43 @@ export interface SpawnFocusInput {
   placementSessionId?: string;
   /** The session the caller was in, when it named a pane to resolve it from. */
   callerSessionId?: string;
+  /**
+   * Whether `callerTty` was VERIFIED to be a client of `callerSessionId`.
+   *
+   * Not redundant with having a tty at all, because the tty the CLI resolves
+   * is not guaranteed to belong to the session it was resolved from: tmux's
+   * `#{client_tty}` falls back to the most-recently-active client of any
+   * session when the caller's own session has none attached (see
+   * `lib/tmux-client.ts`). Spawning from a DETACHED session therefore hands
+   * us some bystander's terminal, and switching it would drag a user who has
+   * nothing to do with this spawn into the new pane — strictly worse than the
+   * `select-window` this replaced. Left unset, no switch happens.
+   */
+  ttyAttachedToCallerSession?: boolean;
+}
+
+/** Ttys of the clients attached to a tmux session; `null` if unknowable. */
+export type ClientTtyProbe = (sessionId: string) => Promise<string[] | null>;
+
+/**
+ * The cross-session switch's preconditions, or `null` when this spawn is not
+ * one. Separated out so the probe below and the decision above cannot drift
+ * on what "cross-session" means.
+ */
+function crossSessionSwitch(
+  input: SpawnFocusInput,
+): { callerTty: string; callerSessionId: string } | null {
+  const { detach, callerTty, placementSessionId, callerSessionId } = input;
+  if (detach) return null;
+  if (
+    callerTty === undefined ||
+    placementSessionId === undefined ||
+    callerSessionId === undefined ||
+    placementSessionId === callerSessionId
+  ) {
+    return null;
+  }
+  return { callerTty, callerSessionId };
 }
 
 /**
@@ -816,22 +853,40 @@ export interface SpawnFocusInput {
  *   own it must name the caller's by tty (`-c`), the same way
  *   `src/commands/switch.ts` does when it runs outside tmux.
  *
- * Anything unknown falls back to `select-window`: a missing tty or an
- * unresolved session means we cannot show that a switch is needed, and
- * guessing would move a client that never asked to be moved.
+ * Anything short of proof falls back to `select-window` — a missing tty, an
+ * unresolved session, or a tty nobody has confirmed is attached to the
+ * caller's session. Moving the wrong client is a worse failure than not
+ * moving one, since the user it interrupts never asked for anything.
  */
 export function buildSpawnFocusArgv(input: SpawnFocusInput): string[] | null {
-  const { paneId, detach, callerTty, placementSessionId, callerSessionId } =
-    input;
+  const { paneId, detach, ttyAttachedToCallerSession } = input;
   if (detach) return null;
-  const crossSession =
-    callerTty !== undefined &&
-    placementSessionId !== undefined &&
-    callerSessionId !== undefined &&
-    placementSessionId !== callerSessionId;
-  return crossSession
-    ? ["switch-client", "-c", callerTty, "-t", paneId]
+  const cross = crossSessionSwitch(input);
+  return cross && ttyAttachedToCallerSession
+    ? ["switch-client", "-c", cross.callerTty, "-t", paneId]
     : ["select-window", "-t", paneId];
+}
+
+/**
+ * {@link buildSpawnFocusArgv} with the membership check run for it.
+ *
+ * The probe costs a tmux round-trip, so it is asked only when everything else
+ * already points at a switch; every other spawn short-circuits to the pure
+ * decision and touches tmux exactly as often as it always did.
+ */
+export async function resolveSpawnFocusArgv(
+  input: SpawnFocusInput,
+  listClientTtys: ClientTtyProbe,
+): Promise<string[] | null> {
+  const cross = crossSessionSwitch(input);
+  if (!cross) return buildSpawnFocusArgv(input);
+  // A failed probe reads as "not attached": it is the same unproven state as
+  // an empty list, and the fallback is the behavior this spawn had anyway.
+  const ttys = await listClientTtys(cross.callerSessionId);
+  return buildSpawnFocusArgv({
+    ...input,
+    ttyAttachedToCallerSession: ttys?.includes(cross.callerTty) ?? false,
+  });
 }
 
 /** A request to spawn into a worktree rather than the given cwd. */

--- a/src/lib/tmux-client.ts
+++ b/src/lib/tmux-client.ts
@@ -38,6 +38,33 @@ export async function getActiveTmuxClientPid(): Promise<number | null> {
 }
 
 /**
+ * The tty of the tmux client the CURRENT context is being viewed with, i.e.
+ * the terminal the user is attached with when this runs inside a pane. Only
+ * meaningful with `$TMUX` set; outside tmux there is no current context and
+ * {@link resolveActiveTmuxClientTty} is the right fallback.
+ *
+ * Deliberately not the pane's own tty: `#{client_tty}` is the ATTACHED
+ * client's device (`/dev/ttys085`), while the pane runs on its own pty
+ * (`/dev/ttys079`). Only the former is a valid `switch-client -c` target,
+ * which is what `ccmux spawn` sends it for.
+ */
+export async function resolveCurrentTmuxClientTty(): Promise<string | null> {
+  try {
+    const proc = Bun.spawn(["tmux", "display-message", "-p", "#{client_tty}"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    const tty = output.trim();
+    return tty || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The tty of the most-recently-active attached tmux client (highest
  * `#{client_activity}` wins), for callers with no implicit current client
  * (invoked outside tmux entirely, e.g. a notification click). Returns null

--- a/src/lib/tmux-client.ts
+++ b/src/lib/tmux-client.ts
@@ -38,15 +38,22 @@ export async function getActiveTmuxClientPid(): Promise<number | null> {
 }
 
 /**
- * The tty of the tmux client the CURRENT context is being viewed with, i.e.
- * the terminal the user is attached with when this runs inside a pane. Only
+ * A tmux client tty for the CURRENT context, from `#{client_tty}`. Only
  * meaningful with `$TMUX` set; outside tmux there is no current context and
  * {@link resolveActiveTmuxClientTty} is the right fallback.
  *
- * Deliberately not the pane's own tty: `#{client_tty}` is the ATTACHED
- * client's device (`/dev/ttys085`), while the pane runs on its own pty
- * (`/dev/ttys079`). Only the former is a valid `switch-client -c` target,
- * which is what `ccmux spawn` sends it for.
+ * Deliberately not the pane's own tty: `#{client_tty}` is a CLIENT's device
+ * (`/dev/ttys085`), while the pane runs on its own pty (`/dev/ttys079`), and
+ * only the former is a valid `switch-client -c` target.
+ *
+ * NOT a promise that the answer belongs to the caller's session. tmux resolves
+ * the current client with `cmd_find_best_client`, which prefers a client of
+ * the resolved session but FALLS BACK to the most-recently-active client of
+ * any session when that session has none attached. So a pane in a detached
+ * session yields some other session's terminal, and anything that would MOVE
+ * the returned client (`ccmux spawn`'s cross-session switch) has to verify
+ * membership itself with {@link listTmuxClientTtys} — otherwise it yanks a
+ * client that was never involved. Verified live on tmux 3.6a.
  */
 export async function resolveCurrentTmuxClientTty(): Promise<string | null> {
   try {
@@ -59,6 +66,36 @@ export async function resolveCurrentTmuxClientTty(): Promise<string | null> {
     if (exitCode !== 0) return null;
     const tty = output.trim();
     return tty || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The ttys of the clients attached to one session, for callers that must know
+ * whether a given client is actually looking at it. An empty array is a real
+ * answer (nobody is attached); `null` means the query failed and nothing
+ * should be concluded from it.
+ *
+ * `-t` is what makes this a membership test rather than a popularity contest:
+ * unlike `#{client_tty}`, `list-clients -t` has no best-effort fallback, so a
+ * detached session returns nothing at all.
+ */
+export async function listTmuxClientTtys(
+  sessionId: string,
+): Promise<string[] | null> {
+  try {
+    const proc = Bun.spawn(
+      ["tmux", "list-clients", "-t", sessionId, "-F", "#{client_tty}"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    return output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Overview

Makes a cross-session `ccmux spawn --target <pane>` actually move the caller's client to the new pane, instead of reporting success while the client stays put.

Resolves #75

## Motivation

`--target` accepts any pane on the server, including one in a different tmux session. The spawn created the pane there, but the final `select-window` only changes which window is current within that session; moving an attached client between sessions needs `switch-client`, and the daemon has no client of its own to run it on. The README documented "pair it with `--detach`" as a caveat; this removes the caveat.

## Changes

### TTY threading (CLI → daemon)

- **spawn.ts** - `callerClientTty()` resolves `#{client_tty}` (the attached client's device, not the pane's own pty) and sends it as `callerTty` on `POST /spawn`. Resolved only when an explicit `--target` was given without `--detach`, behind the same cross-server gate `callerPane` uses, so an ordinary spawn makes zero extra tmux or HTTP calls. Also hoists the single `/server-info` round-trip both placement fields share.
- **tmux-client.ts** - New `resolveCurrentTmuxClientTty()`.

### Decision seam (daemon)

- **spawn-command.ts** - `normalizeClientTty()` validates the wire field against a strict `/dev/...` device-path pattern (400 otherwise; the value travels straight into a tmux argv). `buildSpawnFocusArgv()` is the pure decision: `null` on detach, `switch-client -c <tty> -t <pane>` when the placement session provably differs from the caller's, `select-window` for everything else, including anything unprovable, so a missing tty or a vanished caller pane falls back to today's behavior rather than moving a client that never asked.
- **server.ts** - Captures the placement and caller session ids from the pane probes (a second probe runs only when a target and a tty are both present) and drives the focus step through `buildSpawnFocusArgv`.

### Docs

- **README.md** - The cross-session caveat now documents the switch, with `--detach` as the opt-out.

## Breaking Changes

None. Requests without `callerTty` (older CLIs, the picker, fork) take the exact pre-change path.

## Testing

- [x] Full `bun test`: 3764 pass / 0 fail (+26 tests); `bun run typecheck` clean (verified independently)
- [x] Unit coverage for the decision seam (same-session / cross-session / detach / each unprovable fallback), the tty validator, the daemon route argv for all cases including bad-tty 400s, and the CLI threading gates
- [x] Live e2e on an isolated tmux server (`-L ccmux75`, own daemon on port 22690, scoping proven before start) with a real attached client and a tmux argv recorder, so every case is verified by both client movement and exact command:
  - Cross-session `--target`: `switch-client -c /dev/ttys085 -t %2`, client followed A → B (new-window and `--split h` both)
  - Same-session `--target`: byte-identical old path, single probe, no `switch-client`
  - `--detach`: no tty lookup, no focus command, client stayed on A while the pane appeared in B
  - Ordinary spawn: identical tmux call sequence to pre-change
  - Pre-fix behavior reproduced by hand on the same server (`select-window` leaves the client on A)
