### PR TITLE
fix(watcher): Trust named dir events over cached signatures

### DIFF
--- a/src/daemon/log-tree-watcher.test.ts
+++ b/src/daemon/log-tree-watcher.test.ts
@@ -251,7 +251,6 @@ describe("LogTreeWatcher (native)", () => {
     await startWatcher(1);
 
     const evt = watcher as unknown as Internals;
-    evt.handleEvent(null); // populate both gate signatures for proj-a
 
     const fresh = join(project, "fresh.jsonl");
     writeFileSync(fresh, "x\n");
@@ -321,25 +320,34 @@ describe("LogTreeWatcher (native)", () => {
     // Force the collision precisely: make the cached signature's mtime equal
     // the current mtime but its ctime differ. A gate keyed on mtime alone
     // would skip and silently lose the unlink.
-    mkdirSync(join(root, "proj-a"));
-    const a = join(root, "proj-a", "a.jsonl");
-    const b = join(root, "proj-a", "b.jsonl");
+    //
+    // The collision goes on a CHILD of the named directory, not on the named
+    // directory itself: handleEvent clears the named node's own gates before
+    // reconciling it, so a collision injected there would be discarded and
+    // this test would pass without ever consulting the ctime term. Naming the
+    // parent keeps the child's gate live, which is the only path that still
+    // reads it. (This doubles as the one case covering a named intermediate
+    // ancestor whose descendant carries a cached signature.)
+    const sess = join(root, "proj-a", "sess");
+    mkdirSync(sess, { recursive: true });
+    const a = join(sess, "a.jsonl");
+    const b = join(sess, "b.jsonl");
     writeFileSync(a, "x\n");
     writeFileSync(b, "x\n");
-    await startWatcher(1);
+    await startWatcher(2);
 
     const evt = watcher as unknown as Internals;
-    evt.handleEvent("proj-a"); // cache proj-a's sweepSig
-    const projNode = evt.rootNode.childDirs.get(
-      join(root, "proj-a"),
-    ) as unknown as {
+    evt.handleEvent("proj-a"); // cache sess's sweepSig via the descent
+    const sessNode = evt.rootNode.childDirs
+      .get(join(root, "proj-a"))
+      ?.childDirs.get(sess) as unknown as {
       sweepSig: { mtimeNs: bigint; ctimeNs: bigint } | null;
     };
-    expect(projNode.sweepSig).not.toBeNull();
+    expect(sessNode.sweepSig).not.toBeNull();
 
     unlinkSync(b);
-    const cur = statSync(join(root, "proj-a"), { bigint: true });
-    projNode.sweepSig = { mtimeNs: cur.mtimeNs, ctimeNs: cur.ctimeNs - 1n };
+    const cur = statSync(sess, { bigint: true });
+    sessNode.sweepSig = { mtimeNs: cur.mtimeNs, ctimeNs: cur.ctimeNs - 1n };
     evt.handleEvent("proj-a");
 
     expect(unlinked).toContain(b);

--- a/src/daemon/log-tree-watcher.test.ts
+++ b/src/daemon/log-tree-watcher.test.ts
@@ -243,6 +243,41 @@ describe("LogTreeWatcher (native)", () => {
     expect(unlinked).toContain(gone);
   });
 
+  it("trusts a named directory event over a colliding cached signature", async () => {
+    const project = join(root, "proj-a");
+    mkdirSync(project);
+    const gone = join(project, "gone.jsonl");
+    writeFileSync(gone, "x\n");
+    await startWatcher(1);
+
+    const evt = watcher as unknown as Internals;
+    evt.handleEvent(null); // populate both gate signatures for proj-a
+
+    const fresh = join(project, "fresh.jsonl");
+    writeFileSync(fresh, "x\n");
+    unlinkSync(gone);
+
+    // Model a filesystem whose timestamp granularity lets the rapid pair of
+    // mutations retain the named directory's cached signature. The event
+    // names proj-a itself, so the gate must yield to that direct evidence.
+    const current = statSync(project, { bigint: true });
+    const collidingSig = {
+      mtimeNs: current.mtimeNs,
+      ctimeNs: current.ctimeNs,
+    };
+    const projectNode = evt.rootNode.childDirs.get(project) as TreeNode & {
+      walkSig: typeof collidingSig;
+      sweepSig: typeof collidingSig;
+    };
+    projectNode.walkSig = collidingSig;
+    projectNode.sweepSig = collidingSig;
+
+    evt.handleEvent("proj-a");
+
+    expect(added).toContain(fresh);
+    expect(unlinked).toContain(gone);
+  });
+
   it("falls back to chokidar without throwing when the root is missing", async () => {
     // Parity with the pre-native behavior: a missing log dir (fresh
     // machine, agent never run) must construct and reach ready without

--- a/src/daemon/log-tree-watcher.ts
+++ b/src/daemon/log-tree-watcher.ts
@@ -351,11 +351,20 @@ class NativeLogTreeWatcher extends EventEmitter implements LogTreeWatcher {
       // The event names this directory: direct evidence its own namespace
       // may have changed, which outranks a cached signature that a rapid
       // add/remove pair can leave unchanged on coarse-timestamp
-      // filesystems (see DirSig). Clear only this node's own gates — the
-      // burst model above surfaces a change as the touched file (ungated
-      // branch below), its parent directory (this branch), or the root
-      // (null branch, which clears the whole tree), so deeper levels keep
-      // their gates and the descent stays cheap.
+      // filesystems (see DirSig). Clear only this node's own gates, which
+      // covers the reported case: the change is directly inside the named
+      // directory. Deeper levels keep theirs, so the descent stays cheap.
+      //
+      // That is a scoping decision, not a proof of coverage. A burst can
+      // surface as a path outside the file/parent/root trichotomy (the
+      // handleGone comment below documents one: a delete coalescing into a
+      // single too-deep child's event), so an event naming a non-parent
+      // ANCESTOR still descends into gated children and can be swallowed by
+      // a collision below. Only codex reaches that (depth 4); claude and
+      // copilot put a session file's parent directly under the root, so the
+      // named directory is always the parent. Clearing the whole subtree
+      // here would close it, at a cost that scales with the subtree rather
+      // than with the change.
       node.walkSig = null;
       node.sweepSig = null;
       this.walk(abs, node, segments);

--- a/src/daemon/log-tree-watcher.ts
+++ b/src/daemon/log-tree-watcher.ts
@@ -348,6 +348,16 @@ class NativeLogTreeWatcher extends EventEmitter implements LogTreeWatcher {
 
     if (stat.isDirectory()) {
       const node = this.getOrCreateNode(abs);
+      // The event names this directory: direct evidence its own namespace
+      // may have changed, which outranks a cached signature that a rapid
+      // add/remove pair can leave unchanged on coarse-timestamp
+      // filesystems (see DirSig). Clear only this node's own gates — the
+      // burst model above surfaces a change as the touched file (ungated
+      // branch below), its parent directory (this branch), or the root
+      // (null branch, which clears the whole tree), so deeper levels keep
+      // their gates and the descent stays cheap.
+      node.walkSig = null;
+      node.sweepSig = null;
       this.walk(abs, node, segments);
       this.sweep(abs, node);
       return;


### PR DESCRIPTION
## Summary

A named directory event is direct evidence that the directory's namespace may have changed, but `handleEvent` still consulted the cached `(mtimeNs, ctimeNs)` gate before walking and sweeping it. On filesystems whose timestamp resolution is coarser than the mutation sequence (HFS+, legacy ext4 with 128-byte inodes), a rapid add/remove pair leaves both stamps unchanged, so the gate swallowed the event and the `add`/`unlink` never surfaced.

This clears the named node's own gates before the reconcile. Deeper levels keep theirs, so the descent stays cheap. The three surfaces the burst model produces are now all covered:

| Event surfaces as | Path | Gated? |
| --- | --- | --- |
| The touched file | file branch | no, already ungated |
| Its parent directory | directory branch | **no, this PR** |
| The root | null branch | no, tree-wide clear from #132 |

Intermediate ancestors keep the existing gated descent, unchanged by this PR. That is a scoping decision rather than coverage: an event naming a non-parent ancestor still descends into gated children, so a collision below can still swallow it. Only codex reaches that (depth 4) since claude and copilot put a session file's parent directly under the root, and it behaves identically on `main`, so this PR narrows the bug rather than closing it. Clearing the whole subtree would close it too, at a cost that scales with the subtree rather than with the change.

Measured basis, from the #132 review: 200 rapid creates on HFS+ produce 1 distinct signature and an add+delete pair collides; APFS gives 200/200. #132 corrected the `DirSig` comment to say equality is an optimization rather than proof of no change, and this PR makes the named-event path honor that.

## Related issue

Closes #138

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (4938 pass / 0 fail)
- [ ] Verified the affected TUI surface (picker / sidebar) in a detached tmux session — N/A, daemon-only module with no TUI path
- [ ] Verified end to end with a real agent session — see note below

## Notes for reviewers

The new test mirrors the collision test #132 added, driving `handleEvent("proj-a")` instead of `null`. It was **confirmed red against the unfixed gate** (the `add` was swallowed, `added` contained only the pre-existing file) and green with the fix.

A follow-up commit retargets the pre-existing ctime-gate test. Clearing the named node's own gates discarded the collision that test injected on that same node, so the sweep ran unconditionally and the ctime term went unread: with `ctimeNs` removed from `sigEqual` the whole suite stayed green. The collision now sits on a child (`proj-a/sess`) with the event still naming the parent, which keeps the child's gate live. Verified red with the ctime term removed and green with it intact.

No live end-to-end run: reproducing this needs a coarse-timestamp filesystem, and the synthetic-collision pattern #132 established is what the suite uses to model that on APFS. The underlying collision itself was measured on a real scratch HFS+ image during the #132 review.

