### PR TITLE
test(tui): deliver escape for real in the key harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,7 @@ setup.renderer.destroy();               // always clean up in afterEach
 - **Mocking tmux**: Preview tests use `mock.module()` from `bun:test` to mock `capturePane` before importing the component
 - **Input simulation**: `createMockKeys` and `createSpy` from `@opentui/core/testing` for keyboard/callback tests
 - **Fixed timestamps**: Use `"2024-01-15T12:00:00Z"` instead of `new Date()` to avoid time-dependent fragility
+- **Escape**: use `deliverEscape(setup.renderer)` from `test-helpers.tsx`. `pressKey("escape")` types six letters and a raw `pressEscape()` sits in the parser's 20ms lone-ESC window, so an assertion right after tests nothing; `test-harness-guard.test.ts` fails the suite on either spelling
 
 **Pure logic tests** (store, grouping, format, icons) use standard `bun:test` without `testRender`.
 

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -6755,7 +6755,9 @@ describe("App copy last response", () => {
     try {
       await renderRow();
       await openCopyDialog();
-      await press("escape");
+      deliverEscape(setup.renderer);
+      await settle();
+      await setup.renderOnce();
       const frame = squish(setup.captureCharFrame());
       expect(frame).not.toContain("Lastresponse");
       expect(asked).toEqual([]);

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -11,7 +11,11 @@ import { testRender } from "@opentui/solid";
 import { MouseButtons } from "@opentui/core/testing";
 import type { SSECallbacks } from "./utils/sse";
 import * as clipboard from "./utils/clipboard";
-import { mockEnrichedSession, squish } from "./components/test-helpers";
+import {
+  deliverEscape,
+  mockEnrichedSession,
+  squish,
+} from "./components/test-helpers";
 import { liveEffects } from "./components/WorktreesPanel";
 import { HANDOFF_BADGE } from "./components/session-columns";
 import { MAX_TURNS, renderTurns } from "../daemon/transcript-read";
@@ -757,7 +761,7 @@ describe("App sidebar mode", () => {
 
       setup.mockInput.pressKey("j");
       await setup.renderOnce();
-      setup.mockInput.pressKey("return");
+      setup.mockInput.pressEnter();
       await setup.renderOnce();
 
       expect(exitSpy).not.toHaveBeenCalled();
@@ -773,7 +777,7 @@ describe("App sidebar mode", () => {
 
     try {
       await renderApp(30, 20, { sidebar: true });
-      setup.mockInput.pressKey("escape");
+      deliverEscape(setup.renderer);
       await setup.renderOnce();
 
       expect(exitSpy).not.toHaveBeenCalled();
@@ -2452,8 +2456,8 @@ describe("App fork (F / context menu)", () => {
 
       // Ordinary new-session dialogs still refresh on every open so a
       // long-lived picker can discover agents installed since startup.
-      setup.mockInput.pressEscape();
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
       setup.mockInput.pressKey("n");
       await settle();
@@ -2626,8 +2630,8 @@ describe("App fork (F / context menu)", () => {
 
       // Dismiss the submitted fork and start drafting an unrelated session
       // while its daemon request is still pending.
-      setup.mockInput.pressEscape();
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
       setup.mockInput.pressKey("n");
       await settle();
@@ -2985,10 +2989,8 @@ describe("App new session dialog", () => {
     const { spawns, restore } = withDaemon();
     try {
       await openDialog();
-      setup.mockInput.pressEscape();
-      // A bare ESC byte is the prefix of every escape sequence, so the key
-      // parser holds it briefly before deciding it stands alone.
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
       expect(setup.captureCharFrame()).not.toContain("New session");
       expect(spawns).toHaveLength(0);
@@ -3083,8 +3085,8 @@ describe("App new session dialog", () => {
       await setup.renderOnce();
       setup.mockInput.pressKey("j");
       await setup.renderOnce();
-      setup.mockInput.pressEscape();
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
       // The dialog survives (escape was the overlay's), the held agent is
       // unchanged, and the list is gone.
@@ -3779,8 +3781,8 @@ describe("App new session dialog", () => {
       expect(setup.captureCharFrame()).toContain("connection refused");
 
       // Close, bring the daemon back, reopen: the list is fetched again.
-      setup.mockInput.pressEscape();
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
       failNext = false;
       setup.mockInput.pressKey("n");
@@ -3944,8 +3946,8 @@ describe("App new session dialog", () => {
       expect(calls).toBe(1);
       expect(setup.captureCharFrame()).not.toContain("Codex");
 
-      setup.mockInput.pressEscape();
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
       setup.mockInput.pressKey("n");
       await settle();
@@ -4058,8 +4060,8 @@ describe("App new session dialog", () => {
       const byKey = setup.captureCharFrame();
       expect(byKey).toContain("/where/the/picker/ran");
 
-      setup.mockInput.pressEscape();
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
 
       const byMouse = await openGroupMenuNewSession();
@@ -4103,8 +4105,8 @@ describe("App new session dialog", () => {
       expect(byKey).toContain("/code/myapp");
       expect(byKey).not.toContain("worktrees/feature");
 
-      setup.mockInput.pressEscape();
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
 
       const byMouse = await openGroupMenuNewSession();
@@ -4734,7 +4736,7 @@ describe("App move-changes menu gate", () => {
       // Open on the first row, then dismiss and open on the second.
       await setup.mockMouse.click(5, 1, MouseButtons.RIGHT);
       await setup.renderOnce();
-      setup.mockInput.pressKey("escape");
+      deliverEscape(setup.renderer);
       await setup.renderOnce();
       await setup.mockMouse.click(5, 2, MouseButtons.RIGHT);
       await setup.renderOnce();
@@ -5290,7 +5292,7 @@ describe("App move-changes reporting", () => {
       expect(exitSpy).not.toHaveBeenCalled();
       expect(squish(setup.captureCharFrame())).toContain("deadbee1234");
 
-      setup.mockInput.pressKey("escape");
+      deliverEscape(setup.renderer);
       await settle();
       expect(exitSpy).toHaveBeenCalled();
     } finally {
@@ -5342,7 +5344,7 @@ describe("App move-changes reporting", () => {
 
       // Dismissed by a keypress, and the dialog it was raised over is still
       // there to correct and retry.
-      setup.mockInput.pressKey("escape");
+      deliverEscape(setup.renderer);
       await setup.renderOnce();
       const after = squish(setup.captureCharFrame());
       expect(after).not.toContain("gitstashapplyabc1234def");
@@ -5689,8 +5691,8 @@ describe("App fork into worktree", () => {
     const { spawns, restore } = withForkDaemon();
     try {
       await openForkDialog();
-      setup.mockInput.pressEscape();
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
 
       expect(spawns).toHaveLength(0);
@@ -5963,10 +5965,8 @@ describe("App row menu (m)", () => {
       await press("m");
       expect(setup.captureCharFrame()).toContain("Attach");
 
-      setup.mockInput.pressEscape();
-      // A lone ESC byte is only unambiguous once the parser has waited out
-      // the sequence it could have started; every escape test here does this.
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
       expect(setup.captureCharFrame()).not.toContain("Attach");
     } finally {
@@ -7172,10 +7172,8 @@ describe("App hand off to", () => {
     try {
       await renderRows();
       await pickTarget();
-      setup.mockInput.pressEscape();
-      // A bare ESC byte is the prefix of every escape sequence, so the key
-      // parser holds it briefly before deciding it stands alone.
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
       const frame = squish(setup.captureCharFrame());
       // Neither the dialog nor the pick mode it came from is left behind.
@@ -7287,10 +7285,8 @@ describe("App hand off to", () => {
     try {
       await renderRows();
       await startPick();
-      setup.mockInput.pressEscape();
-      // A bare ESC byte is the prefix of every escape sequence, so the key
-      // parser holds it briefly before deciding it stands alone.
-      await settle(20);
+      deliverEscape(setup.renderer);
+      await settle();
       await setup.renderOnce();
       expect(posted).toEqual([]);
       expect(squish(setup.captureCharFrame())).not.toContain("esccancel");
@@ -7518,10 +7514,8 @@ describe("App worktrees panel (W)", () => {
       setup.mockInput.pressEnter();
       expect(await frame()).toContain("New session in worktree");
 
-      setup.mockInput.pressEscape();
-      // A bare ESC byte is the prefix of every escape sequence, so the key
-      // parser holds it briefly before deciding it stands alone.
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      deliverEscape(setup.renderer);
+      await new Promise((resolve) => setTimeout(resolve, 0));
       const back = await frame();
 
       // The PR VIEW, on the PR row — not the Worktrees view on the path.
@@ -7959,10 +7953,8 @@ describe("App worktrees panel (W)", () => {
       expect(squish(dialog)).toContain(squish("New session in worktree"));
       expect(dialog).not.toContain("Pull Requests");
 
-      setup.mockInput.pressEscape();
-      // A lone ESC needs the input parser disambiguation window before it
-      // is delivered as a key at all.
-      await new Promise((r) => setTimeout(r, 30));
+      deliverEscape(setup.renderer);
+      await new Promise((r) => setTimeout(r, 0));
       const shown = await frame();
       expect(shown).toContain("Pull Requests");
       expect(squish(shown)).not.toContain(squish("New session in worktree"));
@@ -8033,8 +8025,8 @@ describe("App worktrees panel (W)", () => {
       await new Promise((r) => setTimeout(r, 0));
       await setup.renderOnce();
       const before = urls.length;
-      setup.mockInput.pressEscape();
-      await new Promise((r) => setTimeout(r, 30));
+      deliverEscape(setup.renderer);
+      await new Promise((r) => setTimeout(r, 0));
       await setup.renderOnce();
       await new Promise((r) => setTimeout(r, 0));
       await setup.renderOnce();
@@ -8060,8 +8052,8 @@ describe("App worktrees panel (W)", () => {
       await frame();
       setup.mockInput.pressKey("n");
       expect(squish(await frame())).toContain(squish("New session"));
-      setup.mockInput.pressEscape();
-      await new Promise((r) => setTimeout(r, 30));
+      deliverEscape(setup.renderer);
+      await new Promise((r) => setTimeout(r, 0));
       const shown = await frame();
       expect(shown).not.toContain("Pull Requests");
     } finally {

--- a/src/tui/components/SourcePicker.test.tsx
+++ b/src/tui/components/SourcePicker.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import { testRender } from "@opentui/solid";
 import { createMockKeys } from "@opentui/core/testing";
+import { deliverEscape } from "./test-helpers";
 import type { CapturedSpan } from "@opentui/core";
 import type { IssueListResponse, OpenIssue } from "../../daemon/issue-list";
 import type { OpenPR, PRListResponse } from "../../daemon/pr-list";
@@ -138,19 +139,9 @@ async function mount(
     await setup!.renderOnce();
     return setup!.captureCharFrame();
   };
-  /**
-   * Escape, actually delivered.
-   *
-   * A bare `\u001b` is the prefix of every escape SEQUENCE, so the parser
-   * holds it until either more bytes arrive or its timeout elapses — which is
-   * why `pressEscape()` followed by an immediate repaint reports nothing, and
-   * why a following keypress arrives as meta-that-key instead. The wait is
-   * the whole helper. (`pressKey("escape")` is a different trap: it types the
-   * six letters, which is issue #160.)
-   */
+  /** Escape, actually delivered (see `deliverEscape` for why neither raw path is). */
   const escape = async () => {
-    keys.pressEscape();
-    await new Promise((resolve) => setTimeout(resolve, 60));
+    deliverEscape(setup!.renderer);
     await setup!.renderOnce();
   };
   return { picked, keys, escape, frame, spans: () => setup!.captureSpans() };

--- a/src/tui/components/SourcePicker.test.tsx
+++ b/src/tui/components/SourcePicker.test.tsx
@@ -139,7 +139,7 @@ async function mount(
     await setup!.renderOnce();
     return setup!.captureCharFrame();
   };
-  /** Escape, actually delivered (see `deliverEscape` for why neither raw path is). */
+  /** Escape, actually delivered (see `deliverEscape`). */
   const escape = async () => {
     deliverEscape(setup!.renderer);
     await setup!.renderOnce();

--- a/src/tui/components/WorktreesPanel.test.tsx
+++ b/src/tui/components/WorktreesPanel.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import { testRender } from "@opentui/solid";
 import { RGBA, type CapturedFrame, type CapturedSpan } from "@opentui/core";
 import { createMockKeys, createMockMouse } from "@opentui/core/testing";
+import { deliverEscape } from "./test-helpers";
 import type {
   PruneCandidate,
   PruneOutcome,
@@ -405,6 +406,8 @@ async function mountPanel(handlers: Handlers, opts: PanelOptions = {}) {
   return {
     ...recorder,
     keys: createMockKeys(setup.renderer),
+    /** Escape, actually delivered (see `deliverEscape`). */
+    escape: () => deliverEscape(setup!.renderer),
     mouse: createMockMouse(setup.renderer),
     /** Cell-level colours, for the things a char frame cannot show: the view
      *  tabs are filled CHIPS, and a chip is its background. */
@@ -1957,7 +1960,7 @@ describe("removal confirm", () => {
   });
 
   it("restores the list on esc with the selection intact", async () => {
-    const { keys, frame } = await mountPanel({
+    const { keys, escape, frame } = await mountPanel({
       list: async () => json(listOf([mainRow(), row()])),
       scan: async () => json({ candidates: [candidate()], skipped: [] }),
     });
@@ -1966,11 +1969,7 @@ describe("removal confirm", () => {
     keys.pressKey(" ");
     keys.pressKey("x");
     expect(await frame()).toContain("Remove worktrees?");
-    // A bare ESC is the prefix of every CSI sequence, so the parser holds it
-    // briefly to see whether more bytes follow. `frame()`'s single macrotask
-    // is not long enough (App.test.tsx waits the same way).
-    keys.pressEscape();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    escape();
     const back = await frame();
     expect(back).not.toContain("Remove worktrees?");
     expect(back).toContain("x remove 1");
@@ -5058,7 +5057,7 @@ describe("WorktreesPanel PR view safety gate", () => {
     );
     // Select the removable row.
     keys.pressKey("j");
-    keys.pressKey("space");
+    keys.pressKey(" ");
     expect(await frame()).toContain("x remove 1");
 
     keys.pressKey("l");
@@ -5080,7 +5079,7 @@ describe("WorktreesPanel PR view safety gate", () => {
       prsOf([openPR()]),
     );
     keys.pressKey("j");
-    keys.pressKey("space");
+    keys.pressKey(" ");
     keys.pressKey("l");
     keys.pressKey("h");
     expect(await frame()).toContain("x remove 1");
@@ -5098,7 +5097,7 @@ describe("WorktreesPanel PR view safety gate", () => {
       prsOf([openPR()]),
     );
     keys.pressKey("l");
-    keys.pressKey("space");
+    keys.pressKey(" ");
     keys.pressKey("a");
     keys.pressKey("D");
     await frame();
@@ -5430,7 +5429,7 @@ describe("PR row keys", () => {
 
   it("leaves the removal keys inert on a PR row", async () => {
     const { keys, frame } = await onPRRow();
-    keys.pressKey("space");
+    keys.pressKey(" ");
     keys.pressKey("x");
     const shown = await frame();
     // No checkbox appeared, and `x` named the view that owns removal rather

--- a/src/tui/components/test-harness-guard.test.ts
+++ b/src/tui/components/test-harness-guard.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Lint for the `@opentui/core/testing` key harness (issue #160).
+ *
+ * `pressKey()` takes key INPUT, and its only names are the `KeyCodes`
+ * constants (`RETURN`, `ESCAPE`, ...). Any other multi-character string is
+ * typed out letter by letter, so `pressKey("escape")` presses `e s c a p e`,
+ * `pressKey("space")` presses `a` among others, and the test keeps passing
+ * for whatever those letters happen to do. And a raw `pressEscape()` emits a
+ * byte the parser holds for 20ms, so an assertion made right after it tests
+ * a screen escape never reached. Both are silent; this is what makes them
+ * loud. Use `deliverEscape` from `test-helpers` for escape and a real
+ * character (or `KeyCodes` name) for everything else.
+ *
+ * Known gap: for `pressKeys([...])` only the first element is checked.
+ */
+import { describe, it, expect } from "bun:test";
+import { KeyCodes } from "@opentui/core/testing";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, relative } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const SELF = import.meta.path;
+/** The files allowed to use the raw paths: the helper itself and the test
+ *  that pins why each raw path is a trap. */
+const ALLOWLIST = new Set(["test-helpers.tsx", "test-helpers.test.tsx"]);
+
+function testFiles(dir: string, acc: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) {
+      if (name !== "node_modules") testFiles(path, acc);
+    } else if (/\.test\.tsx?$/.test(name) && path !== SELF) {
+      acc.push(path);
+    }
+  }
+  return acc;
+}
+
+const KEY_LITERAL = /\bpressKeys?\((?:\[)?\s*(["'])((?:(?!\1).){2,})\1/g;
+const RAW_ESCAPE = /\.pressEscape\(/g;
+
+function offenders(source: string, path: string): string[] {
+  const found: string[] = [];
+  if (ALLOWLIST.has(basename(path))) return found;
+  const lineOf = (index: number) => source.slice(0, index).split("\n").length;
+  for (const match of source.matchAll(KEY_LITERAL)) {
+    const literal = match[2];
+    // A KeyCodes NAME is fine; an escaped byte sequence (`\r`, `\x1b[A`)
+    // is real input, not a name that fell through.
+    if (literal in KeyCodes || literal.startsWith("\\")) continue;
+    found.push(
+      `${relative(ROOT, path)}:${lineOf(match.index)} pressKey("${literal}") types ${literal.length} characters`,
+    );
+  }
+  for (const match of source.matchAll(RAW_ESCAPE)) {
+    found.push(
+      `${relative(ROOT, path)}:${lineOf(match.index)} raw pressEscape(); use deliverEscape from test-helpers`,
+    );
+  }
+  return found;
+}
+
+describe("key harness guard", () => {
+  it("flags the misuses it exists for", () => {
+    const sample = [
+      'keys.pressKey("escape");',
+      'setup.mockInput.pressKey("space");',
+      "keys.pressKeys(['return', 'j']);",
+      "setup.mockInput.pressEscape();",
+      // Not offenders: a character, a KeyCodes name, an escaped byte.
+      'keys.pressKey("j");',
+      'keys.pressKey("ESCAPE");',
+      'keys.pressKey("\\x1b[A");',
+    ].join("\n");
+    const hits = offenders(sample, join(ROOT, "sample.test.tsx"));
+    expect(hits).toHaveLength(4);
+    expect(hits[0]).toContain('pressKey("escape")');
+    expect(hits[1]).toContain('pressKey("space")');
+    expect(hits[2]).toContain('pressKey("return")');
+    expect(hits[3]).toContain("raw pressEscape()");
+  });
+
+  it("finds no key-name-as-input or raw escape in the test suite", () => {
+    const files = testFiles(ROOT);
+    expect(files.length).toBeGreaterThan(0);
+    const hits = files.flatMap((path) =>
+      offenders(readFileSync(path, "utf8"), path),
+    );
+    expect(hits).toEqual([]);
+  });
+});

--- a/src/tui/components/test-harness-guard.test.ts
+++ b/src/tui/components/test-harness-guard.test.ts
@@ -2,12 +2,16 @@
  * Lint for the `@opentui/core/testing` key harness (issue #160).
  *
  * `pressKey()` takes key INPUT, and its only names are the `KeyCodes`
- * constants (`RETURN`, `ESCAPE`, ...). Any other multi-character string is
+ * constants (`RETURN`, `ARROW_UP`, ...). Any other multi-character string is
  * typed out letter by letter, so the test keeps passing for whatever those
- * letters happen to do. A raw `pressEscape()` is delivered late for the
- * reason `deliverEscape` in `test-helpers` documents; use that instead.
+ * letters happen to do. A raw `pressEscape()` — and `pressKey("ESCAPE")`,
+ * which emits the same lone ESC byte — is delivered late for the reason
+ * `deliverEscape` in `test-helpers` documents; use that instead.
  *
- * Known gap: for `pressKeys([...])` only the first element is checked.
+ * `"escape"` / `"space"` / `"return"` are never valid input. Every quoted
+ * or template token on a `press` / `pressKey` / `pressKeys` call is checked
+ * (wrappers, later array slots, templates), not only the first `pressKey(`
+ * argument.
  */
 import { describe, it, expect } from "bun:test";
 import { KeyCodes } from "@opentui/core/testing";
@@ -32,25 +36,40 @@ function testFiles(dir: string, acc: string[] = []): string[] {
   return acc;
 }
 
-const KEY_LITERAL = /\bpressKeys?\((?:\[)?\s*(["'])((?:(?!\1).){2,})\1/g;
+/** press / pressKey / pressKeys. These calls are single-line. */
+const PRESS_CALL = /\bpress(?:Keys?)?\s*\(([^)]*)\)/g;
+const QUOTED_TOKEN = /(["'`])((?:(?!\1).)+)\1/g;
 const RAW_ESCAPE = /\.pressEscape\(/g;
 
 function offenders(source: string, path: string): string[] {
   const found: string[] = [];
   if (ALLOWLIST.has(basename(path))) return found;
   const lineOf = (index: number) => source.slice(0, index).split("\n").length;
-  for (const match of source.matchAll(KEY_LITERAL)) {
-    const literal = match[2];
-    // A KeyCodes NAME is fine; an escaped byte sequence (`\r`, `\x1b[A`)
-    // is real input, not a name that fell through.
-    if (literal in KeyCodes || literal.startsWith("\\")) continue;
-    found.push(
-      `${relative(ROOT, path)}:${lineOf(match.index)} pressKey("${literal}") types ${literal.length} characters`,
-    );
+  for (const call of source.matchAll(PRESS_CALL)) {
+    const args = call[1];
+    const argsAt = (call.index ?? 0) + call[0].indexOf(args);
+    for (const token of args.matchAll(QUOTED_TOKEN)) {
+      const literal = token[2];
+      const index = argsAt + (token.index ?? 0);
+      if (literal === "ESCAPE") {
+        found.push(
+          `${relative(ROOT, path)}:${lineOf(index)} pressKey("ESCAPE") is a lone ESC; use deliverEscape from test-helpers`,
+        );
+        continue;
+      }
+      // A KeyCodes NAME is fine; an escaped byte sequence (`\r`, `\x1b[A`)
+      // is real input, not a name that fell through. One character is itself.
+      if (literal.length < 2 || literal in KeyCodes || literal.startsWith("\\")) {
+        continue;
+      }
+      found.push(
+        `${relative(ROOT, path)}:${lineOf(index)} pressKey("${literal}") types ${literal.length} characters`,
+      );
+    }
   }
   for (const match of source.matchAll(RAW_ESCAPE)) {
     found.push(
-      `${relative(ROOT, path)}:${lineOf(match.index)} raw pressEscape(); use deliverEscape from test-helpers`,
+      `${relative(ROOT, path)}:${lineOf(match.index ?? 0)} raw pressEscape(); use deliverEscape from test-helpers`,
     );
   }
   return found;
@@ -62,18 +81,26 @@ describe("key harness guard", () => {
       'keys.pressKey("escape");',
       'setup.mockInput.pressKey("space");',
       "keys.pressKeys(['return', 'j']);",
-      "setup.mockInput.pressEscape();",
-      // Not offenders: a character, a KeyCodes name, an escaped byte.
-      'keys.pressKey("j");',
+      'await press("escape");',
+      "keys.pressKeys(['j', 'escape']);",
+      "press(`escape`);",
       'keys.pressKey("ESCAPE");',
+      "setup.mockInput.pressEscape();",
+      // Not offenders: a character, a KeyCodes name (not ESCAPE), an escaped byte.
+      'keys.pressKey("j");',
+      'keys.pressKey("RETURN");',
       'keys.pressKey("\\x1b[A");',
     ].join("\n");
     const hits = offenders(sample, join(ROOT, "sample.test.tsx"));
-    expect(hits).toHaveLength(4);
+    expect(hits).toHaveLength(8);
     expect(hits[0]).toContain('pressKey("escape")');
     expect(hits[1]).toContain('pressKey("space")');
     expect(hits[2]).toContain('pressKey("return")');
-    expect(hits[3]).toContain("raw pressEscape()");
+    expect(hits[3]).toContain('pressKey("escape")');
+    expect(hits[4]).toContain('pressKey("escape")');
+    expect(hits[5]).toContain('pressKey("escape")');
+    expect(hits[6]).toContain('pressKey("ESCAPE")');
+    expect(hits[7]).toContain("raw pressEscape()");
   });
 
   it("finds no key-name-as-input or raw escape in the test suite", () => {

--- a/src/tui/components/test-harness-guard.test.ts
+++ b/src/tui/components/test-harness-guard.test.ts
@@ -3,13 +3,9 @@
  *
  * `pressKey()` takes key INPUT, and its only names are the `KeyCodes`
  * constants (`RETURN`, `ESCAPE`, ...). Any other multi-character string is
- * typed out letter by letter, so `pressKey("escape")` presses `e s c a p e`,
- * `pressKey("space")` presses `a` among others, and the test keeps passing
- * for whatever those letters happen to do. And a raw `pressEscape()` emits a
- * byte the parser holds for 20ms, so an assertion made right after it tests
- * a screen escape never reached. Both are silent; this is what makes them
- * loud. Use `deliverEscape` from `test-helpers` for escape and a real
- * character (or `KeyCodes` name) for everything else.
+ * typed out letter by letter, so the test keeps passing for whatever those
+ * letters happen to do. A raw `pressEscape()` is delivered late for the
+ * reason `deliverEscape` in `test-helpers` documents; use that instead.
  *
  * Known gap: for `pressKeys([...])` only the first element is checked.
  */

--- a/src/tui/components/test-helpers.test.tsx
+++ b/src/tui/components/test-helpers.test.tsx
@@ -27,15 +27,14 @@ describe("deliverEscape", () => {
     const { seen, setup } = await mountProbe();
     deliverEscape(setup.renderer);
     expect(seen).toEqual(["escape"]);
-    // And a key pressed right after is itself, not meta-that-key: the
-    // pending ESC was consumed, not left in the parser's window.
+    // The pending ESC was consumed rather than left in the parser's
+    // window, so the next key is itself and not meta-that-key.
     setup.mockInput.pressKey("x");
     expect(seen).toEqual(["escape", "x"]);
   });
 
-  // The two harness traps this helper exists for, pinned so a future
-  // @opentui upgrade that fixes either shows up as a failure here rather
-  // than as a helper nobody remembers the reason for.
+  // Pinned so an @opentui upgrade that fixes either trap fails here rather
+  // than leaving a helper nobody remembers the reason for.
   it("pins why the raw harness paths cannot be used for escape", async () => {
     const { seen, setup } = await mountProbe();
     setup.mockInput.pressKey("escape");

--- a/src/tui/components/test-helpers.test.tsx
+++ b/src/tui/components/test-helpers.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { testRender, useKeyboard } from "@opentui/solid";
+import { deliverEscape } from "./test-helpers";
+
+let setup: Awaited<ReturnType<typeof testRender>> | null = null;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = null;
+});
+
+async function mountProbe() {
+  const seen: string[] = [];
+  const Probe = () => {
+    useKeyboard((event) => {
+      seen.push(event.meta ? `meta+${event.name}` : event.name);
+    });
+    return <text>probe</text>;
+  };
+  setup = await testRender(() => <Probe />, { width: 20, height: 3 });
+  await setup.renderOnce();
+  return { seen, setup };
+}
+
+describe("deliverEscape", () => {
+  it("delivers one escape event synchronously", async () => {
+    const { seen, setup } = await mountProbe();
+    deliverEscape(setup.renderer);
+    expect(seen).toEqual(["escape"]);
+    // And a key pressed right after is itself, not meta-that-key: the
+    // pending ESC was consumed, not left in the parser's window.
+    setup.mockInput.pressKey("x");
+    expect(seen).toEqual(["escape", "x"]);
+  });
+
+  // The two harness traps this helper exists for, pinned so a future
+  // @opentui upgrade that fixes either shows up as a failure here rather
+  // than as a helper nobody remembers the reason for.
+  it("pins why the raw harness paths cannot be used for escape", async () => {
+    const { seen, setup } = await mountProbe();
+    setup.mockInput.pressKey("escape");
+    expect(seen).toEqual(["e", "s", "c", "a", "p", "e"]);
+    seen.length = 0;
+    setup.mockInput.pressEscape();
+    await setup.renderOnce();
+    expect(seen).toEqual([]);
+    setup.mockInput.pressKey("x");
+    expect(seen).toEqual(["meta+x"]);
+  });
+});

--- a/src/tui/components/test-helpers.tsx
+++ b/src/tui/components/test-helpers.tsx
@@ -1,4 +1,6 @@
 import { expect } from "bun:test";
+import type { CliRenderer } from "@opentui/core";
+import { createMockKeys } from "@opentui/core/testing";
 import type { EnrichedSession, Session } from "../../types";
 import type { FilteredSession, StatusSummary } from "../utils/grouping";
 
@@ -140,4 +142,46 @@ export function expectFrameIntegrity(
 // assertion matches a message regardless of where word-wrap split it.
 export function squish(s: string): string {
   return s.replace(/[│┌┐└┘─\s]/g, "");
+}
+
+/**
+ * Press Escape so the component actually receives it.
+ *
+ * Neither `@opentui/core/testing` path does this on its own (issue #160):
+ *
+ * - `pressKey("escape")` resolves its argument as key INPUT and knows the
+ *   escape byte only under the `KeyCodes.ESCAPE` name, so the word falls
+ *   through as text and the handler sees six keys: `e s c a p e`. The
+ *   harness guard test (`test-harness-guard.test.ts`) fails the suite on
+ *   that spelling.
+ * - `pressEscape()` emits the right byte, but a bare `\x1b` is the prefix of
+ *   every escape sequence, so the stdin parser HOLDS it for a 20ms
+ *   disambiguation window (`StdinParser` `timeoutMs`, on the renderer's
+ *   clock) before it will call it a key. A `renderOnce()` or a 0ms `settle()`
+ *   right after sees nothing, and a keypress inside the window turns into
+ *   meta-that-key instead.
+ *
+ * This forces the window closed instead of sleeping through it: it tells the
+ * parser the timeout has elapsed and drains the event it then releases, so
+ * the escape is dispatched synchronously and the caller only has to repaint.
+ * Both members are private on `CliRenderer`; if an upgrade renames them the
+ * helper throws rather than degrading into a silent no-op, which is the
+ * whole failure mode this exists to close.
+ */
+export function deliverEscape(renderer: CliRenderer): void {
+  const internals = renderer as unknown as {
+    stdinParser?: { flushTimeout?: (nowMs?: number) => void };
+    drainStdinParser?: () => void;
+  };
+  const flush = internals.stdinParser?.flushTimeout;
+  const drain = internals.drainStdinParser;
+  if (typeof flush !== "function" || typeof drain !== "function") {
+    throw new Error(
+      "deliverEscape: CliRenderer no longer exposes stdinParser.flushTimeout " +
+        "and drainStdinParser; update the helper for this @opentui/core",
+    );
+  }
+  createMockKeys(renderer).pressEscape();
+  flush.call(internals.stdinParser, Number.MAX_SAFE_INTEGER);
+  drain.call(internals);
 }

--- a/src/tui/components/test-helpers.tsx
+++ b/src/tui/components/test-helpers.tsx
@@ -165,8 +165,7 @@ export function squish(s: string): string {
  * parser the timeout has elapsed and drains the event it then releases, so
  * the escape is dispatched synchronously and the caller only has to repaint.
  * Both members are private on `CliRenderer`; if an upgrade renames them the
- * helper throws rather than degrading into a silent no-op, which is the
- * whole failure mode this exists to close.
+ * helper throws rather than degrading into a silent no-op.
  */
 export function deliverEscape(renderer: CliRenderer): void {
   const internals = renderer as unknown as {


### PR DESCRIPTION
## Overview

Makes escape testable in the TUI key harness and repoints every escape test at a helper that actually delivers it, with a guard test so a key name can no longer be passed as key input unnoticed.

Resolves #160

## Motivation

`createMockKeys().pressKey("escape")` resolves its argument as key input and only knows the `KeyCodes` constant names, so the word is typed out as `e s c a p e`. The intended `pressEscape()` emits the right byte, but a lone `\x1b` is the prefix of every escape sequence and the renderer's `StdinParser` holds it for a 20ms disambiguation window, so an assertion made right after it sees a screen escape never reached (and a key pressed inside the window arrives as meta-that-key). Four escape tests passed for neither reason, `pressKey("return")` and four `pressKey("space")` sites had the same shape (`space` presses `a`, which is select-all in the Worktrees panel), and 16 other sites each slept through the window with their own magic wait (20, 30, or 60ms).

## Changes

### Harness

- **test-helpers.tsx** - Adds `deliverEscape(renderer)`: emits ESC, then force-flushes the parser's timeout and drains the released event so the escape dispatches synchronously. Reaches through two private `CliRenderer` members (`stdinParser.flushTimeout`, `drainStdinParser`) and throws if an upgrade renames them rather than degrading into a silent no-op
- **test-helpers.test.tsx** - Proves the helper delivers exactly one `escape` and leaves the next key un-metad; pins both raw-harness traps so an upstream fix surfaces as a failure here
- **test-harness-guard.test.ts** - Scans every test file and fails on `pressKey("<multi-char>")` that is not a `KeyCodes` name or escaped byte, and on any raw `pressEscape()` outside the helper files

### Call sites

- **App.test.tsx** - The four `pressKey("escape")` sites and the 16 `pressEscape(); settle(20|30)` sites go through `deliverEscape`; the `pressKey("return")` site uses `pressEnter()`. Where a `settle(20)` existed a 0ms `settle()` stays, since it was also servicing unrelated async
- **SourcePicker.test.tsx**, **WorktreesPanel.test.tsx** - Local escape helpers use `deliverEscape`; the four `pressKey("space")` sites press `" "`
- **AGENTS.md** - One Testing bullet pointing at the helper and the guard

Also checked the issue's shift note: `pressKey("X")` arrives as `x` with `shift` set, and every capital `case` in App, SourcePicker, and WorktreesPanel already pairs with its lowercase-plus-`event.shift` companion, so nothing to change there.

## Breaking Changes

None

## Testing

- [x] `bun run typecheck`
- [x] Full suite: 5468 pass, 0 fail
- [x] Neutering `deliverEscape` fails 21 tests, including three of the four repointed sites (the fourth, "Escape does not exit in sidebar mode", is a negative assertion and cannot prove delivery on its own)
- [x] Guard test flags `pressKey("escape")`, `pressKey("space")`, `pressKeys(["return", ...])`, and raw `pressEscape()` on a sample, and reports zero hits on the suite
