### PR TITLE
fix(tui): Budget the project cell in columns, not code units

### DIFF
--- a/src/tui/components/SessionItem.test.tsx
+++ b/src/tui/components/SessionItem.test.tsx
@@ -5,6 +5,7 @@ import { createSignal } from "solid-js";
 import { SessionItem, alignText } from "./SessionItem";
 import { TickContext } from "../store";
 import { mockEnrichedSession } from "./test-helpers";
+import { displayWidth } from "../utils/format";
 import type { EnrichedSession } from "../../types";
 
 type Setup = Awaited<ReturnType<typeof testRender>>;
@@ -1144,6 +1145,15 @@ describe("alignText", () => {
     expect(alignText("", 3, "right")).toBe("   ");
     expect(alignText("", 3, "left")).toBe("");
   });
+
+  it("pads a wide glyph by the columns it draws", () => {
+    // `📚:1.0` is 7 code units but 6 columns, so a code-unit padStart would
+    // add 5 spaces and leave the cell a column left of its ASCII neighbours.
+    expect(alignText("📚:1.0", 12, "right")).toBe("      📚:1.0");
+    expect(displayWidth(alignText("📚:1.0", 12, "right"))).toBe(
+      displayWidth(alignText("dev:1.0", 12, "right")),
+    );
+  });
 });
 
 describe("SessionItem right-aligned fields", () => {
@@ -1158,5 +1168,49 @@ describe("SessionItem right-aligned fields", () => {
       160,
     );
     expect(frame).toContain("     dev:1.0");
+  });
+
+  // Both dirnames below are 13 characters; the CJK one draws 26 columns and
+  // has to give some back at this width, while the ASCII one fits whole.
+  // Under the code-unit budget both measured 13 and neither truncated, so the
+  // CJK row drew past its cell. One render per test so each gets torn down.
+  const dirnameRow = (dirname: string) =>
+    renderItem(
+      {
+        session: mockEnrichedSession({
+          cwd: `/Users/e/Code/${dirname}`,
+          paneCwd: `/Users/e/Code/${dirname}`,
+          gitBranch: "main",
+          tmuxTarget: "dev:1.0",
+          lastActivityAt: "2024-01-15T11:59:00Z",
+        }),
+      },
+      56,
+    );
+
+  it("leaves a 13-character ASCII dirname whole at 56 columns", async () => {
+    expect(await dirnameRow("abcdefghijklm")).toContain("abcdefghijklm:main");
+  });
+
+  it("truncates a 13-character CJK dirname at the same width", async () => {
+    expect(await dirnameRow("プロジェクトディレクトリ名前")).toContain(
+      "プロジェクトディレクトリ…:main",
+    );
+  });
+
+  it("right-aligns a wide-glyph pane cell to the same column as an ASCII one", async () => {
+    // Six columns of target in a 12-column cell: six spaces of pad. A
+    // code-unit pad counts the emoji's surrogate pair twice and stops at
+    // five, drawing the cell one column left of every ASCII row.
+    const frame = await renderItem(
+      {
+        session: mockEnrichedSession({
+          tmuxTarget: "📚:1.0",
+          lastActivityAt: "2024-01-15T11:59:00Z",
+        }),
+      },
+      160,
+    );
+    expect(frame).toContain("      📚:1.0");
   });
 });

--- a/src/tui/components/SessionItem.test.tsx
+++ b/src/tui/components/SessionItem.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "bun:test";
 import { testRender } from "@opentui/solid";
 import { MouseButtons } from "@opentui/core/testing";
 import { createSignal } from "solid-js";
-import { SessionItem, alignText } from "./SessionItem";
+import { SessionItem, abbreviateTarget, alignText } from "./SessionItem";
 import { TickContext } from "../store";
 import { mockEnrichedSession } from "./test-helpers";
 import { displayWidth } from "../utils/format";
@@ -1124,6 +1124,52 @@ describe("SessionItem active indicator", () => {
   });
 });
 
