### PR TITLE
fix: apply theme text to unstyled headings

### DIFF
--- a/src/tui/components/GroupPreview.tsx
+++ b/src/tui/components/GroupPreview.tsx
@@ -235,7 +235,7 @@ export const GroupPreview: Component<GroupPreviewProps> = (props) => {
     >
       <box height={3} flexDirection="column">
         <box flexDirection="row" gap={1}>
-          <text>
+          <text fg={theme.text}>
             <b>{props.header.label}</b>
           </text>
           <text fg={theme.subtext}>({props.header.count} sessions)</text>

--- a/src/tui/components/Header.tsx
+++ b/src/tui/components/Header.tsx
@@ -34,7 +34,7 @@ export const Header: Component<HeaderProps> = (props) => {
     <box width="100%" height={1} paddingLeft={1} paddingRight={1}>
       <box flexDirection="row" width="100%">
         <text fg={c(dotColor(props.connectionState))}>● </text>
-        <text fg={c(undefined)}>
+        <text fg={c(theme.text)}>
           <b>Sessions</b>
         </text>
         <text fg={c(theme.overlay)}>

--- a/src/tui/components/Preview.tsx
+++ b/src/tui/components/Preview.tsx
@@ -449,7 +449,7 @@ export const Preview: Component<PreviewProps> = (props) => {
         <box height={4} flexDirection="column">
           <box flexDirection="row">
             <box flexGrow={1}>
-              <text>
+              <text fg={theme.text}>
                 <b>{props.session!.project}</b>
               </text>
             </box>


### PR DESCRIPTION
## Summary
- apply the active theme foreground to the picker Sessions heading
- apply the same foreground to group and session preview headings
- prevent OpenTUI white fallback from bypassing configured light themes

## Verification
- bun run typecheck
- bun test
- rendered the picker in a detached tmux session and asserted the Espresso Paper header foreground is #4a4542