### PR TITLE
fix(tui): Share one resize listener across all consumers

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -10,11 +10,7 @@ import {
   createMemo,
   untrack,
 } from "solid-js";
-import {
-  useKeyboard,
-  useRenderer,
-  useTerminalDimensions,
-} from "@opentui/solid";
+import { useKeyboard, useRenderer } from "@opentui/solid";
 import type { KeyEvent, MouseEvent, ScrollBoxRenderable } from "@opentui/core";
 import type { EnrichedSession } from "../types/session";
 import type { TmuxSocketError } from "../types";
@@ -51,6 +47,7 @@ import {
 } from "./utils/tmux";
 import { tmuxArgv } from "../lib/tmux-exec";
 import { isSameServerCached, setDaemonSocketPath } from "./utils/server-guard";
+import { useSharedTerminalDimensions } from "./utils/use-shared-dimensions";
 import { getDaemonUrl, resolvedHomeDir, STATE_FILE } from "../lib/config";
 import { getUIState } from "../lib/state";
 import {
@@ -203,7 +200,7 @@ export function App(props: AppProps) {
   const renderer = useRenderer();
   /** The viewport, for the handful of key handlers that have to agree with
    *  what a component decided it had room to draw. */
-  const appDims = useTerminalDimensions();
+  const appDims = useSharedTerminalDimensions();
   // Probed once at launch (cheap `which`, no need to react to hunk being
   // installed mid-session): gates the footer hint and help row. `d` itself
   // re-probes live so a hunk installed after launch works without restart.
@@ -2995,7 +2992,7 @@ export function App(props: AppProps) {
   // through a debounce; the persister itself tells user drags apart from
   // window resizes (which the window-resized hook re-pins).
   if (props.sidebar) {
-    const dims = useTerminalDimensions();
+    const dims = useSharedTerminalDimensions();
     const persistWidth = createSidebarWidthPersister();
     let widthSettleTimer: Timer | null = null;
     createEffect(

--- a/src/tui/components/ConfirmationDialog.tsx
+++ b/src/tui/components/ConfirmationDialog.tsx
@@ -1,6 +1,6 @@
 import type { Component } from "solid-js";
 import { createMemo } from "solid-js";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import { MouseButton } from "@opentui/core";
 import type { Session } from "../../types";
 import type { ConfirmAction } from "../store";
@@ -57,7 +57,7 @@ export const ConfirmationDialog: Component<ConfirmationDialogProps> = (
     return props.session.project || props.session.cwd || props.session.id;
   });
 
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
   const width = () =>
     Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, dims().width - 4));
   const height = () => Math.min(Math.max(1, dims().height), HEIGHT);

--- a/src/tui/components/ContextMenu.tsx
+++ b/src/tui/components/ContextMenu.tsx
@@ -1,6 +1,6 @@
 import type { Component } from "solid-js";
 import { createEffect, createSignal, For } from "solid-js";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import { MouseButton } from "@opentui/core";
 import { truncateText } from "../utils/format";
 import { theme } from "../theme";
@@ -91,7 +91,7 @@ function fittedLabel(label: string, hint: string): string {
 }
 
 export const ContextMenu: Component<ContextMenuProps> = (props) => {
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
   const [hovered, setHovered] = createSignal<string | null>(null);
   /**
    * Freeze the rows once the pointer enters one of them.

--- a/src/tui/components/CopyDialog.tsx
+++ b/src/tui/components/CopyDialog.tsx
@@ -1,6 +1,6 @@
 import type { Component } from "solid-js";
 import { Show } from "solid-js";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import { MouseButton } from "@opentui/core";
 import { truncateText } from "../utils/format";
 import { turnsLabel } from "../turns-selection";
@@ -72,7 +72,7 @@ interface CopyDialogProps {
  * reads the same as the handoff dialog's Turns row.
  */
 export const CopyDialog: Component<CopyDialogProps> = (props) => {
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
 
   const width = () =>
     Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, dims().width - 4));

--- a/src/tui/components/Footer.tsx
+++ b/src/tui/components/Footer.tsx
@@ -1,6 +1,6 @@
 import type { Component } from "solid-js";
 import { Switch, Match } from "solid-js";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import { DEFAULT_GROUP_BY, type GroupBy } from "../../lib/preferences";
 import { theme } from "../theme";
 
@@ -177,7 +177,7 @@ export function defaultHints(props: {
 }
 
 export const Footer: Component<FooterProps> = (props) => {
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
   const hints = () =>
     fitHints(defaultHints(props), Math.max(1, dims().width - FOOTER_PADDING));
 

--- a/src/tui/components/GroupPreview.tsx
+++ b/src/tui/components/GroupPreview.tsx
@@ -1,6 +1,6 @@
 import type { Component } from "solid-js";
 import { createMemo, For, Show } from "solid-js";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import type { ScrollBoxRenderable } from "@opentui/core";
 import type { EnrichedSession } from "../../types";
 import { WAITING_SUBTYPES, computeStatusSummary } from "../utils/grouping";
@@ -203,7 +203,7 @@ const WorktreeRow: Component<{
 };
 
 export const GroupPreview: Component<GroupPreviewProps> = (props) => {
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
   const separatorWidth = createMemo(() =>
     Math.max(1, Math.floor((dims().width * props.width) / 100) - 3),
   );

--- a/src/tui/components/HandoffDialog.tsx
+++ b/src/tui/components/HandoffDialog.tsx
@@ -1,6 +1,6 @@
 import type { Component } from "solid-js";
 import { Show } from "solid-js";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import { MouseButton } from "@opentui/core";
 import { displayWidth, truncateMiddle, truncateText } from "../utils/format";
 import { turnsLabel } from "../turns-selection";
@@ -195,7 +195,7 @@ interface HandoffDialogProps {
  * is done about that here.
  */
 export const HandoffDialog: Component<HandoffDialogProps> = (props) => {
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
 
   const width = () =>
     Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, dims().width - 4));

--- a/src/tui/components/NewSessionDialog.tsx
+++ b/src/tui/components/NewSessionDialog.tsx
@@ -1,6 +1,6 @@
 import type { Component } from "solid-js";
 import { createMemo, For, Show } from "solid-js";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import { MouseButton } from "@opentui/core";
 import type { SpawnableAgent } from "../../lib/spawnable-agents";
 import {
@@ -331,7 +331,7 @@ interface NewSessionDialogProps {
 }
 
 export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
 
   const width = () =>
     Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, dims().width - 4));

--- a/src/tui/components/NoticeDialog.tsx
+++ b/src/tui/components/NoticeDialog.tsx
@@ -1,6 +1,6 @@
 import type { Component } from "solid-js";
 import { createMemo, For } from "solid-js";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import { MouseButton } from "@opentui/core";
 import { truncateText } from "../utils/format";
 import { wrapText } from "./NewSessionDialog";
@@ -33,7 +33,7 @@ interface NoticeDialogProps {
  * the border instead of clipping.
  */
 export const NoticeDialog: Component<NoticeDialogProps> = (props) => {
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
 
   const width = () =>
     Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, dims().width - 4));

--- a/src/tui/components/Preview.tsx
+++ b/src/tui/components/Preview.tsx
@@ -8,7 +8,7 @@ import {
   Show,
   onCleanup,
 } from "solid-js";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import type {
   StyledText,
   TextRenderable,
@@ -233,7 +233,7 @@ interface PreviewProps {
 }
 
 export const Preview: Component<PreviewProps> = (props) => {
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
   const separatorWidth = createMemo(() =>
     Math.max(1, Math.floor((dims().width * props.width) / 100) - 3),
   );

--- a/src/tui/components/SessionItem.tsx
+++ b/src/tui/components/SessionItem.tsx
@@ -1,7 +1,7 @@
 import type { Component } from "solid-js";
 import { createMemo, For, Show } from "solid-js";
 import { useTick } from "../store";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import { MouseButton, type MouseEvent } from "@opentui/core";
 import type { EnrichedSession } from "../../types";
 import type { IconStyle } from "../../lib/icons";
@@ -788,7 +788,7 @@ const RowRender: Component<{
 
 export const SessionItem: Component<SessionItemProps> = (props) => {
   const { tick } = useTick();
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
   const effectiveWidth = () =>
     props.showPreview
       ? Math.floor((dims().width * (100 - props.previewWidth)) / 100)

--- a/src/tui/components/SessionList.tsx
+++ b/src/tui/components/SessionList.tsx
@@ -1,7 +1,7 @@
 import type { Component } from "solid-js";
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import type { MouseEvent, ScrollBoxRenderable } from "@opentui/core";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import type { EnrichedSession, TmuxSocketError } from "../../types";
 import type { IconStyle } from "../../lib/icons";
 import type {
@@ -82,7 +82,7 @@ const ROW_MENU_INDENT = 2;
 export const SessionList: Component<SessionListProps> = (props) => {
   let scrollboxRef: ScrollBoxRenderable | undefined;
   const [scrollboxLayout, setScrollboxLayout] = createSignal(0);
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
   const effectiveWidth = () =>
     props.showPreview
       ? Math.floor((dims().width * (100 - props.previewWidth)) / 100)

--- a/src/tui/components/Toast.tsx
+++ b/src/tui/components/Toast.tsx
@@ -1,5 +1,5 @@
 import type { Component } from "solid-js";
-import { useTerminalDimensions } from "@opentui/solid";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import { theme } from "../theme";
 
 interface ToastProps {
@@ -16,7 +16,7 @@ const MAX_WIDTH = 40;
  * off the left edge in a narrow pane (e.g. the 30-col default sidebar).
  */
 export const Toast: Component<ToastProps> = (props) => {
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
   // Border-box width, capped and clamped to leave a 1-col gap on each side.
   const width = () => Math.min(MAX_WIDTH, Math.max(1, dims().width - 2));
 

--- a/src/tui/components/WorktreesPanel.tsx
+++ b/src/tui/components/WorktreesPanel.tsx
@@ -8,11 +8,7 @@ import {
   onCleanup,
   onMount,
 } from "solid-js";
-import {
-  useKeyboard,
-  useRenderer,
-  useTerminalDimensions,
-} from "@opentui/solid";
+import { useKeyboard, useRenderer } from "@opentui/solid";
 import type { KeyEvent, ScrollBoxRenderable } from "@opentui/core";
 import { MouseButton } from "@opentui/core";
 import { basename, resolve, sep } from "node:path";
@@ -39,6 +35,7 @@ import type { SessionStatus } from "../../types/session";
 import { displayWidth, sliceToWidth, truncateText } from "../utils/format";
 import { fitHints } from "./Footer";
 import { useStatusIcon } from "../utils/useStatusIcon";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
 import type { IconStyle } from "../../lib/icons";
 import { theme } from "../theme";
 
@@ -1294,7 +1291,7 @@ function spawnClipboardHelper(argv: string[], text: string): boolean {
 }
 
 export const WorktreesPanel: Component<WorktreesPanelProps> = (props) => {
-  const dims = useTerminalDimensions();
+  const dims = useSharedTerminalDimensions();
   // Only for `y`: OSC 52 goes out through the terminal the renderer owns.
   const renderer = useRenderer();
   const [phase, setPhase] = createSignal<Phase>("loading");

--- a/src/tui/utils/use-shared-dimensions.test.tsx
+++ b/src/tui/utils/use-shared-dimensions.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { testRender } from "@opentui/solid";
+import { For, createSignal } from "solid-js";
+import { useSharedTerminalDimensions } from "./use-shared-dimensions";
+
+type Setup = Awaited<ReturnType<typeof testRender>>;
+let setup: Setup;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+});
+
+/** One row that subscribes via the shared hook and renders its dimensions. */
+function DimensionsConsumer(props: {
+  onDims?: (w: number, h: number) => void;
+}) {
+  const dims = useSharedTerminalDimensions();
+  props.onDims?.(dims().width, dims().height);
+  return (
+    <text>
+      {dims().width}x{dims().height}
+    </text>
+  );
+}
+
+describe("useSharedTerminalDimensions", () => {
+  it("adds no listeners beyond the baseline with zero consumers", async () => {
+    setup = await testRender(() => <text>no consumers</text>, {
+      width: 80,
+      height: 24,
+    });
+    await setup.renderOnce();
+    expect(setup.renderer.listenerCount("resize")).toBe(0);
+  });
+
+  it("holds exactly one resize listener for many consumers, and returns real dimensions", async () => {
+    const seen: Array<[number, number]> = [];
+    setup = await testRender(
+      () => (
+        <For each={Array.from({ length: 15 }, (_, i) => i)}>
+          {() => <DimensionsConsumer onDims={(w, h) => seen.push([w, h])} />}
+        </For>
+      ),
+      { width: 100, height: 40 },
+    );
+    await setup.renderOnce();
+
+    // Baseline (no consumers) is 0, so any 15-consumer tree should hold
+    // exactly the one shared listener, not 15.
+    expect(setup.renderer.listenerCount("resize")).toBe(1);
+    expect(seen.length).toBe(15);
+    for (const [w, h] of seen) {
+      expect(w).toBe(setup.renderer.width);
+      expect(h).toBe(setup.renderer.height);
+    }
+  });
+
+  it("drops the shared listener once the last consumer unmounts", async () => {
+    const [mounted, setMounted] = createSignal(true);
+    setup = await testRender(
+      () => (
+        <For each={mounted() ? Array.from({ length: 15 }, (_, i) => i) : []}>
+          {() => <DimensionsConsumer />}
+        </For>
+      ),
+      { width: 80, height: 24 },
+    );
+    await setup.renderOnce();
+    expect(setup.renderer.listenerCount("resize")).toBe(1);
+
+    setMounted(false);
+    await setup.renderOnce();
+    expect(setup.renderer.listenerCount("resize")).toBe(0);
+  });
+
+  it("removes the listener on renderer destroy", async () => {
+    setup = await testRender(
+      () => (
+        <For each={Array.from({ length: 5 }, (_, i) => i)}>
+          {() => <DimensionsConsumer />}
+        </For>
+      ),
+      { width: 80, height: 24 },
+    );
+    await setup.renderOnce();
+    expect(setup.renderer.listenerCount("resize")).toBe(1);
+
+    const renderer = setup.renderer;
+    renderer.destroy();
+    expect(renderer.listenerCount("resize")).toBe(0);
+  });
+
+  it("does not leak entries across separate renderer instances", async () => {
+    const first = await testRender(() => <DimensionsConsumer />, {
+      width: 80,
+      height: 24,
+    });
+    await first.renderOnce();
+    expect(first.renderer.listenerCount("resize")).toBe(1);
+
+    setup = await testRender(() => <DimensionsConsumer />, {
+      width: 80,
+      height: 24,
+    });
+    await setup.renderOnce();
+    expect(setup.renderer.listenerCount("resize")).toBe(1);
+    expect(first.renderer.listenerCount("resize")).toBe(1);
+
+    first.renderer.destroy();
+    expect(first.renderer.listenerCount("resize")).toBe(0);
+    // The second renderer's own listener is untouched by the first's teardown.
+    expect(setup.renderer.listenerCount("resize")).toBe(1);
+  });
+});

--- a/src/tui/utils/use-shared-dimensions.test.tsx
+++ b/src/tui/utils/use-shared-dimensions.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "bun:test";
 import { testRender } from "@opentui/solid";
-import { For, createSignal } from "solid-js";
+import { For, createEffect, createSignal } from "solid-js";
 import { useSharedTerminalDimensions } from "./use-shared-dimensions";
 
 type Setup = Awaited<ReturnType<typeof testRender>>;
@@ -15,7 +15,9 @@ function DimensionsConsumer(props: {
   onDims?: (w: number, h: number) => void;
 }) {
   const dims = useSharedTerminalDimensions();
-  props.onDims?.(dims().width, dims().height);
+  // Effect rather than a setup-time call so onDims also fires on updates,
+  // letting tests observe resize propagation, not just the initial value.
+  createEffect(() => props.onDims?.(dims().width, dims().height));
   return (
     <text>
       {dims().width}x{dims().height}
@@ -53,6 +55,44 @@ describe("useSharedTerminalDimensions", () => {
       expect(w).toBe(setup.renderer.width);
       expect(h).toBe(setup.renderer.height);
     }
+  });
+
+  it("propagates a resize to every consumer through the one listener", async () => {
+    const seen: Array<[number, number]> = [];
+    setup = await testRender(
+      () => (
+        <For each={Array.from({ length: 15 }, (_, i) => i)}>
+          {() => <DimensionsConsumer onDims={(w, h) => seen.push([w, h])} />}
+        </For>
+      ),
+      { width: 100, height: 40 },
+    );
+    await setup.renderOnce();
+    seen.length = 0;
+
+    setup.resize(120, 50);
+    await setup.renderOnce();
+
+    expect(setup.renderer.listenerCount("resize")).toBe(1);
+    expect(seen.length).toBe(15);
+    for (const [w, h] of seen) {
+      expect([w, h]).toEqual([120, 50]);
+    }
+  });
+
+  it("does not notify consumers for a resize reporting unchanged dimensions", async () => {
+    const seen: Array<[number, number]> = [];
+    setup = await testRender(
+      () => <DimensionsConsumer onDims={(w, h) => seen.push([w, h])} />,
+      { width: 100, height: 40 },
+    );
+    await setup.renderOnce();
+    seen.length = 0;
+
+    setup.resize(100, 40);
+    await setup.renderOnce();
+
+    expect(seen.length).toBe(0);
   });
 
   it("drops the shared listener once the last consumer unmounts", async () => {

--- a/src/tui/utils/use-shared-dimensions.ts
+++ b/src/tui/utils/use-shared-dimensions.ts
@@ -29,10 +29,12 @@ export function useSharedTerminalDimensions(): Accessor<TerminalDimensions> {
   const renderer = useRenderer();
   let entry = cache.get(renderer);
   if (!entry) {
-    const [dims, setDims] = createSignal<TerminalDimensions>({
-      width: renderer.width,
-      height: renderer.height,
-    });
+    const [dims, setDims] = createSignal<TerminalDimensions>(
+      { width: renderer.width, height: renderer.height },
+      // A resize event reporting unchanged dimensions should not wake every
+      // consumer (each row subscribes), so compare by value, not reference.
+      { equals: (a, b) => a.width === b.width && a.height === b.height },
+    );
     const onResize = (width: number, height: number) =>
       setDims({ width, height });
     renderer.on("resize", onResize);

--- a/src/tui/utils/use-shared-dimensions.ts
+++ b/src/tui/utils/use-shared-dimensions.ts
@@ -1,0 +1,57 @@
+import type { CliRenderer } from "@opentui/core";
+import { useRenderer } from "@opentui/solid";
+import { createSignal, onCleanup, type Accessor } from "solid-js";
+
+interface TerminalDimensions {
+  width: number;
+  height: number;
+}
+
+interface Entry {
+  dims: Accessor<TerminalDimensions>;
+  refs: number;
+  detach: () => void;
+}
+
+// Keyed by renderer instance: production has one CliRenderer, but each
+// testRender creates its own, and entries must not leak across them.
+const cache = new Map<CliRenderer, Entry>();
+
+/**
+ * Drop-in replacement for @opentui/solid's useTerminalDimensions that shares
+ * ONE renderer "resize" listener across every consumer. The upstream hook
+ * subscribes per call, and SessionItem mounts per row, so a 30-session picker
+ * held 30+ listeners on the renderer EventEmitter and tripped Node's
+ * MaxListenersExceededWarning (default max 10), which prints over the TUI.
+ * Refcounted so the listener detaches when the last consumer unmounts.
+ */
+export function useSharedTerminalDimensions(): Accessor<TerminalDimensions> {
+  const renderer = useRenderer();
+  let entry = cache.get(renderer);
+  if (!entry) {
+    const [dims, setDims] = createSignal<TerminalDimensions>({
+      width: renderer.width,
+      height: renderer.height,
+    });
+    const onResize = (width: number, height: number) =>
+      setDims({ width, height });
+    renderer.on("resize", onResize);
+    entry = { dims, refs: 0, detach: () => renderer.off("resize", onResize) };
+    cache.set(renderer, entry);
+  }
+  entry.refs++;
+  const claimed = entry;
+  onCleanup(() => {
+    claimed.refs--;
+    if (claimed.refs === 0) {
+      claimed.detach();
+      // Guard against evicting a successor: only remove the entry this
+      // consumer actually claimed, in case a fresh one was created before
+      // this cleanup ran.
+      if (cache.get(renderer) === claimed) {
+        cache.delete(renderer);
+      }
+    }
+  });
+  return claimed.dims;
+}


### PR DESCRIPTION
## Summary

`@opentui/solid`'s `useTerminalDimensions` registers its own `"resize"` listener on the `CliRenderer` EventEmitter per call, and `SessionItem` mounts it per row. With a 33-session picker the renderer held a measured peak of 36 concurrent resize listeners, tripping Node/Bun's `MaxListenersExceededWarning` (threshold 11), which prints straight over the TUI:

```
(node:30407) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 resize listeners added...
```

The warning fires once, at the 11th listener. With few rows the baseline (App, SessionList, Footer, dialogs) sits just under the threshold and opening the preview pane (`P`) tips it over, which is why it surfaced as "only when the preview is open". Not an unbounded leak — listeners tear down cleanly on unmount — but the over-subscription is real and the warning corrupts the screen.

This adds `useSharedTerminalDimensions` (`src/tui/utils/use-shared-dimensions.ts`): a refcounted wrapper holding a single renderer listener shared by all consumers, keyed per renderer instance so `testRender` runs stay isolated, detached when the last consumer unmounts. All 15 call sites across 14 files are switched; no upstream-hook calls remain.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (4990 tests / 180 files, including 5 new cases: 15 consumers → exactly 1 listener, teardown to 0, renderer destroy, per-renderer cache isolation)
- [x] Verified the affected TUI surface (picker / sidebar) in a detached tmux session (if this touches the TUI, columns, layout, theming, or the daemon → TUI data path)
- [x] Verified end to end with a real agent session (if this touches detection, state, the daemon, or the CLI)

Instrumented run (patched `EventEmitter.addListener` to count `"resize"` registrations) against 33 live sessions with preview open: peak went from 36 listeners on `CliRenderer` before to exactly 1 after, with clean teardown on quit in both. Picker and Worktrees panel render normally in a 200x50 detached tmux session; dialogs were exercised via typecheck and the component test suite only (mechanical swap).

## Notes for reviewers

The cleanup guard (`cache.get(renderer) === claimed`) exists so a consumer's cleanup can only evict the cache entry it claimed, in case a fresh entry is created before an old cleanup runs.