### PR TITLE
refactor(cli): Read daemon responses through one typed boundary

### DIFF
--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -18,6 +18,7 @@ import {
   getDaemonUrl,
 } from "../lib/config";
 import { printDaemonHealth } from "./shared";
+import { daemonBody } from "../lib/daemon-json";
 import type { TmuxSocketError } from "../types";
 
 /**
@@ -60,10 +61,10 @@ async function printTmuxServer(): Promise<void> {
   try {
     const response = await fetch(`${getDaemonUrl()}/server-info`);
     if (!response.ok) return;
-    const info = (await response.json()) as {
+    const info = await daemonBody<{
       socketPath: string | null;
       socketError?: TmuxSocketError | null;
-    };
+    }>(response, "server info");
     if (info.socketPath) {
       console.log(`tmux socket: ${info.socketPath}`);
       return;

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { getDaemonUrl } from "../lib/config";
+import { daemonBody } from "../lib/daemon-json";
 import { getAgents } from "../lib/agents";
 import { getPreferences } from "../lib/preferences";
 import { isDaemonRunningAsync } from "../daemon";
@@ -54,7 +55,10 @@ async function fetchTrackedSessions(): Promise<EnrichedSession[]> {
   try {
     const response = await fetch(`${getDaemonUrl()}/sessions?all=true`);
     if (!response.ok) return [];
-    const data = (await response.json()) as { sessions: EnrichedSession[] };
+    const data = await daemonBody<{ sessions: EnrichedSession[] }>(
+      response,
+      "session list",
+    );
     return data.sessions ?? [];
   } catch {
     return [];

--- a/src/commands/handoff.ts
+++ b/src/commands/handoff.ts
@@ -13,6 +13,7 @@
 
 import { Command } from "commander";
 import { getDaemonUrl } from "../lib/config";
+import { daemonBody } from "../lib/daemon-json";
 import { ensureDaemon } from "./shared";
 import { proximityLabel } from "../daemon/session-ref";
 import type { RefProximity, SessionRefCandidate } from "../daemon/session-ref";
@@ -196,7 +197,7 @@ export function createHandoffCommand(): Command {
           process.exit(1);
         }
 
-        const data = (await response.json()) as HandoffResponse;
+        const data = await daemonBody<HandoffResponse>(response, "handoff");
 
         if (options.json) {
           console.log(JSON.stringify(data, null, 2));

--- a/src/commands/invoke.ts
+++ b/src/commands/invoke.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { randomUUID } from "crypto";
 import { getDaemonUrl } from "../lib/config";
+import { daemonBody } from "../lib/daemon-json";
 import { getAgents } from "../lib/agents";
 import { getPreferences } from "../lib/preferences";
 import {
@@ -193,7 +194,7 @@ export function createInvokeCommand(): Command {
             }),
           });
 
-          const data = (await response.json()) as InvokeResponse;
+          const data = await daemonBody<InvokeResponse>(response, "invoke");
           if (data.success && typeof data.text === "string") {
             // Wait for the kernel pipe buffer to drain before exiting:
             // `process.exit(0)` does not flush async stdout, so large
@@ -262,9 +263,9 @@ function createInvokeListCommand(): Command {
       try {
         const response = await fetch(`${getDaemonUrl()}/invocations`);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const { invocations } = (await response.json()) as {
+        const { invocations } = await daemonBody<{
           invocations: InvocationRecord[];
-        };
+        }>(response, "invocation list");
 
         if (options.json) {
           console.log(JSON.stringify(invocations, null, 2));
@@ -298,11 +299,11 @@ function createInvokeCancelCommand(): Command {
         const response = await fetch(`${getDaemonUrl()}/invoke/${id}/cancel`, {
           method: "POST",
         });
-        const data = (await response.json()) as {
+        const data = await daemonBody<{
           success?: boolean;
           state?: "cancelling" | "already_finished" | "not_found";
           message?: string;
-        };
+        }>(response, "cancel");
         if (!data.success && data.message) {
           console.error(data.message);
           process.exit(1);
@@ -350,7 +351,10 @@ function createInvokeResultCommand(): Command {
         const response = await fetch(
           `${getDaemonUrl()}/invocations/${id}/result`,
         );
-        const data = (await response.json()) as InvocationResultResponse;
+        const data = await daemonBody<InvocationResultResponse>(
+          response,
+          "invocation result",
+        );
         if (data.available && typeof data.output === "string") {
           // Flush-then-exit: process.exit does not drain async stdout, so
           // a large captured output would lose its tail without the

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { getDaemonUrl } from "../lib/config";
+import { daemonError, readBoolean } from "../lib/daemon-json";
 import { ensureDaemon } from "./shared";
 
 export function createKillCommand(): Command {
@@ -21,8 +22,8 @@ export function createKillCommand(): Command {
         }
 
         if (response.status === 400) {
-          const data = (await response.json()) as { error: string };
-          console.error(data.error);
+          const error = await daemonError(response);
+          console.error(error ?? `HTTP ${response.status}`);
           process.exit(1);
         }
 
@@ -34,12 +35,7 @@ export function createKillCommand(): Command {
         // still running. A background row omits the field, so absent is success.
         const body: unknown = await response.json();
 
-        if (
-          typeof body === "object" &&
-          body !== null &&
-          "killed" in body &&
-          body.killed === false
-        ) {
+        if (readBoolean(body, "killed") === false) {
           console.error(
             `Session ${sessionId} did not exit; the process is still running.`,
           );

--- a/src/commands/last.ts
+++ b/src/commands/last.ts
@@ -7,6 +7,7 @@
 
 import { Command } from "commander";
 import { getDaemonUrl } from "../lib/config";
+import { daemonError, daemonBody } from "../lib/daemon-json";
 import { ensureDaemon } from "./shared";
 import { proximityLabel } from "../daemon/session-ref";
 import type { RefProximity, SessionRefCandidate } from "../daemon/session-ref";
@@ -126,14 +127,12 @@ export function createLastCommand(): Command {
       }
 
       if (!response.ok) {
-        const data = (await response.json().catch(() => null)) as {
-          error?: string;
-        } | null;
-        console.error(data?.error ?? `HTTP ${response.status}`);
+        const error = await daemonError(response);
+        console.error(error ?? `HTTP ${response.status}`);
         process.exit(1);
       }
 
-      const data = (await response.json()) as TranscriptResponse;
+      const data = await daemonBody<TranscriptResponse>(response, "transcript");
 
       const echo = resolutionEcho(data);
       if (echo) console.error(echo);

--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { getDaemonUrl } from "../lib/config";
+import { daemonError } from "../lib/daemon-json";
 import { ensureDaemon } from "./shared";
 
 export function createRestartCommand(): Command {
@@ -21,8 +22,8 @@ export function createRestartCommand(): Command {
         }
 
         if (response.status === 400) {
-          const data = (await response.json()) as { error: string };
-          console.error(data.error);
+          const error = await daemonError(response);
+          console.error(error ?? `HTTP ${response.status}`);
           process.exit(1);
         }
 

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { getDaemonUrl } from "../lib/config";
+import { daemonBody } from "../lib/daemon-json";
 import { resolveRepoRoot } from "../lib/git";
 import { HUNK_INSTALL_HINT, spawnHunkDiff } from "../tui/utils/review";
 import { ensureDaemon } from "./shared";
@@ -37,9 +38,9 @@ export function createReviewCommand(): Command {
             throw new Error(`HTTP ${response.status}`);
           }
 
-          const data = (await response.json()) as {
+          const data = await daemonBody<{
             session: { paneCwd: string | null; cwd: string };
-          };
+          }>(response, "session");
           cwd = data.session.paneCwd ?? data.session.cwd;
         } catch (error) {
           console.error("Failed to look up session:", error);

--- a/src/commands/screen.ts
+++ b/src/commands/screen.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { getDaemonUrl } from "../lib/config";
+import { daemonError, daemonBody } from "../lib/daemon-json";
 import { ensureDaemon } from "./shared";
 import type { EnrichedSession } from "../types";
 
@@ -71,7 +72,7 @@ async function fetchScreen(
       `${daemonUrl}/sessions/${sessionId}/screen?lines=${lines}`,
     );
     if (!response.ok) return null;
-    return (await response.json()) as ScreenResponse;
+    return await daemonBody<ScreenResponse>(response, "screen");
   } catch {
     return null;
   }
@@ -92,8 +93,8 @@ async function handleSingleSession(
   }
 
   if (response.status === 400) {
-    const data = (await response.json()) as { error: string };
-    console.error(data.error);
+    const error = await daemonError(response);
+    console.error(error ?? `HTTP ${response.status}`);
     process.exit(1);
   }
 
@@ -101,7 +102,7 @@ async function handleSingleSession(
     throw new Error(`HTTP ${response.status}`);
   }
 
-  const data = (await response.json()) as ScreenResponse;
+  const data = await daemonBody<ScreenResponse>(response, "screen");
 
   if (!options.grep) {
     if (options.json) {
@@ -125,7 +126,9 @@ async function handleSingleSession(
   }
 
   if (options.json) {
-    console.log(JSON.stringify({ ...data, pattern: options.grep, matches }, null, 2));
+    console.log(
+      JSON.stringify({ ...data, pattern: options.grep, matches }, null, 2),
+    );
   } else {
     for (const m of matches) {
       console.log(`  Line ${m.line}: ${m.text}`);
@@ -143,9 +146,10 @@ async function handleGlobalGrep(options: ScreenOptions): Promise<void> {
     throw new Error(`HTTP ${sessionsRes.status}`);
   }
 
-  const { sessions } = (await sessionsRes.json()) as {
-    sessions: EnrichedSession[];
-  };
+  const { sessions } = await daemonBody<{ sessions: EnrichedSession[] }>(
+    sessionsRes,
+    "session list",
+  );
 
   if (sessions.length === 0) {
     console.log("No active sessions");
@@ -230,7 +234,10 @@ function parseLines(value: string): number {
 export function createScreenCommand(): Command {
   return new Command("screen")
     .description("Capture pane content, or search across all sessions")
-    .argument("[session-id]", "Session ID or pane ID (omit with --grep to search all)")
+    .argument(
+      "[session-id]",
+      "Session ID or pane ID (omit with --grep to search all)",
+    )
     .option("-l, --lines <n>", "Number of lines to capture", "50")
     .option("--json", "Output as JSON with metadata")
     .option("-g, --grep <pattern>", "Search for pattern in pane content")

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { getDaemonUrl } from "../lib/config";
+import { daemonError } from "../lib/daemon-json";
 import { ensureDaemon } from "./shared";
 
 export function createSendCommand(): Command {
@@ -53,8 +54,8 @@ export function createSendCommand(): Command {
           }
 
           if (response.status === 400) {
-            const data = (await response.json()) as { error: string };
-            console.error(data.error);
+            const error = await daemonError(response);
+            console.error(error ?? `HTTP ${response.status}`);
             process.exit(1);
           }
 

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -7,6 +7,7 @@ import {
   getProcessCommand,
 } from "../daemon";
 import { DAEMON_PORT, getDaemonUrl } from "../lib/config";
+import { daemonBody } from "../lib/daemon-json";
 
 /**
  * Evict any zombie on the daemon port, spawn a fresh daemon, wait for health.
@@ -56,11 +57,11 @@ export async function printDaemonHealth(indent = ""): Promise<void> {
   try {
     const response = await fetch(`${getDaemonUrl()}/health`);
     if (response.ok) {
-      const health = (await response.json()) as {
+      const health = await daemonBody<{
         sessions: number;
         clients: number;
         uptime: number;
-      };
+      }>(response, "health");
       console.log(`${indent}Sessions: ${health.sessions}`);
       console.log(`${indent}Connected clients: ${health.clients}`);
       console.log(`${indent}Uptime: ${Math.round(health.uptime)}s`);

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { getDaemonUrl } from "../lib/config";
+import { daemonBody } from "../lib/daemon-json";
 import { ensureDaemon } from "./shared";
 import {
   getStatusIcon,
@@ -36,9 +37,9 @@ async function emptyMessage(): Promise<string> {
     const response = await fetch(`${getDaemonUrl()}/server-info`);
     if (response.ok) {
       // A daemon predating the field omits it, which reads as "no error".
-      const { socketError } = (await response.json()) as {
+      const { socketError } = await daemonBody<{
         socketError?: TmuxSocketError | null;
-      };
+      }>(response, "server info");
       if (socketError) return socketErrorMessage(socketError.attemptedSocket);
     }
   } catch {
@@ -72,9 +73,10 @@ export function createShowCommand(): Command {
           throw new Error(`HTTP ${response.status}`);
         }
 
-        const { sessions } = (await response.json()) as {
-          sessions: EnrichedSession[];
-        };
+        const { sessions } = await daemonBody<{ sessions: EnrichedSession[] }>(
+          response,
+          "session list",
+        );
 
         if (options.json) {
           console.log(JSON.stringify(sessions, null, 2));

--- a/src/commands/spawn.ts
+++ b/src/commands/spawn.ts
@@ -1,6 +1,7 @@
 import { Command, InvalidArgumentError } from "commander";
 import { resolve } from "node:path";
 import { getDaemonUrl } from "../lib/config";
+import { readString } from "../lib/daemon-json";
 import { ensureDaemon } from "./shared";
 import { PANE_ID_PATTERN, type SpawnSplit } from "../daemon/spawn-command";
 import {
@@ -142,8 +143,8 @@ function resolveSpawnCwd(explicit?: string): string {
 async function daemonTmuxSocket(): Promise<string | null> {
   const res = await fetch(`${getDaemonUrl()}/server-info`).catch(() => null);
   if (!res || !res.ok) return null;
-  const data = (await res.json()) as { socketPath: string | null };
-  return data.socketPath;
+  const body: unknown = await res.json();
+  return readString(body, "socketPath");
 }
 
 export function createSpawnCommand(): Command {

--- a/src/commands/spawn.ts
+++ b/src/commands/spawn.ts
@@ -143,7 +143,7 @@ function resolveSpawnCwd(explicit?: string): string {
 async function daemonTmuxSocket(): Promise<string | null> {
   const res = await fetch(`${getDaemonUrl()}/server-info`).catch(() => null);
   if (!res || !res.ok) return null;
-  const body: unknown = await res.json();
+  const body: unknown = await res.json().catch(() => null);
   return readString(body, "socketPath");
 }
 

--- a/src/commands/switch.ts
+++ b/src/commands/switch.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { getDaemonUrl } from "../lib/config";
+import { daemonBody, readString } from "../lib/daemon-json";
 import { isSameTmuxServer } from "../lib/tmux-server";
 import { tmuxArgv } from "../lib/tmux-exec";
 import { resolveActiveTmuxClientTty } from "../lib/tmux-client";
@@ -24,9 +25,9 @@ export function createSwitchCommand(): Command {
           throw new Error(`HTTP ${response.status}`);
         }
 
-        const data = (await response.json()) as {
+        const data = await daemonBody<{
           session: { tmuxPane: string | null; tmuxTarget: string | null };
-        };
+        }>(response, "session");
 
         // Prefer the stable `%N` pane id over the `session:window.pane`
         // coordinate: the coordinate goes stale when a lower-indexed window
@@ -48,8 +49,7 @@ export function createSwitchCommand(): Command {
         );
         const daemonSocket =
           infoRes && infoRes.ok
-            ? ((await infoRes.json()) as { socketPath: string | null })
-                .socketPath
+            ? readString(await infoRes.json(), "socketPath")
             : null;
         if (!isSameTmuxServer(daemonSocket)) {
           console.error(

--- a/src/commands/switch.ts
+++ b/src/commands/switch.ts
@@ -49,7 +49,7 @@ export function createSwitchCommand(): Command {
         );
         const daemonSocket =
           infoRes && infoRes.ok
-            ? readString(await infoRes.json(), "socketPath")
+            ? readString(await infoRes.json().catch(() => null), "socketPath")
             : null;
         if (!isSameTmuxServer(daemonSocket)) {
           console.error(

--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { createInterface } from "node:readline/promises";
 import { resolve } from "node:path";
 import { getDaemonUrl } from "../lib/config";
+import { daemonError, daemonBody } from "../lib/daemon-json";
 import { ensureDaemon } from "./shared";
 import type {
   PruneCandidate,
@@ -172,15 +173,13 @@ async function fetchCandidates(
     `${getDaemonUrl()}/worktrees/prune-candidates${query}`,
   );
   if (!response.ok) {
-    const body = (await response.json().catch(() => ({}))) as {
-      error?: string;
-    };
-    throw new Error(body.error ?? describeHttpFailure(response.status));
+    const error = await daemonError(response);
+    throw new Error(error ?? describeHttpFailure(response.status));
   }
   // Normalized, not cast: a daemon older than the `open` bucket sends a body
   // without it, and a bare cast would hand every reader a field the type
   // promises and the wire does not have.
-  return normalizeScan((await response.json()) as ScanResponse);
+  return normalizeScan(await daemonBody<ScanResponse>(response, "scan"));
 }
 
 async function postPrune(body: {
@@ -213,12 +212,10 @@ async function postPrune(body: {
     body: JSON.stringify({ ...body, source: "cli" }),
   });
   if (!response.ok) {
-    const data = (await response.json().catch(() => ({}))) as {
-      error?: string;
-    };
-    throw new Error(data.error ?? describeHttpFailure(response.status));
+    const error = await daemonError(response);
+    throw new Error(error ?? describeHttpFailure(response.status));
   }
-  return (await response.json()) as PruneRunResult;
+  return await daemonBody<PruneRunResult>(response, "prune");
 }
 
 interface PruneOptions {
@@ -466,12 +463,10 @@ async function fetchWorktrees(options: {
   const query = params.size > 0 ? `?${params}` : "";
   const response = await fetch(`${getDaemonUrl()}/worktrees${query}`);
   if (!response.ok) {
-    const body = (await response.json().catch(() => ({}))) as {
-      error?: string;
-    };
-    throw new Error(body.error ?? describeHttpFailure(response.status));
+    const error = await daemonError(response);
+    throw new Error(error ?? describeHttpFailure(response.status));
   }
-  return (await response.json()) as WorktreeListResponse;
+  return await daemonBody<WorktreeListResponse>(response, "worktree list");
 }
 
 async function runListCommand(options: { repo?: string }): Promise<void> {

--- a/src/lib/daemon-json.test.ts
+++ b/src/lib/daemon-json.test.ts
@@ -77,16 +77,16 @@ describe("daemonBody", () => {
   });
 
   it("throws naming the shape when the body is not JSON", async () => {
-    expect(daemonBody(res("<html>"), "transcript")).rejects.toThrow(
+    await expect(daemonBody(res("<html>"), "transcript")).rejects.toThrow(
       "non-JSON transcript",
     );
   });
 
   it("throws when the body is JSON but not an object", async () => {
-    expect(daemonBody(res(JSON.stringify("hi")), "scan")).rejects.toThrow(
+    await expect(daemonBody(res(JSON.stringify("hi")), "scan")).rejects.toThrow(
       "malformed scan",
     );
-    expect(daemonBody(res(JSON.stringify([1])), "scan")).rejects.toThrow(
+    await expect(daemonBody(res(JSON.stringify([1])), "scan")).rejects.toThrow(
       "malformed scan",
     );
   });

--- a/src/lib/daemon-json.test.ts
+++ b/src/lib/daemon-json.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "bun:test";
+import {
+  daemonError,
+  daemonBody,
+  readBoolean,
+  readString,
+} from "./daemon-json";
+
+/** A `Response` carrying an arbitrary body, including bodies `json()` rejects. */
+function res(body: string, status = 200): Response {
+  return new Response(body, { status });
+}
+
+describe("daemonError", () => {
+  it("returns the error string an endpoint sent", async () => {
+    expect(await daemonError(res(JSON.stringify({ error: "nope" }), 400))).toBe(
+      "nope",
+    );
+  });
+
+  it("returns null rather than throwing on a non-JSON body", async () => {
+    // A proxy's HTML error page, or a daemon that died mid-response: the
+    // caller's fallback message is the right answer, not a second failure.
+    expect(await daemonError(res("<html>502</html>", 502))).toBeNull();
+  });
+
+  it("returns null for an empty body", async () => {
+    expect(await daemonError(res("", 500))).toBeNull();
+  });
+
+  it("returns null when the body is JSON but carries no error", async () => {
+    expect(await daemonError(res(JSON.stringify({ ok: false })))).toBeNull();
+  });
+
+  it("ignores a non-string or empty error field", async () => {
+    expect(await daemonError(res(JSON.stringify({ error: 42 })))).toBeNull();
+    expect(await daemonError(res(JSON.stringify({ error: "" })))).toBeNull();
+  });
+
+  it("ignores an array body", async () => {
+    expect(await daemonError(res(JSON.stringify([{ error: "x" }])))).toBeNull();
+  });
+});
+
+describe("readBoolean / readString", () => {
+  it("reads a present field of the right type", () => {
+    expect(readBoolean({ killed: false }, "killed")).toBe(false);
+    expect(readString({ socketPath: "/tmp/s" }, "socketPath")).toBe("/tmp/s");
+  });
+
+  it("returns null for an absent field", () => {
+    // The distinction the kill path depends on: absent is not `false`.
+    expect(readBoolean({}, "killed")).toBeNull();
+    expect(readString({}, "socketPath")).toBeNull();
+  });
+
+  it("returns null for a field of the wrong type", () => {
+    expect(readBoolean({ killed: "yes" }, "killed")).toBeNull();
+    expect(readString({ socketPath: null }, "socketPath")).toBeNull();
+  });
+
+  it("returns null for a non-object body", () => {
+    for (const body of [null, undefined, 3, "str", [1]]) {
+      expect(readBoolean(body, "killed")).toBeNull();
+      expect(readString(body, "socketPath")).toBeNull();
+    }
+  });
+});
+
+describe("daemonBody", () => {
+  it("returns the parsed object", async () => {
+    const body = await daemonBody<{ sessions: number[] }>(
+      res(JSON.stringify({ sessions: [1, 2] })),
+      "sessions",
+    );
+    expect(body.sessions).toEqual([1, 2]);
+  });
+
+  it("throws naming the shape when the body is not JSON", async () => {
+    expect(daemonBody(res("<html>"), "transcript")).rejects.toThrow(
+      "non-JSON transcript",
+    );
+  });
+
+  it("throws when the body is JSON but not an object", async () => {
+    expect(daemonBody(res(JSON.stringify("hi")), "scan")).rejects.toThrow(
+      "malformed scan",
+    );
+    expect(daemonBody(res(JSON.stringify([1])), "scan")).rejects.toThrow(
+      "malformed scan",
+    );
+  });
+});

