### PR TITLE
feat(notify): Auto-detect nested tmux for OSC passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,7 +951,7 @@ ccmux notify                      # test: a banner should appear locally
 
 Use `all` rather than `on`: at `on`, tmux only forwards passthrough sequences from visible panes, and the agent that needs your attention is usually in a window you're not looking at.
 
-Nested tmux (a local tmux, SSH, then a remote tmux where ccmux runs) is detected automatically: the escape is wrapped twice so it survives both layers. Both tmux instances need `allow-passthrough` (the outer one only forwards from the pane you're attached to, so `on` suffices there), and ccmux can only verify the one it runs under, so set it on the local side too. A Kitty terminal behind an outer tmux receives the plain OSC 9 form, since Kitty can't be detected through that outer tmux; the banner still appears, just without per-session grouping.
+Nested tmux (a local tmux, SSH, then a remote tmux where ccmux runs) is detected automatically: the escape is wrapped twice so it survives both layers. Both tmux instances need `allow-passthrough all` (with `on`, the outer tmux drops the sequence whenever the SSH pane sits in a background local window), and ccmux can only verify the one it runs under, so set it on the local side too. A Kitty terminal behind an outer tmux receives the plain OSC 9 form, since Kitty can't be detected through that outer tmux; the banner still appears, just without per-session grouping.
 
 ## 🏗️ Architecture
 

--- a/README.md
+++ b/README.md
@@ -945,9 +945,13 @@ The one piece that doesn't follow automatically is desktop notifications: the re
 # on the remote host
 ccmux config set notifications.enabled true
 ccmux config set notifications.backend osc
-tmux set -g allow-passthrough on  # add to tmux.conf to persist
+tmux set -g allow-passthrough all # add to tmux.conf to persist
 ccmux notify                      # test: a banner should appear locally
 ```
+
+Use `all` rather than `on`: at `on`, tmux only forwards passthrough sequences from visible panes, and the agent that needs your attention is usually in a window you're not looking at.
+
+Nested tmux (a local tmux, SSH, then a remote tmux where ccmux runs) is detected automatically: the escape is wrapped twice so it survives both layers. Both tmux instances need `allow-passthrough` (the outer one only forwards from the pane you're attached to, so `on` suffices there), and ccmux can only verify the one it runs under, so set it on the local side too. A Kitty terminal behind an outer tmux receives the plain OSC 9 form, since Kitty can't be detected through that outer tmux; the banner still appears, just without per-session grouping.
 
 ## 🏗️ Architecture
 

--- a/src/commands/notify.ts
+++ b/src/commands/notify.ts
@@ -270,7 +270,7 @@ function runOscFlow(
     console.error(
       "tmux option allow-passthrough is not enabled; the escape sequence would be swallowed.",
     );
-    console.error("Enable it with: tmux set -g allow-passthrough on");
+    console.error("Enable it with: tmux set -g allow-passthrough all");
     return false;
   }
 

--- a/src/commands/notify.ts
+++ b/src/commands/notify.ts
@@ -12,6 +12,7 @@ import { DbusNotifier } from "../lib/notify-dbus";
 import {
   deliverOscNotification,
   isKittyTermnames,
+  isMultiplexerTermnames,
   probeAllowPassthrough,
 } from "../lib/notify-osc";
 import { DAEMON_HOST, DAEMON_PORT } from "../lib/config";
@@ -294,7 +295,10 @@ function runOscFlow(
     "#{client_termname}",
   ]);
   const format =
-    termnames && isKittyTermnames(termnames) ? "OSC 99 (kitty)" : "OSC 9";
+    (termnames && isKittyTermnames(termnames) ? "OSC 99 (kitty)" : "OSC 9") +
+    (termnames && isMultiplexerTermnames(termnames)
+      ? " via nested tmux passthrough"
+      : "");
   console.log("Backend: osc");
   console.log(`Pane tty: ${tty}`);
   console.log(`Sequence: ${format}`);

--- a/src/daemon/notify-delivery.ts
+++ b/src/daemon/notify-delivery.ts
@@ -285,7 +285,7 @@ export function createNotifyDelivery(deps: DeliveryDeps): {
           probeResults.set("osc", oscOk);
           if (!oscOk) {
             log(
-              'Notifier: backend "osc" needs tmux option allow-passthrough set to "on" or "all" (enable it with `tmux set -g allow-passthrough on`); disabling osc delivery for this daemon run',
+              'Notifier: backend "osc" needs tmux option allow-passthrough set to "on" or "all" (enable it with `tmux set -g allow-passthrough all`); disabling osc delivery for this daemon run',
             );
           }
         }

--- a/src/lib/notify-osc.test.ts
+++ b/src/lib/notify-osc.test.ts
@@ -5,6 +5,7 @@ import {
   buildOsc99Sequence,
   wrapTmuxPassthrough,
   isKittyTermnames,
+  isMultiplexerTermnames,
   buildPassthroughSequence,
   probeAllowPassthrough,
   deliverOscNotification,
@@ -137,6 +138,24 @@ describe("isKittyTermnames", () => {
   });
 });
 
+describe("isMultiplexerTermnames", () => {
+  it("detects a multiplexer terminfo name among attached clients", () => {
+    expect(isMultiplexerTermnames("tmux-256color")).toBe(true);
+    expect(isMultiplexerTermnames("screen-256color")).toBe(true);
+    expect(isMultiplexerTermnames("tmux")).toBe(true);
+    expect(isMultiplexerTermnames("xterm-ghostty\ntmux-256color\n")).toBe(true);
+  });
+
+  it("returns false for clients that are real terminals", () => {
+    expect(isMultiplexerTermnames("xterm-kitty")).toBe(false);
+    expect(isMultiplexerTermnames("xterm-256color")).toBe(false);
+    expect(isMultiplexerTermnames("")).toBe(false);
+    // Matching is prefix-based, so an unrelated name merely containing "tmux"
+    // is not a multiplexer client.
+    expect(isMultiplexerTermnames("xterm-tmux")).toBe(false);
+  });
+});
+
 describe("buildPassthroughSequence", () => {
   it("selects generic OSC 9 and folds the subtitle into the message", () => {
     const seq = buildPassthroughSequence(BASE_PAYLOAD, false);
@@ -157,6 +176,34 @@ describe("buildPassthroughSequence", () => {
     const bodyChunk = seq.split("p=body;")[1]!;
     const b64 = bodyChunk.slice(0, bodyChunk.indexOf(ESC));
     expect(decodeB64(b64)).toBe("Needs permission: Bash\nrm -rf build");
+  });
+
+  it("wraps twice for a multiplexer client, in both formats", () => {
+    const folded = "Needs permission: Bash\nrm -rf build";
+    const raw9 = buildOsc9Sequence(BASE_PAYLOAD.title, folded);
+    expect(buildPassthroughSequence(BASE_PAYLOAD, false, true)).toBe(
+      wrapTmuxPassthrough(wrapTmuxPassthrough(raw9)),
+    );
+    const raw99 = buildOsc99Sequence(
+      BASE_PAYLOAD.sessionId,
+      BASE_PAYLOAD.title,
+      folded,
+    );
+    expect(buildPassthroughSequence(BASE_PAYLOAD, true, true)).toBe(
+      wrapTmuxPassthrough(wrapTmuxPassthrough(raw99)),
+    );
+  });
+
+  it("wraps once when the multiplexer flag is omitted", () => {
+    const folded = "Needs permission: Bash\nrm -rf build";
+    expect(buildPassthroughSequence(BASE_PAYLOAD, false)).toBe(
+      wrapTmuxPassthrough(buildOsc9Sequence(BASE_PAYLOAD.title, folded)),
+    );
+    expect(buildPassthroughSequence(BASE_PAYLOAD, true)).toBe(
+      wrapTmuxPassthrough(
+        buildOsc99Sequence(BASE_PAYLOAD.sessionId, BASE_PAYLOAD.title, folded),
+      ),
+    );
   });
 });
 
@@ -184,6 +231,37 @@ describe("deliverOscNotification", () => {
     expect(writes).toHaveLength(1);
     expect(writes[0]!.tty).toBe("/dev/ttys061");
     expect(writes[0]!.data).toContain(`${ESC}Ptmux;`);
+  });
+
+  it("double-wraps when the attached client is itself a multiplexer", () => {
+    const writes: string[] = [];
+    deliverOscNotification(BASE_PAYLOAD, "/dev/ttys061", {
+      runTmux: () => "tmux-256color",
+      writeToTty: (_tty, data) => writes.push(data),
+    });
+    expect(writes[0]).toBe(buildPassthroughSequence(BASE_PAYLOAD, false, true));
+    // The outer wrap doubles the inner frame's leading ESC.
+    expect(writes[0]!.startsWith(`${ESC}Ptmux;${ESC}${ESC}Ptmux;`)).toBe(true);
+  });
+
+  it("stays single-wrapped for a plain terminal client", () => {
+    const writes: string[] = [];
+    deliverOscNotification(BASE_PAYLOAD, "/dev/ttys061", {
+      runTmux: () => "xterm-256color",
+      writeToTty: (_tty, data) => writes.push(data),
+    });
+    expect(writes[0]).toBe(buildPassthroughSequence(BASE_PAYLOAD, false));
+    expect(writes[0]!.startsWith(`${ESC}Ptmux;${ESC}${ESC}]9;`)).toBe(true);
+  });
+
+  it("stays single-wrapped OSC 99 for a kitty client", () => {
+    const writes: string[] = [];
+    deliverOscNotification(BASE_PAYLOAD, "/dev/ttys061", {
+      runTmux: () => "xterm-kitty",
+      writeToTty: (_tty, data) => writes.push(data),
+    });
+    expect(writes[0]).toBe(buildPassthroughSequence(BASE_PAYLOAD, true));
+    expect(writes[0]!.startsWith(`${ESC}Ptmux;${ESC}${ESC}]99;`)).toBe(true);
   });
 
   it("scopes the termname sniff to the payload's pane when set", () => {

--- a/src/lib/notify-osc.ts
+++ b/src/lib/notify-osc.ts
@@ -6,8 +6,9 @@
  * Dependency-free (like `src/lib/notify.ts`) so the daemon and `ccmux notify`
  * share the builders; every I/O boundary is injectable for tests. Kitty
  * clients get OSC 99, everything else OSC 9, wrapped in tmux passthrough
- * framing, which requires `allow-passthrough on|all` (probed with a
- * once-per-daemon warning in `notify-delivery.ts`).
+ * framing (twice when the attached client is itself tmux/screen), which
+ * requires `allow-passthrough on|all` (probed with a once-per-daemon warning
+ * in `notify-delivery.ts`).
  *
  * Informational rung: `actions`/`reply`/`sound` are never read (a written
  * escape has no back-channel), retraction is a no-op, delivery is
@@ -110,17 +111,41 @@ export function isKittyTermnames(termnames: string): boolean {
     .some((name) => name.toLowerCase().includes("kitty"));
 }
 
+/** True when any attached client's terminfo name marks the client as itself a
+ * terminal multiplexer (`tmux`, `screen`, or a `tmux-`/`screen-` variant like
+ * `tmux-256color`), i.e. the pane's tmux is nested inside another one. Same
+ * input as {@link isKittyTermnames}: the raw stdout of
+ * `tmux list-clients -F '#{client_termname}'` (one per line). */
+export function isMultiplexerTermnames(termnames: string): boolean {
+  return termnames.split("\n").some((line) => {
+    const name = line.trim().toLowerCase();
+    return (
+      name === "tmux" ||
+      name === "screen" ||
+      name.startsWith("tmux-") ||
+      name.startsWith("screen-")
+    );
+  });
+}
+
 /** Composes the final, passthrough-wrapped sequence for a payload, folding the
- * subtitle (event line) into the body via {@link foldSubtitleIntoBody}. */
+ * subtitle (event line) into the body via {@link foldSubtitleIntoBody}.
+ *
+ * `clientIsMultiplexer` means the attached client is another multiplexer, so a
+ * single passthrough layer is consumed by the inner tmux and the bare escape
+ * then dies at the outer one; wrapping twice makes the sequence survive both.
+ * A false negative simply degrades to the single-wrap behavior. */
 export function buildPassthroughSequence(
   payload: NotificationPayload,
   isKitty: boolean,
+  clientIsMultiplexer = false,
 ): string {
   const body = foldSubtitleIntoBody(payload);
   const raw = isKitty
     ? buildOsc99Sequence(payload.sessionId, payload.title, body)
     : buildOsc9Sequence(payload.title, body);
-  return wrapTmuxPassthrough(raw);
+  const wrapped = wrapTmuxPassthrough(raw);
+  return clientIsMultiplexer ? wrapTmuxPassthrough(wrapped) : wrapped;
 }
 
 /** Default tty writer: write-only and non-blocking, so a flow-controlled or
@@ -164,7 +189,8 @@ export function deliverOscNotification(
       : ["list-clients", "-F", "#{client_termname}"],
   );
   const isKitty = termnames ? isKittyTermnames(termnames) : false;
-  const sequence = buildPassthroughSequence(payload, isKitty);
+  const nested = termnames ? isMultiplexerTermnames(termnames) : false;
+  const sequence = buildPassthroughSequence(payload, isKitty, nested);
   const write = deps.writeToTty ?? defaultWriteToTty;
   try {
     write(tty, sequence);


### PR DESCRIPTION
## Summary

Adds automatic nested-tmux support to the `osc` notification backend. In a nested topology (local tmux → SSH → remote tmux where ccmux runs), the single tmux passthrough layer is consumed by the inner tmux and the outer tmux swallows the resulting bare OSC, so notifications never reach the terminal. The delivery path already sniffs `tmux list-clients -F '#{client_termname}'`; when any attached client's termname identifies the client as itself a multiplexer (`tmux*`/`screen*`, which is exactly what the nested topology reports), the escape is now wrapped twice so each tmux consumes one layer.

No new config. Detection is per delivery, so it follows the client across topologies, and it only changes behavior for deliveries that previously produced nothing; a false negative degrades to the old single-wrap behavior.

Also corrects the README's osc setup to recommend `allow-passthrough all` on the ccmux side: at `on`, tmux only forwards passthrough from visible panes, and a waiting agent usually sits in a background window.

## Related issue

Resolves #144

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (4952 tests, includes 7 new tests: predicate cases, byte-exact double-wrap composition, and delivery-level assertions for tmux/xterm/kitty client termnames)
- [x] Verified end to end with a real agent session: restarted the daemon on this build, drove a real Claude Code session to a `waiting` permission state in a nested topology (default-server session attached from inside an outer tmux, outermost client recorded via a `script` PTY), and confirmed the daemon-delivered notification arrived at the outermost recorder as a single bare `ESC]9;` with ccmux's payload and zero `Ptmux` remnants. The direct-attach topology stays single-wrapped and still delivers (regression guard).

## Notes for reviewers

- Byte-level repro of the bug preceded the fix: with two nested tmux servers and a recorded PTY as the outermost terminal, the production single-wrapped sequence never reaches the recorder while a double-wrapped one arrives intact, matching the reporter's Kitty test in #144.
- A depth config/env var and a dual-emit approach (always writing both depths) were considered and rejected. Dual-emit fails on real parsers: Ghostty, Terminal.app, and WezTerm all abort a directly received `DCS tmux;` at the first interior ESC and execute the embedded sequence (verified with wrapped DSR/DA queries), so it would duplicate notifications on direct attach.
- Known limitation, documented in the README: Kitty behind an outer tmux gets the OSC 9 form (the termname sniff can't see Kitty through the nest), which still notifies but without per-session grouping. A format override can follow if there's demand.
- `probeAllowPassthrough` treats `on` and `all` identically, so a user on `on` gets no warning that background-window panes lose notifications; possible follow-up.