### PR TITLE
fix(tui): Measure text in display columns, not code units

### DIFF
--- a/src/tui/components/NewSessionDialog.test.tsx
+++ b/src/tui/components/NewSessionDialog.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from "bun:test";
 import { testRender } from "@opentui/solid";
 import { NewSessionDialog, optionWindow, wrapText } from "./NewSessionDialog";
 import { expectFrameIntegrity, squish } from "./test-helpers";
+import { displayWidth } from "../utils/format";
 import type { SpawnableAgent } from "../../lib/spawnable-agents";
 import type { NewSessionDraft } from "../store";
 
@@ -112,6 +113,45 @@ describe("wrapText", () => {
 
   it("gives up rather than looping when there is no width to wrap into", () => {
     expect(wrapText("anything", 0)).toEqual(["anything"]);
+  });
+
+  /**
+   * Issue #91: the widths above are display columns, so a line of CJK fills
+   * its column exactly like an ASCII one. Measured in code units these lines
+   * were twice their claimed width and the renderer clipped half of each.
+   */
+  it("wraps wide glyphs to the column they actually occupy", () => {
+    const message = "エージェントを 解決できません でした デーモンを 再起動";
+    const lines = wrapText(message, 19);
+    for (const line of lines) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(19);
+    }
+    expect(lines.join(" ")).toBe(message);
+  });
+
+  it("breaks an over-wide CJK word on a glyph boundary", () => {
+    const lines = wrapText("解決できませんでした", 9);
+    for (const line of lines) expect(displayWidth(line)).toBeLessThanOrEqual(9);
+    expect(lines.join("")).toBe("解決できませんでした");
+    // An odd budget stops a column short rather than splitting a glyph.
+    expect(lines[0]).toBe("解決でき");
+  });
+
+  it("never splits an emoji cluster across lines", () => {
+    const family = "👨‍👩‍👧‍👦";
+    const lines = wrapText(family.repeat(6), 5);
+    for (const line of lines) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(5);
+      // Whole families only, so nothing renders as a replacement glyph.
+      expect(line.replace(new RegExp(family, "gu"), "")).toBe("");
+    }
+    expect(lines.join("")).toBe(family.repeat(6));
+  });
+
+  it("emits an unsplittable glyph rather than spinning on it", () => {
+    // A column too narrow for one wide glyph: it has to overflow, but the
+    // loop must still terminate.
+    expect(wrapText("日本", 1)).toEqual(["日本"]);
   });
 });
 
