### PR TITLE
fix(tui): Long input values scroll instead of widening the dialog

### DIFF
--- a/src/tui/components/HandoffDialog.test.tsx
+++ b/src/tui/components/HandoffDialog.test.tsx
@@ -170,6 +170,27 @@ describe("HandoffDialog", () => {
     expect(frame).toContain("CancelSend");
   });
 
+  it("scrolls a long note inside the control instead of widening it", async () => {
+    // An OpenTUI input measures its own width from its text, and Yoga's
+    // default `flexShrink` is 0, so a value longer than the control used to
+    // widen it (and the wrapper box behind it) straight through the right
+    // border. The border column must survive on the Note row, with the
+    // value's tail shown and its head scrolled off.
+    const note =
+      "default very long text what happening here and beyond the border";
+    const lines = (await render({ note, field: "note", width: 60 })).split(
+      "\n",
+    );
+    const noteLine = lines.find((line) => line.includes("Note"));
+    expect(noteLine).toBeDefined();
+    const borderLine = lines.find((line) => line.includes("Hand off"));
+    const rightEdge = borderLine!.lastIndexOf("│");
+    expect(noteLine![rightEdge]).toBe("│");
+    expect(noteLine!.trimEnd().length).toBe(borderLine!.trimEnd().length);
+    expect(noteLine).toContain("beyond the border");
+    expect(noteLine).not.toContain("default very");
+  });
+
   it("draws the rows in order: title, turns, note, From, To, buttons", async () => {
     // By ORDER rather than presence: nothing here clips, so a row the budget
     // did not account for draws OVER its neighbour instead of disappearing.

--- a/src/tui/components/HandoffDialog.tsx
+++ b/src/tui/components/HandoffDialog.tsx
@@ -208,9 +208,10 @@ export const HandoffDialog: Component<HandoffDialogProps> = (props) => {
     Math.max(1, contentWidth() - LABEL_WIDTH - CONTROL_GAP - 2);
 
   /** Truncated HERE rather than by the layout: an OpenTUI input draws its
-   *  placeholder in full past its own box. (A long typed VALUE overruns the
-   *  border at sidebar widths exactly as the new-session dialog's Prompt
-   *  field has always done; that is the input's own scrolling, not this.) */
+   *  placeholder in full past its own box. (A long typed VALUE is the other
+   *  overrun, handled at the input: it measures itself from its text, and
+   *  Yoga's default `flexShrink` of 0 let that measurement widen the control
+   *  past the border instead of scrolling; see the `flexShrink` below.) */
   const notePlaceholder = () =>
     truncateText("note (optional) · sent in the header", controlWidth());
 
@@ -346,6 +347,7 @@ export const HandoffDialog: Component<HandoffDialogProps> = (props) => {
           height={1}
           flexDirection="row"
           flexGrow={1}
+          flexShrink={1}
           paddingLeft={1}
           paddingRight={1}
           backgroundColor={
@@ -366,6 +368,7 @@ export const HandoffDialog: Component<HandoffDialogProps> = (props) => {
             // being refused AFTER the dialog closed would lose what was typed.
             maxLength={MAX_HANDOFF_NOTE_CHARS}
             flexGrow={1}
+            flexShrink={1}
           />
         </box>
       </box>

--- a/src/tui/components/NewSessionDialog.test.tsx
+++ b/src/tui/components/NewSessionDialog.test.tsx
@@ -739,6 +739,28 @@ describe("NewSessionDialog", () => {
     expect(frame).not.toContain("New window");
   });
 
+  it("scrolls a long prompt inside its control instead of widening it", async () => {
+    // Same defect the handoff dialog's Note field had: the input measures
+    // itself from its text, and with Yoga's default `flexShrink` of 0 a long
+    // value pushed the control (and its wrapper) through the right border.
+    const prompt =
+      "a very long prompt that keeps going well past the width of the dialog box";
+    const frame = await renderDialog({
+      draft: draft({ prompt, field: "prompt" }),
+      width: 60,
+    });
+    const lines = frame.split("\n");
+    const promptLine = lines.find((line) => line.includes("Prompt"));
+    const titleLine = lines.find((line) => line.includes("New session"));
+    expect(promptLine).toBeDefined();
+    expect(titleLine).toBeDefined();
+    const rightEdge = titleLine!.lastIndexOf("│");
+    expect(promptLine![rightEdge]).toBe("│");
+    expect(promptLine!.trimEnd().length).toBe(titleLine!.trimEnd().length);
+    expect(promptLine).toContain("dialog box");
+    expect(promptLine).not.toContain("a very long");
+  });
+
   it("keeps the placements distinguishable at the real sidebar rail", async () => {
     // A 30-column rail leaves the overlay too few columns for the full
     // labels, which truncated `Split right`/`Split down` into two rows both

--- a/src/tui/components/NewSessionDialog.tsx
+++ b/src/tui/components/NewSessionDialog.tsx
@@ -1030,6 +1030,7 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
               height={1}
               flexDirection="row"
               flexGrow={1}
+              flexShrink={1}
               paddingLeft={1}
               paddingRight={1}
               backgroundColor={
@@ -1047,6 +1048,7 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
                 backgroundColor="transparent"
                 focusedBackgroundColor="transparent"
                 flexGrow={1}
+                flexShrink={1}
               />
             </box>
           </box>
@@ -1100,6 +1102,7 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
               height={1}
               flexDirection="row"
               flexGrow={1}
+              flexShrink={1}
               paddingLeft={1}
               paddingRight={1}
               backgroundColor={
@@ -1119,6 +1122,7 @@ export const NewSessionDialog: Component<NewSessionDialogProps> = (props) => {
                 backgroundColor="transparent"
                 focusedBackgroundColor="transparent"
                 flexGrow={1}
+                flexShrink={1}
               />
             </box>
             <Show when={nameHint()}>


### PR DESCRIPTION
## Summary

Typing a value longer than the control in the Hand off dialog's **Note** field widened the input straight through the dialog's right border instead of scrolling. The New session dialog's **Prompt** and worktree **Name** fields had the same defect (a comment in `HandoffDialog.tsx` even called it out as long-standing).

Cause: an OpenTUI `<input>` measures its own width from its text, and Yoga's default `flexShrink` is `0`, so once the value outgrows the available columns the measured width becomes the flex basis, the input can't shrink, and it (plus the `flexGrow` wrapper box painting the control background) overflows the box.

Fix: `flexShrink={1}` on the input and its wrapper in all three fields, so the input gets the width the row actually has and scrolls the value inside it. The stale comment in `HandoffDialog.tsx` is rewritten to explain the mechanism.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (5466 pass, 0 fail)
- [x] Verified the affected TUI surface (picker / sidebar) in a detached tmux session (if this touches the TUI, columns, layout, theming, or the daemon → TUI data path)
- [ ] Verified end to end with a real agent session (if this touches detection, state, the daemon, or the CLI) — N/A, rendering only

Regression tests added on both dialogs: render with a long value at 60 columns and assert the right border column survives on that row, the value's tail is visible, and its head is scrolled off. Both fail on the previous code and pass with the fix. The worktree Name field has no dedicated test; it is the identical mechanism, covered by the Prompt test.

Verified live in the picker against two real Claude sessions (row menu → Hand off → pick target → Tab → long note; and `n` → Tab to Prompt → long prompt).

## Notes for reviewers

Before/after screen recordings are in https://github.com/epilande/ccmux/pull/170#issuecomment-5467596164 (before: the Note control widens through the border; after: the same flow, plus the New session Prompt field).
