### PR TITLE
fix(tui): Render session names with theme.text instead of white

### DIFF
--- a/src/tui/components/GroupPreview.tsx
+++ b/src/tui/components/GroupPreview.tsx
@@ -235,7 +235,7 @@ export const GroupPreview: Component<GroupPreviewProps> = (props) => {
     >
       <box height={3} flexDirection="column">
         <box flexDirection="row" gap={1}>
-          <text>
+          <text fg={theme.text}>
             <b>{props.header.label}</b>
           </text>
           <text fg={theme.subtext}>({props.header.count} sessions)</text>

--- a/src/tui/components/Header.tsx
+++ b/src/tui/components/Header.tsx
@@ -34,7 +34,7 @@ export const Header: Component<HeaderProps> = (props) => {
     <box width="100%" height={1} paddingLeft={1} paddingRight={1}>
       <box flexDirection="row" width="100%">
         <text fg={c(dotColor(props.connectionState))}>● </text>
-        <text fg={c(undefined)}>
+        <text fg={c(theme.text)}>
           <b>Sessions</b>
         </text>
         <text fg={c(theme.overlay)}>

--- a/src/tui/components/Preview.tsx
+++ b/src/tui/components/Preview.tsx
@@ -449,7 +449,7 @@ export const Preview: Component<PreviewProps> = (props) => {
         <box height={4} flexDirection="column">
           <box flexDirection="row">
             <box flexGrow={1}>
-              <text>
+              <text fg={theme.text}>
                 <b>{props.session!.project}</b>
               </text>
             </box>

--- a/src/tui/components/SessionItem.tsx
+++ b/src/tui/components/SessionItem.tsx
@@ -424,10 +424,7 @@ const FieldCell: Component<{
       // budget even while fitting `maxBranchLen`.
       const highlightUnbounded = () =>
         !!(ctx.highlights?.project || ctx.highlights?.gitBranch);
-      const dirnameColor = () =>
-        ctx.isActiveSession && !ctx.selected
-          ? dimColor(ctx, theme.text)
-          : dimColor(ctx, undefined);
+      const dirnameColor = () => dimColor(ctx, theme.text);
       return (
         // When a prompt shares this row (inline mode), the prompt is the
         // flexible filler and the project must NOT shrink below its fitted
@@ -448,7 +445,7 @@ const FieldCell: Component<{
               <HighlightedText
                 text={ctx.highlights?.project ?? ""}
                 highlightColor={dimColor(ctx, theme.yellow)}
-                baseColor={dimColor(ctx, undefined)}
+                baseColor={dimColor(ctx, theme.text)}
               />
             }
           >


### PR DESCRIPTION
## Problem

On light themes (e.g. `catppuccin-latte` with GitHub Primer overrides), the session/project name text renders pure white `#ffffff`, which is invisible on the light row background.

Root cause: `SessionItem.tsx` passes `fg={undefined}` for the project cell's dirname (and the search-highlight base color), and `Header.tsx` passes `fg={undefined}` for the `Sessions` title. OpenTUI paints an undefined foreground as white. Same for the project title in `Preview.tsx` and the group label in `GroupPreview.tsx` (bare `<text>` with no `fg`).

## Fix

Use `theme.text` wherever the code currently passes `undefined` (or no `fg` at all) for primary text, so it follows the active theme instead of defaulting to white.

Files changed:
- `src/tui/components/SessionItem.tsx` — dirname color and search-highlight base color now `theme.text`
- `src/tui/components/Header.tsx` — `Sessions` title now `theme.text`
- `src/tui/components/Preview.tsx` — preview project title now `theme.text`
- `src/tui/components/GroupPreview.tsx` — group label now `theme.text`

## Verification

- `bun run typecheck` passes
- `bun test src/tui/App.test.tsx` passes (276 tests)
- Confirmed via `tmux capture-pane -e`: session names and the `Sessions` header now render `#1f2328` (the GitHub Light `text` override) instead of `#ffffff`
