### PR TITLE
docs: add Cursor Cloud agent testing notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,3 +204,21 @@ setup.renderer.destroy();               // always clean up in afterEach
 - **Fixed timestamps**: Use `"2024-01-15T12:00:00Z"` instead of `new Date()` to avoid time-dependent fragility
 
 **Pure logic tests** (store, grouping, format, icons) use standard `bun:test` without `testRender`.
+
+## Cursor Cloud specific instructions
+
+In Cursor Cloud Agent VMs, `bun` and the linked `ccmux` binary live in `~/.bun/bin` (on `PATH` for fresh shells), installed by the environment `install` step (`bun install` + `bun link`). `tmux`, `git`, `gh`, and `node` are preinstalled on the base image.
+
+### Running the test suite
+
+Cloud VMs configure git with `commit.gpgsign=true` and an SSH signing helper globally. The git-backed suites (`worktree-*`) create throwaway repos that inherit this, and signing the hundreds of test commits is slow and can fail nondeterministically (`git commit` failing with empty stderr), so a plain `bun test` may hang for minutes or report spurious failures that do not reproduce locally. Run the suite with commit signing disabled for that invocation only:
+
+```bash
+GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false bun test
+```
+
+With signing disabled the full suite is deterministic (~5377 pass / 0 fail in ~70s). The first cold `bun test` after boot can still take a few minutes (module transpile + tree-sitter wasm compile) before warming up. This override affects only the test run; it does not change how the agent signs its own commits.
+
+### Exercising ccmux end to end
+
+`ccmux` needs a tmux server with agent processes to track. To drive it without a real agent, run a stand-in whose `argv[0]` basename matches an agent's `processMatch` (e.g. `exec -a claude bash <script>` for Claude, matched by `/\bclaude\b/i`), then point an isolated daemon at that server (`CCMUX_TMUX_SOCKET`/`CCMUX_PORT`) as described under "Fully isolated runs" above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,8 +217,8 @@ Cloud VMs configure git with `commit.gpgsign=true` and an SSH signing helper glo
 GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false bun test
 ```
 
-With signing disabled the full suite is deterministic (~5377 pass / 0 fail in ~70s). The first cold `bun test` after boot can still take a few minutes (module transpile + tree-sitter wasm compile) before warming up. This override affects only the test run; it does not change how the agent signs its own commits.
+With signing disabled the full suite passes with no failures and, once warm, finishes in under a couple of minutes. The first cold `bun test` after boot can still take several minutes (module transpile + tree-sitter wasm compile) before warming up. This override affects only the test run; it does not change how the agent signs its own commits.
 
 ### Exercising ccmux end to end
 
-`ccmux` needs a tmux server with agent processes to track. To drive it without a real agent, run a stand-in whose `argv[0]` basename matches an agent's `processMatch` (e.g. `exec -a claude bash <script>` for Claude, matched by `/\bclaude\b/i`), then point an isolated daemon at that server (`CCMUX_TMUX_SOCKET`/`CCMUX_PORT`) as described under "Fully isolated runs" above.
+`ccmux` needs a tmux server with agent processes to track. To drive it without a real agent, run a stand-in whose `argv[0]` basename matches an agent's `processMatch` (defined per agent in `src/lib/agents.ts`) — e.g. `exec -a claude bash <script>` makes the process's `argv[0]` `claude`, which Claude's `processMatch` matches — then point an isolated daemon at that server (`CCMUX_TMUX_SOCKET`/`CCMUX_PORT`) as described under "Fully isolated runs" above.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing durable, non-obvious operating guidance discovered while setting up this repo's Cloud Agent development environment.

The key note: Cloud Agent VMs configure git globally with `commit.gpgsign=true` plus an SSH signing helper. The git-backed test suites (`worktree-*`) create throwaway repos that inherit this, and signing the hundreds of test commits is slow and can fail nondeterministically (`git commit` failing with empty stderr). As a result a plain `bun test` may hang for minutes or report spurious failures that do not reproduce locally. The section documents the fix — run the suite with commit signing disabled for that one invocation:

```bash
GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false bun test
```

With signing disabled the full suite is deterministic (~5377 pass / 0 fail in ~70s). It also notes that `bun`/`ccmux` live in `~/.bun/bin` and gives the `exec -a claude` stand-in trick for exercising detection without a real agent.

This is a docs-only change; no code or behavior is affected.

## Related issue

N/A

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (5377 pass / 0 fail with commit signing disabled, as documented)
- [ ] Verified the affected TUI surface (picker / sidebar) in a detached tmux session (if this touches the TUI, columns, layout, theming, or the daemon → TUI data path) — N/A, docs only
- [ ] Verified end to end with a real agent session (if this touches detection, state, the daemon, or the CLI) — N/A, docs only

## Notes for reviewers

Docs-only. The guidance was validated both on the setup VM and in a fresh Cloud Agent booted from the tested environment build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b57bc93d-a864-4b49-92ff-905212a38654?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b57bc93d-a864-4b49-92ff-905212a38654&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