--- a/src/lib/daemon-json.ts
+++ b/src/lib/daemon-json.ts
@@ -1,0 +1,80 @@
+/**
+ * Reading a daemon response body.
+ *
+ * `Response.json()` is typed `any`, so every reader has to decide what to
+ * believe about the wire. Left to each call site that decision was an
+ * unannounced `as`, repeated about thirty times. These helpers make the same
+ * decision explicit and keep it in one place:
+ *
+ * - `daemonError` pulls the `error` string an endpoint sends with a non-OK
+ *   status. It never throws: a body that is missing, empty, or not JSON at all
+ *   is a daemon that failed before it could explain itself, which is the
+ *   caller's fallback message rather than a second failure.
+ * - `readBoolean` / `readString` narrow a single field off an unknown body,
+ *   for the small reads (`killed`, `socketPath`, `socketError`).
+ * - `daemonBody` is the honest name for the wide case: a response shape the
+ *   daemon owns and the CLI mirrors (`TranscriptResponse`, `ScanResponse`).
+ *   It proves the body is a JSON object and then TRUSTS the fields.
+ *
+ * `daemonBody` deliberately stops at the object check. Hand-maintaining a
+ * field-level validator for every response type would duplicate definitions
+ * the server already owns and drift the moment one changes, buying type
+ * safety the compiler cannot enforce anyway. What it does buy is a single
+ * stated point of trust, and a clear failure when the body is not an object
+ * at all (an HTML error page from a proxy, a bare string) instead of an
+ * `undefined` field surfacing as a confusing crash several lines later.
+ */
+
+/** True for a JSON object body, narrowing so `in` checks compile. */
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The `error` string a daemon endpoint sent with a non-OK status, or null if
+ * it sent none. Never throws, and consumes the body, so call it once per
+ * response.
+ */
+export async function daemonError(response: Response): Promise<string | null> {
+  const body: unknown = await response.json().catch(() => null);
+  if (!isJsonObject(body)) return null;
+  const error = body.error;
+  return typeof error === "string" && error.length > 0 ? error : null;
+}
+
+/** One boolean field off an already-parsed body, or null if absent/other. */
+export function readBoolean(body: unknown, key: string): boolean | null {
+  if (!isJsonObject(body)) return null;
+  const value = body[key];
+  return typeof value === "boolean" ? value : null;
+}
+
+/** One string field off an already-parsed body, or null if absent/other. */
+export function readString(body: unknown, key: string): string | null {
+  if (!isJsonObject(body)) return null;
+  const value = body[key];
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Parse a response the daemon owns the shape of. Proves the body is a JSON
+ * object, then trusts `T` (see the file header for why it stops there).
+ *
+ * `what` names the shape in the thrown message, so a daemon returning
+ * something else fails where it happened rather than several lines later.
+ */
+export async function daemonBody<T>(
+  response: Response,
+  what: string,
+): Promise<T> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw new Error(`Daemon sent a non-JSON ${what} response`);
+  }
+  if (!isJsonObject(body)) {
+    throw new Error(`Daemon sent a malformed ${what} response`);
+  }
+  return body as T;
+}


