### PR TITLE
fix(opencode): Write float-second marker timestamps

### DIFF
--- a/src/daemon/adapters/opencode/aggregate.test.ts
+++ b/src/daemon/adapters/opencode/aggregate.test.ts
@@ -254,4 +254,30 @@ describe("aggregateOpenCodeMarkers", () => {
     ]);
     expect(agg.lastPrompt).toBeNull();
   });
+
+  it("breaks a same-integer-second tie using sub-second state_timestamp precision", () => {
+    // Regression guard: the opencode plugin writes float-second
+    // state_timestamps so two markers landing in the same wall-clock second
+    // still order deterministically instead of tying (which previously fell
+    // back to nondeterministic sort/readdir order).
+    const older = marker({
+      session_id: "old",
+      state: "idle",
+      state_timestamp: 1_700_000_000.001,
+      last_prompt: "old",
+    });
+    const newer = marker({
+      session_id: "new",
+      state: "idle",
+      state_timestamp: 1_700_000_000.002,
+    });
+
+    const ascending = aggregateOpenCodeMarkers([older, newer]);
+    expect(ascending.nativeSessionId).toBe("new");
+    expect(ascending.lastPrompt).toBeNull();
+
+    const descending = aggregateOpenCodeMarkers([newer, older]);
+    expect(descending.nativeSessionId).toBe("new");
+    expect(descending.lastPrompt).toBeNull();
+  });
 });

