### PR TITLE
fix: rearm watcher tree after null events

### DIFF
--- a/src/daemon/log-tree-watcher.test.ts
+++ b/src/daemon/log-tree-watcher.test.ts
@@ -208,6 +208,41 @@ describe("LogTreeWatcher (native)", () => {
     expect(unlinked).toContain(gone);
   });
 
+  it("reopens nested gates on a null event when directory signatures collide", async () => {
+    const project = join(root, "proj-a");
+    mkdirSync(project);
+    const gone = join(project, "gone.jsonl");
+    writeFileSync(gone, "x\n");
+    await startWatcher(1);
+
+    const evt = watcher as unknown as Internals;
+    evt.handleEvent(null);
+
+    const fresh = join(project, "fresh.jsonl");
+    writeFileSync(fresh, "x\n");
+    unlinkSync(gone);
+
+    // Model a filesystem whose timestamp granularity lets the rapid pair of
+    // mutations retain a cached child signature. Reopening only the root
+    // gates cannot discover either change below that still-closed child.
+    const current = statSync(project, { bigint: true });
+    const collidingSig = {
+      mtimeNs: current.mtimeNs,
+      ctimeNs: current.ctimeNs,
+    };
+    const projectNode = evt.rootNode.childDirs.get(project) as TreeNode & {
+      walkSig: typeof collidingSig;
+      sweepSig: typeof collidingSig;
+    };
+    projectNode.walkSig = collidingSig;
+    projectNode.sweepSig = collidingSig;
+
+    evt.handleEvent(null);
+
+    expect(added).toContain(fresh);
+    expect(unlinked).toContain(gone);
+  });
+
   it("falls back to chokidar without throwing when the root is missing", async () => {
     // Parity with the pre-native behavior: a missing log dir (fresh
     // machine, agent never run) must construct and reach ready without

--- a/src/daemon/log-tree-watcher.ts
+++ b/src/daemon/log-tree-watcher.ts
@@ -20,14 +20,11 @@ function isEnoent(error: unknown): boolean {
 }
 
 /**
- * A directory's gate key. `ctimeNs` is part of the key, not decoration:
- * on coarse-mtime filesystems (Linux ext4 with small inodes resolves
- * mtime to the second) two namespace mutations in the same directory
- * within one second share an mtime tick, but ctime advances on every
- * inode metadata change regardless of granularity — and `utimes` cannot
- * reset it. Keying on (mtimeNs, ctimeNs) makes a same-tick add/remove
- * collision (which would silently drop an `add`/`unlink`) unreachable on
- * every local filesystem we target.
+ * A directory's cheap gate key. Node exposes nanoseconds, but both values
+ * retain the filesystem's actual timestamp resolution. Rapid namespace
+ * mutations can therefore leave both unchanged on coarse-resolution
+ * filesystems, so equality is an optimization rather than proof that the
+ * directory did not change.
  */
 interface DirSig {
   mtimeNs: bigint;
@@ -74,6 +71,13 @@ function newDirNode(): DirNode {
     files: new Set(),
     childDirs: new Map(),
   };
+}
+
+/** Reopen every cached gate under `node` for the null-event reconcile. */
+function clearSigs(node: DirNode): void {
+  node.walkSig = null;
+  node.sweepSig = null;
+  for (const child of node.childDirs.values()) clearSigs(child);
 }
 
 /**
@@ -308,6 +312,15 @@ class NativeLogTreeWatcher extends EventEmitter implements LogTreeWatcher {
     // whole subtree (walk for new files, sweep for gone ones) rather
     // than trusting the event to name the exact path that changed.
     if (!relPath) {
+      // A null event carries no path-local evidence, so cached directory
+      // signatures cannot safely close the gates. On filesystems whose
+      // timestamp resolution is coarser than the mutation sequence (HFS+,
+      // legacy ext4 with 128-byte inodes), a rapid add/remove pair can
+      // leave a directory's (mtime, ctime) unchanged. Clear every cached
+      // gate, not just the root: no built-in keeps session files at the
+      // root (claude depth 1, copilot 2, codex 4), so a root-only reset
+      // would miss every .jsonl that matters.
+      clearSigs(this.rootNode);
       this.walk(this.root, this.rootNode, 0);
       this.sweep(this.root, this.rootNode);
       return;


### PR DESCRIPTION
<!--
Thanks for contributing to ccmux! Please fill out the sections below.
Keep the PR focused and use conventional commit style for the title
(e.g. `fix: handle stale hook markers`, `docs: expand security policy`).
-->

## Summary

Reopen the native watcher’s root walk and sweep gates when `fs.watch`
delivers an event without a path.

This prevents rapid root-level additions and removals from being missed when
the filesystem reports colliding directory timestamps.

## Testing

<!-- How did you verify this change? Check all that apply and note anything relevant. -->

- [x] `bun run typecheck` passes
- [x] `bun test` passes
- [x] Verified the affected TUI surface (picker / sidebar) in a detached tmux session (if this touches the TUI, columns, layout, theming, or the daemon → TUI data path)
- [ ] Verified end to end with a real agent session (if this touches detection, state, the daemon, or the CLI)

## Notes for reviewers

The regression test deterministically models a root-directory signature
collision. On current main, the watcher misses the added and removed files.
With this change, it detects both correctly.

The picker was also verified using an isolated tmux server, isolated ccmux
daemon, and a seeded Codex session.
