### PR TITLE
fix(tui): Restore terminal modes on process.exit quits

### DIFF
--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -119,10 +119,17 @@ export async function launchTUI(options: TUIOptions = {}): Promise<void> {
   // Quit paths exit via process.exit(), which skips OpenTUI's `beforeExit`
   // cleanup (its signal handlers do fire, but `process.exit` emits only
   // `exit`), leaving mouse tracking and the alternate screen armed on the
-  // host terminal (issue #125). destroy() is synchronous and idempotent,
-  // so it is safe here even when a signal-driven destroy already ran.
+  // host terminal (issue #125). destroy() is idempotent, so it is safe here
+  // even when a signal-driven destroy already ran, and it restores the
+  // terminal synchronously as long as no frame callback awaits real I/O
+  // (destroy() during a live render pass defers the restore to the render
+  // loop, which never resumes once process.exit is in flight). The catch
+  // matters: destroy() runs every Solid onCleanup before the native restore,
+  // and a throw there would skip the restore and reinstate #125.
   process.on("exit", () => {
-    renderer.destroy();
+    try {
+      renderer.destroy();
+    } catch {}
   });
 
   await render(

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -100,18 +100,30 @@ export async function launchTUI(options: TUIOptions = {}): Promise<void> {
 
   // Sidebar spawned via -d into an unfocused pane needs the focus dance
   // to keep terminal capability probe replies from leaking into the
-  // user's shell. Picker/non-sidebar TUIs run in the user's own focused
-  // pane, so the dance is a no-op there.
-  let rendererOrConfig: CliRenderer | typeof config = config;
+  // user's shell. Focus must be stolen before the renderer exists, since
+  // creating it fires the probes. Picker/non-sidebar TUIs run in the
+  // user's own focused pane, so the dance is a no-op there.
+  let restoreTarget: string | null = null;
   if (options.sidebar && process.env.TMUX_PANE) {
-    const restoreTarget = await findRestorePane();
+    restoreTarget = await findRestorePane();
     if (restoreTarget) {
       await selectPane(process.env.TMUX_PANE);
-      const renderer = await createCliRenderer(config);
-      arrangeSidebarFocusDance(renderer, restoreTarget);
-      rendererOrConfig = renderer;
     }
   }
+
+  const renderer = await createCliRenderer(config);
+  if (restoreTarget) {
+    arrangeSidebarFocusDance(renderer, restoreTarget);
+  }
+
+  // Quit paths exit via process.exit(), which skips OpenTUI's `beforeExit`
+  // cleanup (its signal handlers do fire, but `process.exit` emits only
+  // `exit`), leaving mouse tracking and the alternate screen armed on the
+  // host terminal (issue #125). destroy() is synchronous and idempotent,
+  // so it is safe here even when a signal-driven destroy already ran.
+  process.on("exit", () => {
+    renderer.destroy();
+  });
 
   await render(
     () => (
@@ -136,6 +148,6 @@ export async function launchTUI(options: TUIOptions = {}): Promise<void> {
         forkableAgents={options.forkableAgents}
       />
     ),
-    rendererOrConfig,
+    renderer,
   );
 }


### PR DESCRIPTION
## Summary

Restores the host terminal's modes when the TUI quits. Every user-visible quit path (<kbd>q</kbd>/<kbd>Escape</kbd>, <kbd>Enter</kbd>-to-jump, spawn-enter) exits via `process.exit()`, which skips OpenTUI's `beforeExit` cleanup hook, so the mouse-tracking modes (`?1000h ?1002h ?1003h ?1006h`) and the `?1049` alternate screen were never restored. Anywhere the TUI shares a real terminal with the user's shell (picker run directly in a pane, persistent pickers), every subsequent mouse move spewed SGR sequences like `35;71;29M...` into the prompt. tmux popups masked the leak by discarding the popup's pty.

`launchTUI` now always creates the renderer itself (previously the picker path let `@opentui/solid` create it internally, leaving no handle) and installs a `process.on("exit")` listener that calls `renderer.destroy()`, whose native shutdown emits the full disable block. `destroy()` is synchronous and idempotent, so it is safe from an `exit` listener and composes with OpenTUI's signal handlers, which already cover `SIGHUP`/`SIGINT`/`SIGTERM` correctly (verified by counter-test: a SIGHUP'd picker restores cleanly on both old and new builds). The sidebar focus dance keeps its ordering: focus is stolen before renderer creation, since creation fires the capability probes.

## Related issue

Resolves #125

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (4930 pass / 0 fail)
- [x] Verified the affected TUI surface (picker / sidebar) in a detached tmux session (if this touches the TUI, columns, layout, theming, or the daemon → TUI data path)
- [ ] Verified end to end with a real agent session (if this touches detection, state, the daemon, or the CLI)

Verification used tmux's per-pane mode flags as ground truth:

- Before the fix, picker + <kbd>q</kbd>: `mouse_any=1 mouse_sgr=1 alt_screen=1` left armed (reproduces #125 exactly).
- After the fix, picker + <kbd>q</kbd>: `mouse_any=0 mouse_sgr=0 alt_screen=0`.
- Sidebar direct launch renders and <kbd>q</kbd> kills its pane as designed; `ccmux sidebar --toggle` still spawns unfocused with no capability-probe gibberish in the shell pane, and a second toggle tears it down.

## Notes for reviewers

- The issue's proposed mechanism (missing `SIGHUP` handling) is not the actual gap: OpenTUI registers handlers for `SIGHUP` and friends, and they restore correctly. The gap is `process.exit()`, which emits only `exit`, and OpenTUI listens on `beforeExit`.
- Upstream OpenTUI has adjacent open issues (anomalyco/opentui#904 / #905, a brief echo window during destroy ordering) that are distinct from this bug and not addressed here.
- A `mouse: false` config preference (also noted in #125) would be a separate small feature.
- E2E recording to follow as a comment.