### PR DESCRIPTION
## Summary

`Response.json()` is typed `any`, so every CLI reader was deciding what to believe about the wire with an unannounced `as`, about thirty times over. Adds `src/lib/daemon-json.ts` and routes the command layer through it.

- **`daemonError(response)`** pulls the `error` string a non-OK response carried. It never throws: a body that is missing, empty, or not JSON at all is a daemon that failed before it could explain itself, which is the caller's fallback message rather than a second failure.
- **`readBoolean` / `readString`** narrow a single field off an unknown body, for the small reads (`killed`, `socketPath`, `socketError`).
- **`daemonBody<T>(response, what)`** proves the body is a JSON object and then trusts the shape, throwing `Daemon sent a malformed <what> response` otherwise.

## What `daemonBody` deliberately does not do

It stops at the object check. Hand-maintaining a field-level validator for every response type would duplicate definitions the server already owns and drift the moment one changes, buying type safety the compiler cannot enforce anyway.

What it does buy is a single stated point of trust instead of the same assertion re-made silently at every call site, and a clear failure when the body is not an object at all (an HTML error page from a proxy, a bare string) rather than an `undefined` field surfacing as a confusing crash several lines later. Genuine runtime validation of those shapes is a different and much larger job, and would want a schema library rather than hand-written guards.

## Behavior changes

Two, both intended:

- Four 400 branches printed `data.error` with no fallback, so a body lacking the field printed literally `undefined`. They now print the status.
- A non-object body now throws at the boundary instead of yielding `undefined` fields downstream.

## One site deliberately left alone

`last.ts`'s 409 ambiguous-candidates branch keeps its cast. It degrades to a fixed message by design and reads a `candidates` array rather than a scalar, so routing it through `daemonBody` would convert a deliberate graceful path into a throw.

## Testing

- [x] `bun run typecheck`, `knip`, `bun test` (4985 tests) all pass
- [x] 13 new tests for the helpers, covering non-JSON bodies, empty bodies, wrong-typed fields, array bodies, and the absent-vs-`false` distinction the kill path depends on