@@ -281,6 +321,38 @@ describe("NewSessionDialog", () => {
     expect(frame).toContain("Worktree");
     expect(frame).toContain("Directory");
     expect(frame).toContain("enter");
+  });
+
+  /**
+   * Issue #91, the reported repro: a Japanese agent error at a sidebar width.
+   * Wrapped by code units every line was twice the column it claimed, the
+   * renderer clipped the overflow, and the message read as garbage rather
+   * than as a truncation.
+   */
+  it("wraps a wide-glyph agent error to the column it renders in", async () => {
+    const error =
+      "エージェントを解決できませんでした デーモンを再起動してください";
+    const frame = await renderDialog({
+      agents: [],
+      agentsError: error,
+      width: 34,
+      height: 30,
+    });
+
+    expectFrameIntegrity(frame);
+    // Every rendered row of the message is a contiguous prefix of the
+    // original, in order, with nothing dropped between rows.
+    const rendered = squish(frame);
+    let cursor = 0;
+    for (const char of squish(error)) {
+      const at = rendered.indexOf(char, cursor);
+      expect(at).toBeGreaterThanOrEqual(cursor);
+      cursor = at + 1;
+    }
+    // And the fields budgeted below the (now correctly counted) rows survive.
+    expect(frame).toContain("New window");
+    expect(frame).toContain("Split down");
+    expect(frame).toContain("Directory");
   });
 
   /** An error too tall for the screen cannot be shown whole; what it must

--- a/src/tui/components/NewSessionDialog.tsx
+++ b/src/tui/components/NewSessionDialog.tsx
@@ -11,7 +11,12 @@ import {
   type NewSessionPlacement,
 } from "../store";
 import { slugFromPrompt } from "../../daemon/worktree-create";
-import { shortenCwd, truncateText } from "../utils/format";
+import {
+  displayWidth,
+  shortenCwd,
+  sliceToWidth,
+  truncateText,
+} from "../utils/format";
 import { agentColorFor } from "./SessionItem";
 import { theme } from "../theme";
 
@@ -72,30 +77,48 @@ export const DESTINATION_OPTIONS: readonly DestinationOption[] = [
  * boundary moves to the next row). Lines produced here already fit, so
  * nothing can wrap a second time and the budget cannot be wrong.
  *
- * Widths are UTF-16 code units, not display columns, so a line of wide
- * glyphs (CJK) over-fills its column — the same limitation `truncateText`
- * has, tracked in issue #91, whose real fix is a shared display-width helper.
+ * Widths are display columns (`displayWidth`), so a line of wide glyphs (CJK,
+ * emoji) fits its column like an ASCII one does, and mid-word breaks land on
+ * grapheme boundaries (issue #91).
  */
 export function wrapText(text: string, width: number): string[] {
   if (width <= 0) return [text];
   const lines: string[] = [];
   let line = "";
+  let lineWidth = 0;
   for (const word of text.split(/\s+/).filter(Boolean)) {
     let rest = word;
     // Longer than the whole column: it can only be broken mid-word.
-    while (rest.length > width) {
+    while (displayWidth(rest) > width) {
       if (line) {
         lines.push(line);
         line = "";
+        lineWidth = 0;
       }
-      lines.push(rest.slice(0, width));
-      rest = rest.slice(width);
+      const head = sliceToWidth(rest, width);
+      if (!head) {
+        // A single cluster wider than the whole column (a wide glyph at
+        // width 1): nothing can be split off it, so let the word overflow
+        // rather than slice a cluster or spin on an empty head.
+        lines.push(rest);
+        rest = "";
+        break;
+      }
+      lines.push(head);
+      rest = rest.slice(head.length);
     }
-    if (!line) line = rest;
-    else if (line.length + 1 + rest.length <= width) line += ` ${rest}`;
-    else {
+    if (!rest) continue;
+    const restWidth = displayWidth(rest);
+    if (!line) {
+      line = rest;
+      lineWidth = restWidth;
+    } else if (lineWidth + 1 + restWidth <= width) {
+      line += ` ${rest}`;
+      lineWidth += 1 + restWidth;
+    } else {
       lines.push(line);
       line = rest;
+      lineWidth = restWidth;
     }
   }
   if (line) lines.push(line);

--- a/src/tui/utils/format.test.ts
+++ b/src/tui/utils/format.test.ts
@@ -1,9 +1,31 @@
 import { describe, it, expect } from "bun:test";
-import { formatSubagentName, formatVersion, truncateText, truncateHighlighted } from "./format";
+import {
+  displayWidth,
+  formatSubagentName,
+  formatVersion,
+  sliceToWidth,
+  truncateText,
+  truncateHighlighted,
+} from "./format";
 
 /** Visible length: markup tags and ellipsis affixes excluded. */
 const visibleLen = (s: string) =>
   s.replace(/<\/?b>/g, "").replace(/…/g, "").length;
+
+/** Visible display columns: markup tags and ellipsis affixes excluded. */
+const visibleWidth = (s: string) =>
+  displayWidth(s.replace(/<\/?b>/g, "").replace(/…/g, ""));
+
+/** A half of a surrogate pair with no partner: what a code-unit slice
+ *  through an astral character leaves behind, rendered as `�`. */
+const hasLoneSurrogate = (s: string) =>
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+    s,
+  );
+
+const CJK = "日本語テキスト"; // 7 chars, 14 columns
+const FAMILY = "👨‍👩‍👧‍👦"; // 11 code units, 2 columns
+const FLAG = "🇯🇵"; // 4 code units, 2 columns
 
 describe("formatVersion", () => {
   it("should return empty string for null", () => {
@@ -36,6 +58,116 @@ describe("formatVersion", () => {
 
   it("should handle v prefix with suffix", () => {
     expect(formatVersion("v0.104.0-darwin-arm64")).toBe("v0.104.0");
+  });
+});
+
+describe("displayWidth", () => {
+  it("counts ASCII one column per character", () => {
+    expect(displayWidth("hello")).toBe(5);
+    expect(displayWidth("")).toBe(0);
+  });
+
+  it("counts wide glyphs as two columns, not as code units", () => {
+    expect(CJK.length).toBe(7);
+    expect(displayWidth(CJK)).toBe(14);
+  });
+
+  it("counts a ZWJ sequence as the single glyph it renders as", () => {
+    expect(FAMILY.length).toBe(11);
+    expect(displayWidth(FAMILY)).toBe(2);
+  });
+
+  it("counts a regional-indicator flag as one glyph", () => {
+    expect(FLAG.length).toBe(4);
+    expect(displayWidth(FLAG)).toBe(2);
+  });
+
+  it("adds up a mixed string", () => {
+    expect(displayWidth(`ok ${CJK} ${FLAG}`)).toBe(3 + 14 + 1 + 2);
+  });
+
+  it("treats ambiguous-width characters as narrow, like the renderer does", () => {
+    // OpenTUI draws ten of each in a ten-column box; a wcwidth table that
+    // called them wide would make every ellipsis-terminated string overflow.
+    for (const char of ["…", "▎", "α", "→", "①"]) {
+      expect(displayWidth(char)).toBe(1);
+    }
+  });
+});
+
+describe("sliceToWidth", () => {
+  it("returns the whole string when it already fits", () => {
+    expect(sliceToWidth("hello", 10)).toBe("hello");
+    expect(sliceToWidth(CJK, 14)).toBe(CJK);
+  });
+
+  it("cuts ASCII at the exact column", () => {
+    expect(sliceToWidth("hello world", 5)).toBe("hello");
+  });
+
+  it("cuts CJK by columns, not by characters", () => {
+    expect(sliceToWidth(CJK, 6)).toBe("日本語");
+    expect(displayWidth(sliceToWidth(CJK, 6))).toBe(6);
+  });
+
+  it("drops a wide glyph that would straddle the limit", () => {
+    // Odd budget: the fourth character needs two columns and only one is
+    // left, so the result lands a column short rather than a column over.
+    expect(sliceToWidth(CJK, 7)).toBe("日本語");
+  });
+
+  it("never splits a ZWJ sequence or a flag", () => {
+    expect(sliceToWidth(`${FAMILY}abc`, 3)).toBe(`${FAMILY}a`);
+    expect(sliceToWidth(FAMILY, 1)).toBe("");
+    expect(sliceToWidth(`${FLAG}x`, 2)).toBe(FLAG);
+    expect(sliceToWidth(FLAG, 1)).toBe("");
+  });
+
+  it("leaves no lone surrogate at any budget", () => {
+    const mixed = `a${FAMILY}${CJK}${FLAG}z`;
+    for (let budget = 0; budget <= displayWidth(mixed) + 2; budget++) {
+      const out = sliceToWidth(mixed, budget);
+      expect(hasLoneSurrogate(out)).toBe(false);
+      expect(displayWidth(out)).toBeLessThanOrEqual(budget);
+    }
+  });
+
+  it("returns nothing when there is no room", () => {
+    expect(sliceToWidth("hello", 0)).toBe("");
+    expect(sliceToWidth("hello", -3)).toBe("");
+  });
+});
+
+describe("truncateText", () => {
+  it("leaves text that fits alone", () => {
+    expect(truncateText("hello", 10)).toBe("hello");
+    expect(truncateText("hello", 5)).toBe("hello");
+  });
+
+  it("clips ASCII to the budget, ellipsis included", () => {
+    expect(truncateText("hello world", 8)).toBe("hello w…");
+    expect(displayWidth(truncateText("hello world", 8))).toBe(8);
+  });
+
+  it("measures CJK in columns rather than characters", () => {
+    // Seven characters, fourteen columns: it does NOT fit an 8-column cell.
+    const out = truncateText(CJK, 8);
+    expect(out).toBe("日本語…");
+    expect(displayWidth(out)).toBeLessThanOrEqual(8);
+  });
+
+  it("keeps emoji clusters whole and leaves no lone surrogate", () => {
+    const out = truncateText(FAMILY.repeat(3), 4);
+    expect(out).toBe(`${FAMILY}…`);
+    expect(hasLoneSurrogate(out)).toBe(false);
+    expect(displayWidth(out)).toBeLessThanOrEqual(4);
+  });
+
+  it("fits a mixed string to its column budget", () => {
+    const out = truncateText(`ok ${FLAG} ${CJK}`, 10);
+    expect(hasLoneSurrogate(out)).toBe(false);
+    expect(displayWidth(out)).toBeLessThanOrEqual(10);
+    expect(out.startsWith(`ok ${FLAG}`)).toBe(true);
   });
 });
 
@@ -114,6 +246,34 @@ describe("truncateHighlighted", () => {
   it("falls back to plain truncation when there is no span", () => {
     const plain = "plain long text well over the budget";
     expect(truncateHighlighted(plain, 10)).toBe(truncateText(plain, 10));
+  });
+
+  it("budgets a wide-glyph window in columns, not code units", () => {
+    const markup = `${CJK.repeat(3)}<b>探す</b>${CJK.repeat(3)}`;
+    const out = truncateHighlighted(markup, 20);
+    expect(out).toContain("<b>探す</b>"); // span intact
+    expect(out.startsWith("…")).toBe(true);
+    expect(out.endsWith("…")).toBe(true);
+    expect(visibleWidth(out)).toBeLessThanOrEqual(20);
+    expect(hasLoneSurrogate(out)).toBe(false);
+  });
+
+  it("keeps emoji clusters whole on both sides of the span", () => {
+    const markup = `${FAMILY.repeat(6)}<b>hit</b>${FLAG.repeat(6)}`;
+    const out = truncateHighlighted(markup, 16);
+    expect(out).toContain("<b>hit</b>");
+    expect(hasLoneSurrogate(out)).toBe(false);
+    expect(visibleWidth(out)).toBeLessThanOrEqual(16);
+    // Whole families and whole flags survived, never a half of either.
+    const visible = out.replace(/<\/?b>|…|hit/g, "");
+    expect(visible.replace(new RegExp(`${FAMILY}|${FLAG}`, "gu"), "")).toBe("");
+  });
+
+  it("returns a wide-glyph markup untouched when it already fits", () => {
+    const markup = `<b>探す</b>${CJK}`;
+    expect(truncateHighlighted(markup, 18)).toBe(markup);
+    // ...and not when only its code-unit count fits.
+    expect(truncateHighlighted(markup, 12)).not.toBe(markup);
   });
 });
 

--- a/src/tui/utils/format.ts
+++ b/src/tui/utils/format.ts
@@ -29,25 +29,82 @@ export function formatSubagentName(agentId: string): string {
   return body.replace(/-[0-9a-f]{8,}$/, "");
 }
 
-/** Truncate plain text to `maxLen` chars, adding an ellipsis when clipped. */
+/**
+ * Terminal columns `text` occupies.
+ *
+ * `ambiguousIsNarrow` is pinned rather than left to Bun's default because the
+ * two measurers in play could disagree there: OpenTUI's renderer measures with
+ * its grapheme-aware "unicode" method, `Bun.stringWidth` is wcwidth-flavoured.
+ * They agree on CJK (2), ZWJ sequences (2) and flags (2); ambiguous-width
+ * characters are the only class where they can differ. Rendering probes of the
+ * ones ccmux actually draws (`…`, `▎`, `α`, `→`, `①`) put ten of each in a
+ * ten-column box, so OpenTUI treats them as narrow and so do we.
+ */
+const WIDTH_OPTIONS = { ambiguousIsNarrow: true } as const;
+
+export function displayWidth(text: string): number {
+  return Bun.stringWidth(text, WIDTH_OPTIONS);
+}
+
+const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+/**
+ * Longest prefix of `text` that fits in `maxWidth` columns, cut on grapheme
+ * boundaries: a cluster is taken whole or not at all, so no slice can end
+ * mid-surrogate (a replacement glyph) or halfway through a ZWJ sequence. A
+ * wide cluster that would straddle the limit is dropped, leaving the result a
+ * column short of `maxWidth` rather than a column over.
+ */
+export function sliceToWidth(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  if (displayWidth(text) <= maxWidth) return text;
+  let out = "";
+  let width = 0;
+  for (const { segment } of graphemes.segment(text)) {
+    const segmentWidth = displayWidth(segment);
+    if (width + segmentWidth > maxWidth) break;
+    out += segment;
+    width += segmentWidth;
+  }
+  return out;
+}
+
+/** `sliceToWidth` from the other end: the longest fitting SUFFIX. */
+function sliceTailToWidth(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  if (displayWidth(text) <= maxWidth) return text;
+  const clusters = [...graphemes.segment(text)];
+  let out = "";
+  let width = 0;
+  for (let i = clusters.length - 1; i >= 0; i--) {
+    const segment = clusters[i]!.segment;
+    const segmentWidth = displayWidth(segment);
+    if (width + segmentWidth > maxWidth) break;
+    out = segment + out;
+    width += segmentWidth;
+  }
+  return out;
+}
+
+/** Truncate plain text to `maxLen` columns, adding an ellipsis when clipped. */
 export function truncateText(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  return text.slice(0, Math.max(1, maxLen - 1)) + "…";
+  if (displayWidth(text) <= maxLen) return text;
+  return sliceToWidth(text, Math.max(1, maxLen - 1)) + "…";
 }
 
 /**
  * Window single-span highlight markup (one `<b>…</b>`, as `wrapFirstMatch`
- * emits) to `maxLen` VISIBLE chars (tags excluded from the count) so a match
+ * emits) to `maxLen` VISIBLE columns (tags excluded from the count) so a match
  * deep in a long prompt still renders within a height-1 row instead of
  * wrapping/overlapping. The bold span is always kept whole; `…` is affixed
  * on whichever side is clipped. Leading pre-match context is capped hard (see
- * LEAD_CONTEXT_CAP) so the span starts within ~25 chars of the window even
+ * LEAD_CONTEXT_CAP) so the span starts within ~25 columns of the window even
  * when the real box is narrower than `maxLen` (maxLen is a layout budget, not
  * the actual box width: a row with long project/branch cells gets a narrower
  * box and OpenTUI clips the tail, so a span pushed far right by ~1/3-of-budget
  * leading context could be clipped off). Any leftover budget goes to the
  * trailing side. Markup with no span is treated as plain text. Mirrors the
- * daemon's radius-windowed transcript snippets, but works from a char budget.
+ * daemon's radius-windowed transcript snippets, but works from a column budget.
  */
 const LEAD_CONTEXT_CAP = 24;
 
@@ -61,21 +118,22 @@ export function truncateHighlighted(markup: string, maxLen: number): string {
   const span = markup.slice(open + 3, close);
   const post = markup.slice(close + 4);
 
-  if (pre.length + span.length + post.length <= maxLen) return markup;
+  const spanWidth = displayWidth(span);
+  if (displayWidth(pre) + spanWidth + displayWidth(post) <= maxLen) {
+    return markup;
+  }
 
-  // Chars left for context once the (always-kept) span is reserved.
-  const contextBudget = Math.max(0, maxLen - span.length);
+  // Columns left for context once the (always-kept) span is reserved.
+  const contextBudget = Math.max(0, maxLen - spanWidth);
   // Leading context is ~1/3 of the budget but hard-capped so the span always
   // starts near the window start (surviving a real box narrower than maxLen).
   // Any budget the (possibly short) leading side leaves goes to the trailing
   // side.
   const leadTarget = Math.min(Math.floor(contextBudget / 3), LEAD_CONTEXT_CAP);
-  const preShown = Math.min(pre.length, leadTarget);
-  const postShown = Math.min(post.length, contextBudget - preShown);
+  const preSlice = sliceTailToWidth(pre, leadTarget);
+  const postSlice = sliceToWidth(post, contextBudget - displayWidth(preSlice));
 
-  const lead = preShown < pre.length ? "…" : "";
-  const trail = postShown < post.length ? "…" : "";
-  const preSlice = pre.slice(pre.length - preShown);
-  const postSlice = post.slice(0, postShown);
+  const lead = preSlice.length < pre.length ? "…" : "";
+  const trail = postSlice.length < post.length ? "…" : "";
   return `${lead}${preSlice}<b>${span}</b>${postSlice}${trail}`;
 }


### PR DESCRIPTION
## Overview

Adds shared display-width helpers (`displayWidth`, `sliceToWidth`) and rebuilds the TUI's text-measuring utilities on top of them, so truncation and wrapping count terminal columns instead of UTF-16 code units.

Resolves #91

## Motivation

Prompts, transcript snippets, and error messages flow through `truncateText`, `truncateHighlighted`, and `wrapText`, and all three measured code units. A CJK string over-fills its cell (each glyph is 2 columns but counted as 1), a ZWJ emoji like a family burns 11 units of budget for 2 visible columns, and a naive `slice()` can cut mid-surrogate and render a replacement glyph. The new-session dialog repro in #91 turned a Japanese error message into half-clipped gibberish.

## Changes

### Shared helpers

- **src/tui/utils/format.ts** - Adds `displayWidth` (built on `Bun.stringWidth` with `ambiguousIsNarrow: true`, verified against OpenTUI's renderer by probing ambiguous glyphs like `…` and `▎` in a fixed-width box) and `sliceToWidth` (grapheme-safe prefix via `Intl.Segmenter`, never splits a cluster). `truncateText` and `truncateHighlighted` now measure and slice in columns; a private `sliceTailToWidth` handles the leading-context suffix case.

### Wrapping

- **src/tui/components/NewSessionDialog.tsx** - `wrapText` measures in columns and breaks over-wide words on grapheme boundaries, with a termination guard for a single cluster wider than the column (emits the word whole rather than spinning or splitting the cluster).

### Tests

- **src/tui/utils/format.test.ts** - Column-true assertions for CJK, ZWJ emoji, flags, and mixed strings; verifies no output ends in a lone surrogate.
- **src/tui/components/NewSessionDialog.test.tsx** - Wrapping invariants (`displayWidth(line) <= width` for every line) plus the issue's repro as a component test: the dialog at 34 columns with a Japanese `agentsError` renders a contiguous, legible message with the border intact. Five of the new tests fail against the pre-fix code.

Out of scope (deferred follow-up): the raw `.length` budget arithmetic in `session-columns.ts` and `SessionItem.tsx`.

## Breaking Changes

None

## Testing

- [x] Full suite: 3821 pass, 0 fail; typecheck clean (verified independently of the implementation run)
- [x] New tests proven to catch the bug (revert check: 5 fail on pre-fix code)
- [x] Live picker + new-session dialog rendered in a detached tmux session at 200x50 and 60x30 (borders, ellipsis truncation, active indicator intact)