--- a/src/daemon/adapters/opencode/integration.test.ts
+++ b/src/daemon/adapters/opencode/integration.test.ts
@@ -38,7 +38,10 @@ const PANE_ID = "%9";
 function makeClock(): { now: () => number; advance: (ms: number) => void } {
   let t = 1_700_000_000_000;
   return {
-    now: () => ++t,
+    // Advance a full second per call (not 1ms) so consecutive marker writes
+    // land in distinct integer seconds: aggregate.ts's activity ordering is
+    // no longer sensitive to sub-second precision here.
+    now: () => (t += 1000),
     advance: (ms: number) => {
       t += ms;
     },

--- a/src/plugins/opencode/plugin.js
+++ b/src/plugins/opencode/plugin.js
@@ -21,7 +21,10 @@ import { join } from "node:path";
 /**
  * @typedef {object} MarkerState
  * @property {"idle"|"working"|"waiting_permission"} [state]
- * @property {number} [state_timestamp]
+ * @property {number} [state_timestamp] Float epoch seconds (sub-second
+ *   precision, matching the jq-based hook scripts' `now`), so two sibling
+ *   sessions updated within the same wall-clock second still order
+ *   deterministically instead of tying.
  * @property {string} [directory]
  * @property {string} [title]
  * @property {string|null} [pending_tool]
@@ -79,8 +82,10 @@ export function makePlugin({ markersDir, version, now = Date.now }) {
       agent_type: AGENT_TYPE,
       pid: process.pid,
       session_id: sessionId,
-      timestamp: Math.floor(ts / 1000),
-      state_timestamp: Math.floor(ts / 1000),
+      // Float seconds (not floored) so sibling sessions updated within the
+      // same wall-clock second still order deterministically in aggregate.ts.
+      timestamp: ts / 1000,
+      state_timestamp: ts / 1000,
       ...state,
     };
     return JSON.stringify(body);

--- a/src/plugins/opencode/plugin.test.ts
+++ b/src/plugins/opencode/plugin.test.ts
@@ -133,6 +133,27 @@ describe("makePlugin: eager seed", () => {
     expect(m3).toMatchObject({ state: "working", title: "Gamma" });
   });
 
+  it("writes state_timestamp with sub-second precision from the injected clock", async () => {
+    // Regression guard: floored integer-second timestamps make two sibling
+    // sessions written within the same wall-clock second tie in
+    // aggregate.ts's newest-marker sort. Float seconds keep them ordered.
+    const client = makeClient(
+      [{ id: "s1", directory: "/tmp/a", title: "Alpha" }],
+      { s1: { type: "idle" } },
+    );
+    const plugin = makePlugin({
+      markersDir,
+      version: "1.0.0",
+      now: () => 1_700_000_000_123,
+    });
+    const hooks = await plugin({ client });
+    await awaitSeed(hooks);
+
+    const m1 = readMarker(markersDir, "s1");
+    expect(m1?.state_timestamp).toBeCloseTo(1_700_000_000.123, 3);
+    expect(m1?.timestamp).toBeCloseTo(1_700_000_000.123, 3);
+  });
+
   it("defaults to idle when a session has no status entry", async () => {
     const client = makeClient(
       [{ id: "s1", directory: "/tmp/a", title: "Alpha" }],


### PR DESCRIPTION
## Overview

Fixes the OpenCode plugin to write float-second marker timestamps instead of flooring them to whole seconds, removing a tie that made sibling-marker ordering depend on filesystem readdir order. This is what turned CI red on `main`.

## Motivation

`aggregateOpenCodeMarkers` folds the N markers under one OpenCode server into a single session, sorting them by `state_timestamp` to pick the newest. Because the plugin floored that value to whole seconds, two sibling sessions updated within the same wall-clock second produced identical timestamps. A stable sort leaves a tie resolved by input order, which comes from `readdir` via the marker cache, so whichever sibling the filesystem happened to list first won.

That is exactly the sticky-prompt bug the fold already guards against. On a tie, the "newest" marker could be the older session, so a freshly created session kept showing the previous sibling's prompt in the picker.

The same tie made the regression test in `integration.test.ts` order-dependent. Its mock clock advanced 1ms per call, so every marker floored into one second. The test passed on macOS and failed on Linux CI, which is why `main` went red on #130 and stayed red through a rerun.

Float seconds is already the convention everywhere else: the jq-based hook scripts for Claude, Codex, Cursor, Antigravity, and Copilot all emit jq's `now`, and `watcher.ts` documents markers as carrying float seconds. OpenCode was the outlier.

## Changes

### Plugin

- **src/plugins/opencode/plugin.js** - Writes `timestamp` and `state_timestamp` as float seconds rather than `Math.floor(ts / 1000)`, so siblings updated in the same second still order deterministically. Documents the invariant on the `MarkerState` typedef

### Tests

- **src/plugins/opencode/plugin.test.ts** - Asserts a written marker preserves sub-second precision from the injected clock, guarding against a floor being reintroduced
- **src/daemon/adapters/opencode/aggregate.test.ts** - Covers a same-integer-second tie broken by sub-second precision, asserted in both input orders
- **src/daemon/adapters/opencode/integration.test.ts** - Advances the mock clock a full second per call so the regression test no longer depends on sub-second precision to disambiguate

## Breaking Changes

None

Consumers only multiply the value by 1000, so they gain millisecond resolution and nothing else. The plugin's redundant-write suppression compares patch fields against in-memory state and never sees timestamps, so marker write frequency is unchanged. Old and new daemons read each other's markers fine in both directions.

## Testing

- [x] Full suite green (4935 pass, 0 fail) and `bun run typecheck` clean
- [x] Proved the mechanism: the pre-fix tie reproduces the exact CI failure value under one input order, and post-fix values are order-independent across every permutation
- [x] Verified the installed artifact renders through `renderOpenCodePlugin()`, loads as a module, and writes float markers
- [x] E2E against real OpenCode 1.18.11 in an isolated config dir and daemon: markers carried sub-second precision end to end, and the daemon derived `idle` to `working` to `idle` plus a `waiting` permission state from them

> [!NOTE]
> Existing installs keep the old plugin until `ccmux setup --agent opencode` is rerun. The daemon's staleness nudge keys off the version string, so it stays quiet while the version is unchanged. A release bump makes it fire normally.
