### PR TITLE
fix: apply theme text to session row project names

### DIFF
--- a/src/tui/components/SessionItem.test.tsx
+++ b/src/tui/components/SessionItem.test.tsx
@@ -1,9 +1,11 @@
 import { describe, it, expect, afterEach } from "bun:test";
 import { testRender } from "@opentui/solid";
 import { MouseButtons } from "@opentui/core/testing";
+import { RGBA, type CapturedFrame } from "@opentui/core";
 import { createSignal } from "solid-js";
 import { SessionItem, abbreviateTarget, alignText } from "./SessionItem";
 import { TickContext } from "../store";
+import { theme } from "../theme";
 import { mockEnrichedSession } from "./test-helpers";
 import { displayWidth } from "../utils/format";
 import { HANDOFF_BADGE } from "./session-columns";
@@ -1349,5 +1351,67 @@ describe("SessionItem right-aligned fields", () => {
       100,
     );
     expect(frame).toContain("予算パイプライン");
+  });
+});
+
+// Regression test for issue #142: the project-name span passed `undefined`
+// as its fg fallback (`dimColor(ctx, undefined)`), and OpenTUI's <text>
+// defaults an undefined fg to opaque white, so the project name rendered
+// white on every theme instead of following theme.text. captureCharFrame()
+// is text-only (see SessionItem.pr-color.test.tsx), so color must be
+// asserted via captureSpans() instead. Width is narrowed to keep the project
+// cell in "dirname" mode (bare "myapp"), below the "full" mode breakpoint
+// that would also draw a separate prefix span.
+describe("SessionItem project name color", () => {
+  function projectSpanFg(
+    frame: CapturedFrame,
+  ): [number, number, number, number] {
+    for (const line of frame.lines) {
+      for (const span of line.spans) {
+        if (span.text.includes("myapp")) return span.fg.toInts();
+      }
+    }
+    throw new Error('project span ("myapp") not found in frame');
+  }
+
+  const hex = (h: string) => RGBA.fromHex(h).toInts();
+
+  it("renders theme.text, not opaque white, for a plain row", async () => {
+    const [tick] = createSignal(0);
+    setup = await testRender(
+      () => (
+        <TickContext.Provider value={{ tick }}>
+          <SessionItem
+            session={mockEnrichedSession()}
+            selected={false}
+            index={0}
+            previewWidth={30}
+          />
+        </TickContext.Provider>
+      ),
+      { width: 70, height: 3 },
+    );
+    await setup.renderOnce();
+    expect(projectSpanFg(setup.captureSpans())).toEqual(hex(theme.text));
+  });
+
+  it("keeps a dimmed row muted (theme.border)", async () => {
+    const [tick] = createSignal(0);
+    setup = await testRender(
+      () => (
+        <TickContext.Provider value={{ tick }}>
+          <SessionItem
+            session={mockEnrichedSession()}
+            selected={false}
+            index={0}
+            previewWidth={30}
+            dimmed
+          />
+        </TickContext.Provider>
+      ),
+      { width: 70, height: 3 },
+    );
+    await setup.renderOnce();
+    expect(projectSpanFg(setup.captureSpans())).toEqual(hex(theme.border));
   });
 });

--- a/src/tui/components/SessionItem.tsx
+++ b/src/tui/components/SessionItem.tsx
@@ -424,10 +424,6 @@ const FieldCell: Component<{
       // budget even while fitting `maxBranchLen`.
       const highlightUnbounded = () =>
         !!(ctx.highlights?.project || ctx.highlights?.gitBranch);
-      const dirnameColor = () =>
-        ctx.isActiveSession && !ctx.selected
-          ? dimColor(ctx, theme.text)
-          : dimColor(ctx, undefined);
       return (
         // When a prompt shares this row (inline mode), the prompt is the
         // flexible filler and the project must NOT shrink below its fitted
@@ -448,14 +444,14 @@ const FieldCell: Component<{
               <HighlightedText
                 text={ctx.highlights?.project ?? ""}
                 highlightColor={dimColor(ctx, theme.yellow)}
-                baseColor={dimColor(ctx, undefined)}
+                baseColor={dimColor(ctx, theme.text)}
               />
             }
           >
             <Show when={fitted().prefix}>
               <text fg={dimColor(ctx, theme.subtext)}>{fitted().prefix}</text>
             </Show>
-            <text fg={dirnameColor()}>
+            <text fg={dimColor(ctx, theme.text)}>
               <Bold when={ctx.selected || !!ctx.isActiveSession}>
                 {fitted().dirname}
               </Bold>


### PR DESCRIPTION
Fixes #142. Completes what #141 started: session row project names (the picker's highest-traffic text) still passed `undefined` through `dimColor()`, landing on OpenTUI's opaque-white default fg and ignoring the configured palette. On light themes that is white text on a light background.

## Changes

- `SessionItem.tsx`: both `undefined` fallbacks become `theme.text`, the dirname span and the search-highlight `baseColor`. The `dirnameColor()` helper is deleted; its ternary (active-and-unselected rows got `theme.text`, everything else white) dated to the v1.0.0 import and was visually indistinguishable on dark themes, so it collapses rather than survives with a substitute token. Dimmed rows still get `theme.border` through the untouched `dimColor` pass-through.
- `SessionItem.test.tsx`: regression tests asserting the actually rendered fg via `captureSpans()` (the pattern from `SessionItem.pr-color.test.tsx`; `captureCharFrame()` is text-only). Plain row expects `theme.text`, dimmed row expects `theme.border`. The plain-row assertion was verified to fail against the old code with received `[255,255,255,255]`.

## Verification

- `bun run typecheck` clean; full suite 4945 pass / 0 fail (2 new).
- Live render per AGENTS.md: picker launched from this branch in a detached tmux pane under an isolated `CCMUX_HOME` with `catppuccin-latte`, captured with `capture-pane -e`. Every row's project name now emits the theme's text color (`38;2;76;79;105`); a sweep of the frame finds zero readable white runs left. Before the fix, the same capture showed every non-active row dirname as `38;2;255;255;255`.
- Sweep for the same bug class: `grep` for helpers passing an optional color through as `undefined` surfaces no remaining sites in `src/tui`.