+describe("abbreviateTarget", () => {
+  /** A half of a surrogate pair with no partner: what a code-unit slice
+   *  through an astral character leaves behind, rendered as `�`. */
+  const hasLoneSurrogate = (s: string) =>
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+      s,
+    );
+
+  it("leaves the ASCII shapes exactly as they were", () => {
+    expect(abbreviateTarget("dev:1.0")).toBe("dev:1.0");
+    expect(abbreviateTarget("FlashJump:3.4")).toBe("FlashJu~:3.4");
+    expect(abbreviateTarget("some-really-long-session:12.34")).toBe(
+      "some-~:12.34",
+    );
+    expect(abbreviateTarget("nocolon-but-very-long-name")).toBe("nocolon-but~");
+  });
+
+  it("cuts an emoji session name on a cluster, never mid-pair", () => {
+    // The code-unit slice landed between the two surrogates of the fourth
+    // 📚 and drew a replacement glyph in the pane cell.
+    const out = abbreviateTarget("📚📚📚📚📚📚:1.0");
+    expect(out).toBe("📚📚📚~:1.0");
+    expect(hasLoneSurrogate(out)).toBe(false);
+    expect(displayWidth(out)).toBeLessThanOrEqual(12);
+  });
+
+  it("shortens a CJK session name to the box it renders in", () => {
+    // 6 characters of session name draw 12 columns, so the untouched target
+    // drew 16 into a 12-column cell.
+    const out = abbreviateTarget("プロジェクト:1.0");
+    expect(out).toBe("プロジ~:1.0");
+    expect(displayWidth(out)).toBeLessThanOrEqual(12);
+  });
+
+  it("keeps a ZWJ sequence whole", () => {
+    // Three families draw 6 columns, so the whole target already fits; the
+    // code-unit gate called it 37 and sliced through the first family's ZWJ
+    // chain, splitting one glyph into several.
+    const family = "👨‍👩‍👧‍👦";
+    const out = abbreviateTarget(`${family}${family}${family}:10.2`);
+    expect(out).toBe(`${family}${family}${family}:10.2`);
+    expect(hasLoneSurrogate(out)).toBe(false);
+    expect(displayWidth(out)).toBeLessThanOrEqual(12);
+  });
+});
+
 describe("alignText", () => {
   it("passes through for left side", () => {
     expect(alignText("hi", 10, "left")).toBe("hi");
@@ -1212,5 +1258,51 @@ describe("SessionItem right-aligned fields", () => {
       160,
     );
     expect(frame).toContain("      📚:1.0");
+  });
+
+  it("budgets an inline prompt against the columns the project cell draws", async () => {
+    // `projectCellWidth` feeds the prompt's budget. Measured in code units it
+    // reports 13 for a cell drawing 26 columns, so the prompt is handed a
+    // budget it cannot have, skips its own `…`, and gets flex-clipped
+    // mid-word instead ("please refactor the entire" with nothing to say it
+    // was cut).
+    const cwd = "/Users/e/Code/プロジェクトディレクトリ名前";
+    const frame = await renderItem(
+      {
+        session: mockEnrichedSession({
+          cwd,
+          paneCwd: cwd,
+          gitBranch: "main",
+          tmuxTarget: "dev:1.0",
+          lastPrompt:
+            "please refactor the entire authentication module and add tests",
+          lastActivityAt: "2024-01-15T11:59:00Z",
+        }),
+      },
+      120,
+    );
+    expect(frame).toContain("please refactor the entire…");
+  });
+
+  it("reserves the columns a short wide-glyph prompt needs on row 1", async () => {
+    // The prompt floor reserves min(prompt width, 16) before the project cell
+    // spends the rest. Counting this 8-character prompt as 8 instead of the
+    // 16 columns it draws hands the path 8 columns that were the prompt's,
+    // and the prompt comes back clipped to `予算パイプ`.
+    const cwd = "/Users/e/Code/some-long-project-directory-name";
+    const frame = await renderItem(
+      {
+        session: mockEnrichedSession({
+          cwd,
+          paneCwd: cwd,
+          gitBranch: "feature/long-branch-name",
+          tmuxTarget: "dev:1.0",
+          lastPrompt: "予算パイプライン",
+          lastActivityAt: "2024-01-15T11:59:00Z",
+        }),
+      },
+      100,
+    );
+    expect(frame).toContain("予算パイプライン");
   });
 });

--- a/src/tui/components/SessionItem.tsx
+++ b/src/tui/components/SessionItem.tsx
@@ -40,8 +40,10 @@ import {
 import { theme } from "../theme";
 import type { MatchSource } from "../utils/grouping";
 import {
+  displayWidth,
   formatRelativeTime,
   formatVersion,
+  padStartWidth,
   shortenCwd,
   truncateText,
   truncateHighlighted,
@@ -203,9 +205,10 @@ function fittedProjectCell(
 }
 
 /**
- * Rendered char width of the `project` cell, used to budget an inline prompt
+ * Rendered column width of the `project` cell, used to budget an inline prompt
  * that shares row 1 with it. Derived from {@link fittedProjectCell} so it
- * reflects the truncated (`…`) rendering, not the natural width.
+ * reflects the truncated (`…`) rendering, not the natural width, and measured
+ * the same way `fitProjectCell` spends the budget.
  */
 function projectCellWidth(
   session: EnrichedSession,
@@ -215,7 +218,9 @@ function projectCellWidth(
 ): number {
   const fitted = fittedProjectCell(session, mode, budget, maxBranchLen);
   return (
-    fitted.prefix.length + fitted.dirname.length + fitted.branchLabel.length
+    displayWidth(fitted.prefix) +
+    displayWidth(fitted.dirname) +
+    displayWidth(fitted.branchLabel)
   );
 }
 
@@ -304,7 +309,10 @@ function dimColor(ctx: FieldRenderContext, color?: string): string | undefined {
  * Right-align `text` within a fixed-width cell on the right side by padding
  * the left with spaces. Left-side cells keep their natural left-alignment.
  * Opentui's `<text>` fills its parent box, so flex `justifyContent` alone
- * can't right-align a single text child — padStart does the job instead.
+ * can't right-align a single text child, so a left pad does the job instead.
+ * The pad is counted in columns (`padStartWidth`): a code-unit `padStart`
+ * over-pads a cell holding a wide glyph (an emoji tmux session name, a custom
+ * agent label) and shoves it right of its ASCII neighbours.
  */
 export function alignText(
   text: string,
@@ -312,8 +320,7 @@ export function alignText(
   side: "left" | "right",
 ): string {
   if (side !== "right") return text;
-  if (text.length >= width) return text;
-  return text.padStart(width);
+  return padStartWidth(text, width);
 }
 
 const FieldCell: Component<{
@@ -449,7 +456,7 @@ const FieldCell: Component<{
               <Show
                 when={
                   ctx.highlights?.gitBranch &&
-                  branch().length <= ctx.maxBranchLen
+                  displayWidth(branch()) <= ctx.maxBranchLen
                 }
                 fallback={
                   <text fg={dimColor(ctx, theme.blue)}>
@@ -816,16 +823,16 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
   // only by SessionList, so it distinguishes the two contexts.
   const scrollbarReserve = () => (props.layout ? 3 : 1);
 
-  // Prompt-floor budgeting shorthand: how many chars an inline prompt is
+  // Prompt-floor budgeting shorthand: how many columns an inline prompt is
   // guaranteed on row 1 before the project cell starts yielding width. The
   // prompt truncates down to this floor first; only then does the path give
-  // up space. Bounded by data length so a short prompt reserves less.
+  // up space. Bounded by the prompt's own width so a short one reserves less.
   const PROMPT_MIN = 16;
 
   // Budget for the project cell's `…` truncation. Full width minus the item
   // padding, every row-1 sibling except project (and the prompt, budgeted via
   // its floor below), the reserved attention cell, and a small margin. Reads
-  // only the raw prompt length (capped at PROMPT_MIN), never maxPromptLen, so
+  // only the raw prompt width (capped at PROMPT_MIN), never maxPromptLen, so
   // maxPromptLen can depend on the fitted project width without a cycle.
   const maxProjectLen = createMemo(() => {
     const cols = columns();
@@ -844,7 +851,7 @@ export const SessionItem: Component<SessionItemProps> = (props) => {
     const promptFloor =
       promptOnRow1 && hasFieldData(props.session, "prompt")
         ? Math.min(
-            normalizePrompt(props.session.lastPrompt ?? "").length,
+            displayWidth(normalizePrompt(props.session.lastPrompt ?? "")),
             PROMPT_MIN,
           ) + 1
         : 0;

--- a/src/tui/components/SessionItem.tsx
+++ b/src/tui/components/SessionItem.tsx
@@ -45,6 +45,7 @@ import {
   formatVersion,
   padStartWidth,
   shortenCwd,
+  sliceToWidth,
   truncateText,
   truncateHighlighted,
 } from "../utils/format";
@@ -88,15 +89,23 @@ interface SessionItemProps {
   onContextMenu?: (event: MouseEvent) => void;
 }
 
-function abbreviateTarget(target: string, maxLen: number = 12): string {
-  if (target.length <= maxLen) return target;
+/**
+ * Abbreviate a `session:window.pane` target to `maxLen` COLUMNS, keeping the
+ * `:window.pane` suffix whole and shortening the session name with `~`. The
+ * budget and every cut are column-true (a tmux session name is free-form user
+ * text, so it can hold emoji or CJK): a code-unit slice through an emoji left
+ * a lone surrogate in the cell, and a CJK session name drew past the fixed
+ * 12-column box it shares with the right-aligned metadata.
+ */
+export function abbreviateTarget(target: string, maxLen: number = 12): string {
+  if (displayWidth(target) <= maxLen) return target;
   const colonIdx = target.lastIndexOf(":");
-  if (colonIdx === -1) return target.slice(0, maxLen - 1) + "~";
+  if (colonIdx === -1) return sliceToWidth(target, maxLen - 1) + "~";
   const suffix = target.slice(colonIdx);
   const sessionName = target.slice(0, colonIdx);
-  const availableLen = maxLen - suffix.length - 1;
-  if (availableLen <= 0) return target.slice(0, maxLen - 1) + "~";
-  return sessionName.slice(0, availableLen) + "~" + suffix;
+  const availableLen = maxLen - displayWidth(suffix) - 1;
+  if (availableLen <= 0) return sliceToWidth(target, maxLen - 1) + "~";
+  return sliceToWidth(sessionName, availableLen) + "~" + suffix;
 }
 
 interface ProjectPathParts {

--- a/src/tui/components/session-columns.test.ts
+++ b/src/tui/components/session-columns.test.ts
@@ -924,12 +924,11 @@ describe("trailingLabelsWidth", () => {
 
   it("reserves what a wide-glyph label draws, not its code units", () => {
     // The label renders through the column-true `truncateText`, so the
-    // reserve has to agree: `.length` counted this tool name as 12 and
-    // reserved the full cap for something that draws 7 columns.
-    const s = mockEnrichedSession({ pendingTool: "Bash(🚀 go)" });
-    expect(trailingLabelsWidth(s, false)).toBe(
-      displayWidth("Bash(🚀 go)"), // 11 columns for 12 code units
-    );
+    // reserve has to agree: `Bash(検索)` is 8 code units but draws 10 columns,
+    // and reserving 8 leaves the label overhanging whatever sits next to it.
+    const s = mockEnrichedSession({ pendingTool: "Bash(検索)" });
+    expect("Bash(検索)".length).toBe(8);
+    expect(trailingLabelsWidth(s, false)).toBe(10);
     expect(trailingLabelsWidth(s, false)).toBeLessThanOrEqual(
       ATTENTION_LABEL_MAX,
     );
@@ -1350,6 +1349,47 @@ describe("fitProjectCell with wide glyphs", () => {
     );
     expect(out.branchLabel).toBe(":🚀🚀🚀~");
     expect(displayWidth(out.branchLabel)).toBeLessThanOrEqual(8 + 1);
+  });
+
+  it("drops a branch label whose body cannot hold one wide grapheme", () => {
+    // One usable column, and every grapheme of this branch needs two: the
+    // body comes back empty, and `:~` (or `:~+`) would name no branch while
+    // still charging the row two columns it would rather spend on identity.
+    const out = fitProjectCell(
+      {
+        prefix: "epilande/",
+        dirname: "ccm",
+        branch: "日本語ブランチ",
+        isWorktree: true,
+        repoPrefix: true,
+      },
+      16,
+      8,
+    );
+    expect(out.branchLabel).toBe("");
+    expect(out.prefix).toBe("epilande/");
+    expect(cellWidth(out)).toBeLessThanOrEqual(16);
+  });
+
+  it("never emits a content-free branch label at any budget", () => {
+    for (const branch of ["日本語ブランチ", "🚀🚀🚀-go", `${FAMILY}x`]) {
+      for (const isWorktree of [false, true]) {
+        for (let budget = 0; budget <= 40; budget++) {
+          const out = fitProjectCell(
+            {
+              prefix: "epilande/",
+              dirname: "ccm",
+              branch,
+              isWorktree,
+              repoPrefix: true,
+            },
+            budget,
+            8,
+          );
+          expect(out.branchLabel).not.toMatch(/^:~\+?$/);
+        }
+      }
+    }
   });
 
   it("shortens an emoji branch on clusters, never mid-pair", () => {

--- a/src/tui/components/session-columns.test.ts
+++ b/src/tui/components/session-columns.test.ts
@@ -20,10 +20,29 @@ import {
   getAttentionLabel,
   subagentCountLabel,
   ATTENTION_LABEL_MAX,
+  type ProjectCellDisplay,
 } from "./session-columns";
 import type { SubagentState } from "../../types";
 import { DEFAULT_BREAKPOINTS, type Responsive } from "../../lib/preferences";
 import { mockEnrichedSession } from "./test-helpers";
+import { displayWidth } from "../utils/format";
+
+/** A half of a surrogate pair with no partner: what a code-unit slice through
+ *  an astral character leaves behind, rendered as `�`. */
+const hasLoneSurrogate = (s: string) =>
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+    s,
+  );
+
+/**
+ * Columns a fitted project cell draws. The budget `fitProjectCell` spends is a
+ * column count, so every assertion about "how much of the cell rendered"
+ * measures the same way; `.length` would read a wide glyph as two.
+ */
+const cellWidth = (out: ProjectCellDisplay): number =>
+  displayWidth(out.prefix) +
+  displayWidth(out.dirname) +
+  displayWidth(out.branchLabel);
 
 describe("resolveResponsive", () => {
   const bp = DEFAULT_BREAKPOINTS;
@@ -903,6 +922,19 @@ describe("trailingLabelsWidth", () => {
     ).toBe(ATTENTION_LABEL_MAX);
   });
 
+  it("reserves what a wide-glyph label draws, not its code units", () => {
+    // The label renders through the column-true `truncateText`, so the
+    // reserve has to agree: `.length` counted this tool name as 12 and
+    // reserved the full cap for something that draws 7 columns.
+    const s = mockEnrichedSession({ pendingTool: "Bash(🚀 go)" });
+    expect(trailingLabelsWidth(s, false)).toBe(
+      displayWidth("Bash(🚀 go)"), // 11 columns for 12 code units
+    );
+    expect(trailingLabelsWidth(s, false)).toBeLessThanOrEqual(
+      ATTENTION_LABEL_MAX,
+    );
+  });
+
   it("sums attention + subagent + the inter-label gap", () => {
     // pendingTool suppresses the subagent count, so use a waiting session with
     // subagents but no pending tool.
@@ -959,9 +991,7 @@ describe("fitProjectCell", () => {
     expect(out.dirname).toBe("ccmux");
     expect(out.branchLabel).toBe(":main");
     expect(out.prefix.endsWith("…")).toBe(true);
-    expect(
-      out.prefix.length + out.dirname.length + out.branchLabel.length,
-    ).toBe(12);
+    expect(cellWidth(out)).toBe(12);
   });
 
   it("drops the prefix entirely when under 2 usable chars remain", () => {
@@ -986,7 +1016,7 @@ describe("fitProjectCell", () => {
     expect(out.dirname.endsWith("…")).toBe(true);
     expect(out.dirname).not.toBe("claude-toolkit");
     // floor keeps it identifiable, never a negative slice
-    expect(out.dirname.length).toBeGreaterThanOrEqual(5);
+    expect(displayWidth(out.dirname)).toBeGreaterThanOrEqual(5);
   });
 
   it("never produces negative slices on a zero/negative budget", () => {
@@ -1004,7 +1034,7 @@ describe("fitProjectCell", () => {
     // raw mid-word clip), and no slice went negative.
     expect(out.prefix).toBe("");
     expect(out.dirname.endsWith("…")).toBe(true);
-    expect(out.dirname.length).toBeGreaterThanOrEqual(5);
+    expect(displayWidth(out.dirname)).toBeGreaterThanOrEqual(5);
   });
 
   it("keeps a short dirname whole even when the budget is exhausted", () => {
@@ -1032,9 +1062,7 @@ describe("fitProjectCell", () => {
     expect(out.prefix).toBe("ccmux/");
     expect(out.dirname.endsWith("…")).toBe(true);
     expect(out.branchLabel).toBe(":main+");
-    expect(
-      out.prefix.length + out.dirname.length + out.branchLabel.length,
-    ).toBeLessThanOrEqual(20);
+    expect(cellWidth(out)).toBeLessThanOrEqual(20);
   });
 
   it("takes the worktree name below the normal dirname floor to keep the repo", () => {
@@ -1052,11 +1080,9 @@ describe("fitProjectCell", () => {
       8,
     );
     expect(out.prefix).toBe("ccmux/");
-    expect(out.dirname.length).toBeLessThan(5);
+    expect(displayWidth(out.dirname)).toBeLessThan(5);
     expect(out.dirname.endsWith("…")).toBe(true);
-    expect(
-      out.prefix.length + out.dirname.length + out.branchLabel.length,
-    ).toBeLessThanOrEqual(19);
+    expect(cellWidth(out)).toBeLessThanOrEqual(19);
   });
 
   it("drops a repo prefix that no longer names the repo, giving the space back", () => {
@@ -1149,8 +1175,7 @@ describe("fitProjectCell", () => {
             budget,
             24,
           );
-          const width =
-            out.prefix.length + out.dirname.length + out.branchLabel.length;
+          const width = cellWidth(out);
           expect(width).toBeLessThanOrEqual(budget);
         }
       }
@@ -1173,8 +1198,7 @@ describe("fitProjectCell", () => {
             budget,
             24,
           );
-          const width =
-            out.prefix.length + out.dirname.length + out.branchLabel.length;
+          const width = cellWidth(out);
           expect(width).toBeGreaterThanOrEqual(previous);
           previous = width;
         }
@@ -1221,9 +1245,7 @@ describe("fitProjectCell", () => {
     expect(out.prefix).toBe("ccmux/");
     expect(out.dirname.startsWith("p")).toBe(true);
     expect(out.branchLabel.endsWith("~+")).toBe(true);
-    expect(
-      out.prefix.length + out.dirname.length + out.branchLabel.length,
-    ).toBeLessThanOrEqual(25);
+    expect(cellWidth(out)).toBeLessThanOrEqual(25);
   });
 
   it("leaves a branch-less cell without a stray colon", () => {
@@ -1256,8 +1278,159 @@ describe("fitProjectCell", () => {
     expect(out.branchLabel).toBe(":featu~");
     expect(out.branchLabel.endsWith("~")).toBe(true);
     // The cascade never overshoots its budget.
-    expect(
-      out.prefix.length + out.dirname.length + out.branchLabel.length,
-    ).toBeLessThanOrEqual(12);
+    expect(cellWidth(out)).toBeLessThanOrEqual(12);
+  });
+});
+
+describe("fitProjectCell with wide glyphs", () => {
+  const CJK = "プロジェクト"; // 6 chars, 12 columns
+  const FAMILY = "👨‍👩‍👧‍👦"; // 11 code units, 2 columns
+
+  it("truncates a CJK dirname by the columns it draws", () => {
+    // 12 columns of dirname in an 8-column cell. A code-unit budget saw 6 and
+    // let all six characters through, drawing 12 columns into 8.
+    const out = fitProjectCell(
+      { prefix: "", dirname: CJK, branch: null, isWorktree: false },
+      8,
+      24,
+    );
+    expect(out.dirname).toBe("プロジ…");
+    expect(cellWidth(out)).toBeLessThanOrEqual(8);
+  });
+
+  it("keeps the issue's CJK worktree case inside its cell", () => {
+    // The regression the issue reports: budget 8 rendered `プロ…` plus `:ma~+`
+    // at 10 columns, because the code-unit gate freed room for a branch label
+    // the cell could not actually pay for.
+    const out = fitProjectCell(
+      { prefix: "", dirname: CJK, branch: "main", isWorktree: true },
+      8,
+      24,
+    );
+    expect(cellWidth(out)).toBeLessThanOrEqual(8);
+  });
+
+  it("truncates an emoji dirname by columns, keeping the emoji whole", () => {
+    const dirname = "docs-📚"; // 7 columns, 8 code units
+    const fits = fitProjectCell(
+      { prefix: "", dirname, branch: null, isWorktree: false },
+      7,
+      24,
+    );
+    expect(fits.dirname).toBe(dirname);
+
+    const tight = fitProjectCell(
+      { prefix: "", dirname, branch: null, isWorktree: false },
+      6,
+      24,
+    );
+    // The emoji needs two columns and only one is left, so it is dropped
+    // whole rather than sliced into a lone surrogate.
+    expect(tight.dirname).toBe("docs-…");
+    expect(cellWidth(tight)).toBeLessThanOrEqual(6);
+  });
+
+  it("truncates an emoji prefix by columns", () => {
+    const out = fitProjectCell(
+      { prefix: "📚docs/", dirname: "ccmux", branch: null, isWorktree: false },
+      10,
+      24,
+    );
+    expect(out.prefix).toBe("📚do…");
+    expect(out.dirname).toBe("ccmux");
+    expect(cellWidth(out)).toBe(10);
+  });
+
+  it("caps an emoji branch at maxBranchLen columns", () => {
+    // Six rockets are 12 columns; the 8-column cap keeps three plus the `~`.
+    const out = fitProjectCell(
+      { prefix: "", dirname: "app", branch: "🚀🚀🚀🚀🚀🚀", isWorktree: false },
+      40,
+      8,
+    );
+    expect(out.branchLabel).toBe(":🚀🚀🚀~");
+    expect(displayWidth(out.branchLabel)).toBeLessThanOrEqual(8 + 1);
+  });
+
+  it("shortens an emoji branch on clusters, never mid-pair", () => {
+    const out = fitProjectCell(
+      {
+        prefix: "",
+        dirname: "app",
+        branch: "🚀🚀🚀🚀-launch",
+        isWorktree: true,
+      },
+      12,
+      24,
+    );
+    expect(out.branchLabel).toBe(":🚀🚀🚀~+");
+    expect(cellWidth(out)).toBeLessThanOrEqual(12);
+  });
+
+  it("never splits a ZWJ sequence in the dirname", () => {
+    const out = fitProjectCell(
+      {
+        prefix: "",
+        dirname: `${FAMILY}-team`,
+        branch: null,
+        isWorktree: false,
+      },
+      5,
+      24,
+    );
+    // Either the whole family renders or none of it does; a code-unit slice
+    // would have left a bare 👨 (or half of one) behind.
+    expect(out.dirname).toBe(`${FAMILY}-t…`);
+    expect(cellWidth(out)).toBeLessThanOrEqual(5);
+  });
+
+  it("reserves a wide repo prefix at its drawn width", () => {
+    const out = fitProjectCell(
+      {
+        prefix: "📚repo/",
+        dirname: CJK,
+        branch: "main",
+        isWorktree: true,
+        repoPrefix: true,
+      },
+      20,
+      24,
+    );
+    expect(out.prefix).toBe("📚repo/");
+    expect(out.branchLabel).toBe(":main+");
+    expect(cellWidth(out)).toBeLessThanOrEqual(20);
+  });
+
+  it("stays inside its budget across a wide-glyph sweep", () => {
+    // Every prefix x dirname x branch x budget combination of mixed ASCII,
+    // emoji, ZWJ and CJK content: the rendered cell fits, and no output holds
+    // a lone surrogate (the `�` a code-unit slice through an astral character
+    // leaves). The sweep starts at the dirname floor, below which nothing can
+    // fit by construction (the same documented trade the ASCII sweep skips).
+    const prefixes = ["", "epilande/", "📚docs/", `${FAMILY}team/`, "プロ/"];
+    const dirnames = ["ccmux", "docs-📚", FAMILY, CJK, "emoji-🎉-dir"];
+    const branches = [null, "main", "feat/🚀-launch", "機能/ブランチ"];
+    let checked = 0;
+    for (const prefix of prefixes) {
+      for (const dirname of dirnames) {
+        for (const branch of branches) {
+          for (const repoPrefix of [false, true]) {
+            for (let budget = 5; budget <= 30; budget++) {
+              const out = fitProjectCell(
+                { prefix, dirname, branch, isWorktree: true, repoPrefix },
+                budget,
+                12,
+              );
+              expect(cellWidth(out)).toBeLessThanOrEqual(budget);
+              expect(
+                hasLoneSurrogate(out.prefix + out.dirname + out.branchLabel),
+              ).toBe(false);
+              checked++;
+            }
+          }
+        }
+      }
+    }
+    expect(checked).toBeGreaterThan(1000);
   });
 });

--- a/src/tui/components/session-columns.ts
+++ b/src/tui/components/session-columns.ts
@@ -16,7 +16,7 @@ import {
   DEFAULT_BREAKPOINTS,
 } from "../../lib/preferences";
 import type { EnrichedSession, BranchPR } from "../../types";
-import { truncateText } from "../utils/format";
+import { displayWidth, sliceToWidth, truncateText } from "../utils/format";
 
 const RESPONSIVE_KEYS = new Set([
   "default",
@@ -536,8 +536,8 @@ export function trailingLabelsWidth(
   const attn = getAttentionLabel(session);
   if (sidebar) return attn ? 1 : 0;
   const sub = subagentCountLabel(session);
-  const attnW = attn ? Math.min(attn.length, ATTENTION_LABEL_MAX) : 0;
-  const subW = sub ? sub.length : 0;
+  const attnW = attn ? Math.min(displayWidth(attn), ATTENTION_LABEL_MAX) : 0;
+  const subW = sub ? displayWidth(sub) : 0;
   const gap = attn && sub ? 1 : 0; // the space between the two labels
   return attnW + subW + gap;
 }
@@ -567,7 +567,9 @@ export interface ProjectCellDisplay {
 
 /**
  * The `:branch` label with the existing conventions: capped at `maxBranchLen`
- * with a trailing `~`, worktree `+` appended.
+ * COLUMNS with a trailing `~`, worktree `+` appended. Every budget in this
+ * pipeline is a column count, so a branch of wide glyphs is capped by what it
+ * draws rather than by how many code units it happens to spend.
  */
 function branchLabelFor(
   branch: string,
@@ -575,8 +577,8 @@ function branchLabelFor(
   maxBranchLen: number,
 ): string {
   const shown =
-    branch.length > maxBranchLen
-      ? branch.slice(0, maxBranchLen - 1) + "~"
+    displayWidth(branch) > maxBranchLen
+      ? sliceToWidth(branch, maxBranchLen - 1) + "~"
       : branch;
   return ":" + shown + (isWorktree ? "+" : "");
 }
@@ -588,11 +590,11 @@ function minBranchLabelWidth(isWorktree: boolean): number {
 }
 
 /**
- * Shorten a branch label to `avail` chars using the `~` marker; "" if too
+ * Shorten a branch label to `avail` columns using the `~` marker; "" if too
  * tight. "Too tight" counts the worktree `+` as well as the ":" and one
- * usable char, because a label that keeps a one-char body plus both markers
- * would come back WIDER than the room it was given — and on a worktree row
- * that single overspent char is enough to push the repo out of the cell.
+ * usable column, because a label that keeps a one-column body plus both
+ * markers would come back WIDER than the room it was given, and on a worktree
+ * row that single overspent column is enough to push the repo out of the cell.
  */
 function shortenBranchLabel(
   branch: string,
@@ -601,42 +603,47 @@ function shortenBranchLabel(
 ): string {
   const wt = isWorktree ? "+" : "";
   if (avail < minBranchLabelWidth(isWorktree)) return "";
-  const bodyLen = Math.max(1, avail - 1 /* colon */ - 1 /* ~ */ - wt.length);
-  if (branch.length <= bodyLen) return ":" + branch + wt;
-  return ":" + branch.slice(0, bodyLen) + "~" + wt;
+  const bodyWidth = Math.max(1, avail - 1 /* colon */ - 1 /* ~ */ - wt.length);
+  if (displayWidth(branch) <= bodyWidth) return ":" + branch + wt;
+  return ":" + sliceToWidth(branch, bodyWidth) + "~" + wt;
 }
 
-/** Fit the prefix into `avail` chars; dropped entirely under 2 usable ones. */
+/** Fit the prefix into `avail` columns; dropped entirely under 2 usable ones. */
 function fitPrefix(prefix: string, avail: number): string {
   if (avail < 2) return "";
-  return prefix.length > avail ? truncateText(prefix, avail) : prefix;
+  return displayWidth(prefix) > avail ? truncateText(prefix, avail) : prefix;
 }
 
 /** The dirname is the cell's last identifiable part, so it holds this many
- *  chars even when the budget says otherwise. */
+ *  columns even when the budget says otherwise. */
 const DIRNAME_FLOOR = 5;
 /** Floor for a dirname that shares the cell with a repo prefix: the repo is
  *  the identity there, so the worktree name gives up more before the repo
  *  gives up anything. */
 const WORKTREE_NAME_FLOOR = 3;
 
-/** Fit the dirname into `avail` chars, never below `floor` (the caller
+/** Fit the dirname into `avail` columns, never below `floor` (the caller
  *  absorbs the overflow elsewhere). */
 function fitDirname(
   dirname: string,
   avail: number,
   floor = DIRNAME_FLOOR,
 ): string {
-  if (dirname.length <= avail) return dirname;
+  if (displayWidth(dirname) <= avail) return dirname;
   return truncateText(dirname, Math.max(floor, avail));
 }
 
 /**
- * Fit the project (path:branch) cell into `budget` chars, never silently
+ * Fit the project (path:branch) cell into `budget` COLUMNS, never silently
  * clipping: any shortening shows `…` (or the existing `~` for the branch).
  * Shrink order matches the design: prefix first (drop it under 2 usable
- * chars), then the dirname (kept to a small floor), then the branch as a last
- * resort.
+ * columns), then the dirname (kept to a small floor), then the branch as a
+ * last resort.
+ *
+ * Every budget here is measured with `displayWidth`, not `.length`: the parts
+ * are cut by `truncateText`/`sliceToWidth`, which are column-true, so counting
+ * the leftovers in code units would let a wide-glyph dirname (or an emoji in a
+ * branch name) buy room the terminal never gives it back.
  *
  * A `repoPrefix` cell (a worktree's `<repo>/<worktree>`) reverses the first
  * two, since the repo a worktree belongs to is worth more than the tail of
@@ -660,6 +667,8 @@ export function fitProjectCell(
   maxBranchLen: number,
 ): ProjectCellDisplay {
   const { prefix, dirname, branch, isWorktree, repoPrefix } = input;
+  const prefixWidth = displayWidth(prefix);
+  const dirnameWidth = displayWidth(dirname);
   let branchLabel = branch
     ? branchLabelFor(branch, isWorktree, maxBranchLen)
     : "";
@@ -674,11 +683,11 @@ export function fitProjectCell(
     // branch blink out of existence as the terminal *widens* into the band
     // where the repo starts fitting.
     const identityReserve =
-      prefix.length + Math.min(dirname.length, WORKTREE_NAME_FLOOR);
+      prefixWidth + Math.min(dirnameWidth, WORKTREE_NAME_FLOOR);
     const minBranch = minBranchLabelWidth(isWorktree);
     if (
       identityReserve + minBranch <= budget &&
-      branchLabel.length > budget - identityReserve
+      displayWidth(branchLabel) > budget - identityReserve
     ) {
       branchLabel = shortenBranchLabel(
         branch,
@@ -689,9 +698,9 @@ export function fitProjectCell(
   }
 
   // What the path parts get to share once the branch label has its width.
-  const pathBudget = budget - branchLabel.length;
+  const pathBudget = budget - displayWidth(branchLabel);
 
-  if (prefix.length + dirname.length <= pathBudget) {
+  if (prefixWidth + dirnameWidth <= pathBudget) {
     return { prefix, dirname, branchLabel };
   }
 
@@ -702,10 +711,10 @@ export function fitProjectCell(
     // 1. Shrink the worktree name first, keeping the repo whole.
     outDirname = fitDirname(
       dirname,
-      pathBudget - prefix.length,
+      pathBudget - prefixWidth,
       WORKTREE_NAME_FLOOR,
     );
-    if (prefix.length + outDirname.length > pathBudget) {
+    if (prefixWidth + displayWidth(outDirname) > pathBudget) {
       // 2. Even at its floor the pair doesn't fit: drop the repo whole (never
       //    a stub) and give the worktree name the entire path budget back.
       outPrefix = "";
@@ -713,17 +722,18 @@ export function fitProjectCell(
     }
   } else {
     // 1. Shrink the prefix first: give it what's left after dirname+branch.
-    outPrefix = fitPrefix(prefix, pathBudget - dirname.length);
+    outPrefix = fitPrefix(prefix, pathBudget - dirnameWidth);
     // 2. Then the dirname, kept to a small floor so it stays identifiable.
-    outDirname = fitDirname(dirname, pathBudget - outPrefix.length);
+    outDirname = fitDirname(dirname, pathBudget - displayWidth(outPrefix));
   }
-  if (outPrefix.length + outDirname.length <= pathBudget) {
+  if (displayWidth(outPrefix) + displayWidth(outDirname) <= pathBudget) {
     return { prefix: outPrefix, dirname: outDirname, branchLabel };
   }
 
   // 3. Last resort: shorten the branch further with the `~` marker.
   if (branch) {
-    const availForBranch = budget - outPrefix.length - outDirname.length;
+    const availForBranch =
+      budget - displayWidth(outPrefix) - displayWidth(outDirname);
     branchLabel = shortenBranchLabel(branch, isWorktree, availForBranch);
   }
   return { prefix: outPrefix, dirname: outDirname, branchLabel };

--- a/src/tui/components/session-columns.ts
+++ b/src/tui/components/session-columns.ts
@@ -583,8 +583,10 @@ function branchLabelFor(
   return ":" + shown + (isWorktree ? "+" : "");
 }
 
-/** Narrowest branch label that still renders: ":" + one char + "~" + the
- *  worktree "+". Anything less and `shortenBranchLabel` returns "". */
+/** Narrowest budget that could still render a label: ":" + one column of
+ *  branch + "~" + the worktree "+". Anything less and `shortenBranchLabel`
+ *  returns "" outright; at or above it the label still drops when the branch
+ *  has no grapheme narrow enough to fill that one column. */
 function minBranchLabelWidth(isWorktree: boolean): number {
   return 3 + (isWorktree ? 1 : 0);
 }
@@ -595,6 +597,11 @@ function minBranchLabelWidth(isWorktree: boolean): number {
  * usable column, because a label that keeps a one-column body plus both
  * markers would come back WIDER than the room it was given, and on a worktree
  * row that single overspent column is enough to push the repo out of the cell.
+ *
+ * A body that comes back empty drops the whole label. The one usable column
+ * can hold no part of a wide-glyph branch (a CJK or emoji grapheme needs two),
+ * and `:~` names no branch while still charging two columns the row would
+ * rather spend on identity.
  */
 function shortenBranchLabel(
   branch: string,
@@ -605,7 +612,9 @@ function shortenBranchLabel(
   if (avail < minBranchLabelWidth(isWorktree)) return "";
   const bodyWidth = Math.max(1, avail - 1 /* colon */ - 1 /* ~ */ - wt.length);
   if (displayWidth(branch) <= bodyWidth) return ":" + branch + wt;
-  return ":" + sliceToWidth(branch, bodyWidth) + "~" + wt;
+  const body = sliceToWidth(branch, bodyWidth);
+  if (!body) return "";
+  return ":" + body + "~" + wt;
 }
 
 /** Fit the prefix into `avail` columns; dropped entirely under 2 usable ones. */

--- a/src/tui/utils/format.test.ts
+++ b/src/tui/utils/format.test.ts
@@ -3,6 +3,7 @@ import {
   displayWidth,
   formatSubagentName,
   formatVersion,
+  padStartWidth,
   sliceToWidth,
   truncateText,
   truncateHighlighted,
@@ -135,6 +136,34 @@ describe("sliceToWidth", () => {
   it("returns nothing when there is no room", () => {
     expect(sliceToWidth("hello", 0)).toBe("");
     expect(sliceToWidth("hello", -3)).toBe("");
+  });
+});
+
+describe("padStartWidth", () => {
+  it("matches padStart for ASCII", () => {
+    expect(padStartWidth("hi", 5)).toBe("   hi");
+    expect(padStartWidth("", 3)).toBe("   ");
+  });
+
+  it("leaves text that already fills (or overflows) the width alone", () => {
+    expect(padStartWidth("hello", 5)).toBe("hello");
+    expect(padStartWidth("too long", 5)).toBe("too long");
+  });
+
+  it("pads a wide glyph by the columns it draws, not its code units", () => {
+    // padStart would count FAMILY as 11 and pad nothing at all; the cell needs
+    // 8 spaces to end on the same column as an ASCII neighbour.
+    expect(padStartWidth(FAMILY, 10)).toBe(" ".repeat(8) + FAMILY);
+    expect(displayWidth(padStartWidth(FAMILY, 10))).toBe(10);
+    expect(displayWidth(padStartWidth(CJK, 20))).toBe(20);
+  });
+
+  it("lands an emoji cell on the same column as an ASCII one", () => {
+    const width = 12;
+    for (const text of ["1:2.3", FLAG, `${FAMILY}:1.0`, `${CJK}`]) {
+      const padded = padStartWidth(text, width);
+      expect(displayWidth(padded)).toBe(Math.max(width, displayWidth(text)));
+    }
   });
 });
 

--- a/src/tui/utils/format.ts
+++ b/src/tui/utils/format.ts
@@ -86,6 +86,18 @@ function sliceTailToWidth(text: string, maxWidth: number): string {
   return out;
 }
 
+/**
+ * Left-pad `text` with spaces until it occupies `width` columns; the
+ * column-true counterpart of `String.padStart`, which counts code units and so
+ * over-pads anything holding a wide glyph (an emoji pads as if it were its two
+ * surrogates, pushing a right-aligned cell out of line with its ASCII
+ * neighbours). Text already at or over `width` comes back untouched.
+ */
+export function padStartWidth(text: string, width: number): string {
+  const pad = width - displayWidth(text);
+  return pad > 0 ? " ".repeat(pad) + text : text;
+}
+
 /** Truncate plain text to `maxLen` columns, adding an ellipsis when clipped. */
 export function truncateText(text: string, maxLen: number): string {
   if (displayWidth(text) <= maxLen) return text;


### PR DESCRIPTION
## Overview

Converts the project-cell layout pipeline from UTF-16 code-unit budgets to display-column budgets, so emoji and other wide glyphs in directory names, branch names, and prompts measure and align exactly like ASCII.

Resolves #93

## Motivation

#92 made the shared truncation helpers column-true, but the budget arithmetic feeding them still counted code units, so the two halves of the pipeline disagreed. A cell holding an emoji directory or branch name could overflow its column budget and push neighbouring cells out of alignment, and the right-aligned pane cell padded by code units, shoving an emoji session name right of its ASCII neighbours. This finishes the job: one metric end to end.

## Changes

### Column budgets

- **src/tui/components/session-columns.ts** - All budget reads in `fitProjectCell` and its helpers (`branchLabelFor`, `shortenBranchLabel`, `fitPrefix`, `fitDirname`, `trailingLabelsWidth`) now measure with `displayWidth` and slice with `sliceToWidth`. The shrink order is untouched; only the measurement changed.
- **src/tui/components/SessionItem.tsx** - `projectCellWidth` sums fitted parts in columns, the `promptFloor` reserve measures the normalized prompt in columns, `alignText` pads via the new column-true helper, and the highlighted-branch gate now agrees with `branchLabelFor`'s cap (left in code units it would have let a wide highlighted branch render past it).
- **src/tui/utils/format.ts** - Adds `padStartWidth`, the column-true counterpart of `String.padStart`.

### Tests

- **src/tui/components/session-columns.test.ts** - Existing width assertions converted from `.length` sums to `displayWidth`; wide-glyph cases per helper (emoji dirname, ZWJ, CJK, emoji branch) plus a sweep-style property test asserting fitted cells never exceed their column budget and never emit a lone surrogate.
- **src/tui/components/SessionItem.test.tsx** - Right-align parity: a row with an emoji cell ends on the same column as an ASCII one.
- **src/tui/utils/format.test.ts** - `padStartWidth` coverage.

Sweep results (throwaway scripts, not committed): 73,200 ASCII configurations old vs new produced 0 differences, and a 109,800-configuration wide-glyph sweep went from 14,620 over-budget cells to 0.

Known limit: tmux itself measures ZWJ sequences (family emoji) wider than the 2 columns OpenTUI and `Bun.stringWidth` agree on, so a ZWJ directory name can still look ragged in a real terminal. That is a terminal-vs-renderer disagreement outside the layout's control; single-codepoint emoji and CJK render correctly.

## Breaking Changes

None

## Testing

- [x] Full suite: 3839 pass, 0 fail (+18 new tests); typecheck clean (verified independently of the implementation run)
- [x] ASCII parity: 73,200 configurations, 0 differences vs main
- [x] Wide-glyph sweep: 14,620 over-budget cells before, 0 after
- [x] Live picker frames (mock daemon rows, isolated tmux server): emoji and CJK cells truncate to exactly 12 columns and the pane cell right-aligns flush with ASCII rows