### PR TITLE
fix: target picker switches to invoking tmux client

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The zsh `eval` has to come after `compinit`, since the script registers itself w
 > bind-key -n M-p run-shell -C 'display-popup -c "#{client_tty}" -e "CCMUX_CLIENT_TTY=#{client_tty}" -E -w 80% -h 75% "ccmux"'
 > ```
 >
-> The wrapper captures the client that opened the popup, so selecting a session never switches another attached client. The picker exits after selection, so the popup closes itself and drops you straight into that pane. (`display-popup` requires tmux 3.2+.)
+> The wrapper captures the client that opened the popup, so selecting a session never switches another attached client. The picker exits after selection, so the popup closes itself and drops you straight into that pane. (This binding needs tmux 3.3+, since `display-popup -e` arrived in 3.3.)
 
 ## 🎮 Usage
 

--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ The zsh `eval` has to come after `compinit`, since the script registers itself w
 >
 > ```tmux
 > # Prefix + C-p: open ccmux in a centered popup
-> bind-key C-p display-popup -E -w 80% -h 75% "ccmux"
+> bind-key C-p run-shell -C 'display-popup -c "#{client_tty}" -e "CCMUX_CLIENT_TTY=#{client_tty}" -E -w 80% -h 75% "ccmux"'
 >
 > # Or skip the prefix entirely (Alt+p from any pane)
-> bind-key -n M-p display-popup -E -w 80% -h 75% "ccmux"
+> bind-key -n M-p run-shell -C 'display-popup -c "#{client_tty}" -e "CCMUX_CLIENT_TTY=#{client_tty}" -E -w 80% -h 75% "ccmux"'
 > ```
 >
-> The picker exits after you select a session, so the popup closes itself and drops you straight into that pane. (`display-popup` requires tmux 3.2+.)
+> The wrapper captures the client that opened the popup, so selecting a session never switches another attached client. The picker exits after selection, so the popup closes itself and drops you straight into that pane. (`display-popup` requires tmux 3.2+.)
 
 ## 🎮 Usage
 

--- a/src/daemon/spawn-command.ts
+++ b/src/daemon/spawn-command.ts
@@ -1,11 +1,14 @@
 import { accessSync, constants, statSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import type { AgentDef } from "../lib/agents";
+import { CLIENT_TTY_PATTERN } from "../lib/tmux-client";
 import {
   isUntrackedMode,
   UNTRACKED_MODES,
   type UntrackedMode,
 } from "./worktree-move-changes";
+
+export { CLIENT_TTY_PATTERN } from "../lib/tmux-client";
 
 /**
  * Requested split direction, in tmux's own vocabulary: `"h"` splits the
@@ -95,8 +98,6 @@ export function normalizeTarget(
  * anything outside that shape is a caller mistake worth naming rather than a
  * flag to hand to tmux.
  */
-export const CLIENT_TTY_PATTERN = /^\/dev\/[A-Za-z0-9._/-]{1,64}$/;
-
 /** Validate a wire tmux-client-tty field (`callerTty`). */
 export function normalizeClientTty(
   value: unknown,

--- a/src/daemon/spawn-command.ts
+++ b/src/daemon/spawn-command.ts
@@ -8,8 +8,6 @@ import {
   type UntrackedMode,
 } from "./worktree-move-changes";
 
-export { CLIENT_TTY_PATTERN } from "../lib/tmux-client";
-
 /**
  * Requested split direction, in tmux's own vocabulary: `"h"` splits the
  * target pane left/right (tmux `-h`), `"v"` splits it top/bottom (tmux
@@ -92,13 +90,10 @@ export function normalizeTarget(
 }
 
 /**
- * The only accepted shape for a tmux client tty (`callerTty`). tmux reports
- * `#{client_tty}` as an absolute device path (`/dev/ttys004` on macOS,
- * `/dev/pts/3` on Linux), and the value travels straight into a tmux argv, so
- * anything outside that shape is a caller mistake worth naming rather than a
- * flag to hand to tmux.
+ * Validate a wire tmux-client-tty field (`callerTty`). Anything outside the
+ * accepted shape is a caller mistake worth naming rather than a flag to hand
+ * to tmux.
  */
-/** Validate a wire tmux-client-tty field (`callerTty`). */
 export function normalizeClientTty(
   value: unknown,
   field = "callerTty",

--- a/src/lib/tmux-client.ts
+++ b/src/lib/tmux-client.ts
@@ -17,7 +17,11 @@
 
 import { tmuxArgv } from "./tmux-exec";
 
-/** The device-path shape tmux reports for `#{client_tty}`. */
+/**
+ * The only accepted shape for a tmux client tty. tmux reports
+ * `#{client_tty}` as an absolute device path (`/dev/ttys004` on macOS,
+ * `/dev/pts/3` on Linux), and callers may pass it straight into a tmux argv.
+ */
 export const CLIENT_TTY_PATTERN = /^\/dev\/[A-Za-z0-9._/-]{1,64}$/;
 
 /**

--- a/src/lib/tmux-client.ts
+++ b/src/lib/tmux-client.ts
@@ -17,6 +17,9 @@
 
 import { tmuxArgv } from "./tmux-exec";
 
+/** The device-path shape tmux reports for `#{client_tty}`. */
+export const CLIENT_TTY_PATTERN = /^\/dev\/[A-Za-z0-9._/-]{1,64}$/;
+
 /**
  * The pid of the tmux client attached to the current session context (i.e.
  * `$TMUX`'s session, or - when invoked from inside a pane - the one

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -42,7 +42,10 @@ mock.module("./utils/sse", () => ({
   },
 }));
 
-const switchToPaneSpy = mock(async (_target: string): Promise<boolean> => true);
+type SwitchToPaneResult = boolean | "client-unavailable";
+const switchToPaneSpy = mock(
+  async (_target: string): Promise<SwitchToPaneResult> => true,
+);
 const sendKeysSpy = mock(
   async (
     _target: string,
@@ -1593,6 +1596,23 @@ describe("App pane-switch feedback and server scoping", () => {
       await renderWithSession();
       await selectFirstRowAndEnter();
       expect(setup.captureCharFrame()).toContain("Failed to switch");
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      restoreExit();
+      restoreFetch();
+    }
+  });
+
+  it("one-shot picker: an unknown caller client is refused with a specific toast", async () => {
+    switchToPaneSpy.mockImplementation(async () => "client-unavailable");
+    const restoreFetch = withServerInfo(null);
+    const { exitSpy, restore: restoreExit } = withExitSpy();
+    try {
+      await renderWithSession();
+      await selectFirstRowAndEnter();
+      const frame = setup.captureCharFrame();
+      expect(frame).toContain("Cannot switch: unable to identify");
+      expect(frame).toContain("this picker's tmux client");
       expect(exitSpy).not.toHaveBeenCalled();
     } finally {
       restoreExit();

--- a/src/tui/App.test.tsx
+++ b/src/tui/App.test.tsx
@@ -22,6 +22,7 @@ import { MAX_TURNS, renderTurns } from "../daemon/transcript-read";
 import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import type { SwitchToPaneResult } from "./utils/client-switch";
 
 // Capture SSE callbacks so tests can fire events
 let sseCallbacks: SSECallbacks | null = null;
@@ -42,7 +43,6 @@ mock.module("./utils/sse", () => ({
   },
 }));
 
-type SwitchToPaneResult = boolean | "client-unavailable";
 const switchToPaneSpy = mock(
   async (_target: string): Promise<SwitchToPaneResult> => true,
 );
@@ -1589,13 +1589,15 @@ describe("App pane-switch feedback and server scoping", () => {
   }
 
   it("one-shot picker: a failed pane switch shows a toast and does not exit", async () => {
-    switchToPaneSpy.mockImplementation(async () => false);
+    switchToPaneSpy.mockImplementation(async () => "switch-failed");
     const restoreFetch = withServerInfo(null); // fail-open: same-server guard passes
     const { exitSpy, restore: restoreExit } = withExitSpy();
     try {
       await renderWithSession();
       await selectFirstRowAndEnter();
-      expect(setup.captureCharFrame()).toContain("Failed to switch");
+      expect(squish(setup.captureCharFrame())).toContain(
+        squish("Failed to switch: pane or client unavailable"),
+      );
       expect(exitSpy).not.toHaveBeenCalled();
     } finally {
       restoreExit();
@@ -1610,9 +1612,11 @@ describe("App pane-switch feedback and server scoping", () => {
     try {
       await renderWithSession();
       await selectFirstRowAndEnter();
-      const frame = setup.captureCharFrame();
-      expect(frame).toContain("Cannot switch: unable to identify");
-      expect(frame).toContain("this picker's tmux client");
+      expect(squish(setup.captureCharFrame())).toContain(
+        squish(
+          "Cannot switch: CCMUX_CLIENT_TTY is malformed or no tmux client was found (check your tmux binding)",
+        ),
+      );
       expect(exitSpy).not.toHaveBeenCalled();
     } finally {
       restoreExit();
@@ -1697,13 +1701,15 @@ describe("App pane-switch feedback and server scoping", () => {
   it("persistent picker: a failed pane switch shows a toast (was sidebar-only)", async () => {
     // The Toast render gate used to be sidebar-only, so a switch failure in the
     // persistent picker showed nothing. Now it must surface here too.
-    switchToPaneSpy.mockImplementation(async () => false);
+    switchToPaneSpy.mockImplementation(async () => "switch-failed");
     const restoreFetch = withServerInfo(null);
     const { exitSpy, restore: restoreExit } = withExitSpy();
     try {
       await renderWithSession({ persistent: true });
       await selectFirstRowAndEnter();
-      expect(setup.captureCharFrame()).toContain("Failed to switch");
+      expect(squish(setup.captureCharFrame())).toContain(
+        squish("Failed to switch: pane or client unavailable"),
+      );
       expect(exitSpy).not.toHaveBeenCalled(); // persistent never exits
     } finally {
       restoreExit();

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -275,11 +275,14 @@ export function App(props: AppProps) {
     } else {
       flashPaneDetached(pane);
     }
-    switchToPane(pane).then((ok) => {
-      if (!ok) {
-        // Pane is gone (daemon holds the stale row until its liveness sweep).
-        // Surface it instead of exiting the one-shot picker as if it worked.
-        store.actions.showToast("Failed to switch: pane is gone");
+    switchToPane(pane).then((result) => {
+      if (result !== true) {
+        // Surface refusal/failure instead of exiting the picker as if it worked.
+        store.actions.showToast(
+          result === "client-unavailable"
+            ? "Cannot switch: unable to identify this picker's tmux client"
+            : "Failed to switch: pane is gone",
+        );
         return;
       }
       if (!props.persistent && !props.sidebar) process.exit(0);

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -280,8 +280,8 @@ export function App(props: AppProps) {
         // Surface refusal/failure instead of exiting the picker as if it worked.
         store.actions.showToast(
           result === "client-unavailable"
-            ? "Cannot switch: unable to identify this picker's tmux client"
-            : "Failed to switch: pane is gone",
+            ? "Cannot switch: CCMUX_CLIENT_TTY is malformed or no tmux client was found (check your tmux binding)"
+            : "Failed to switch: pane or client unavailable",
         );
         return;
       }

--- a/src/tui/utils/client-switch.test.ts
+++ b/src/tui/utils/client-switch.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+
+// App.test.tsx process-wide mocks tmux.ts, which re-exports this function.
+// Use a distinct cache entry so this file always exercises the implementation.
+const REAL_CLIENT_SWITCH_SPECIFIER = "./client-switch" + "?real";
+const { switchToPane } = (await import(
+  REAL_CLIENT_SWITCH_SPECIFIER
+)) as typeof import("./client-switch");
+
+interface SpawnResponse {
+  stdout?: string;
+  exitCode?: number;
+}
+
+function withSpawn(responses: SpawnResponse[]): {
+  calls: string[][];
+  restore: () => void;
+} {
+  const original = Bun.spawn;
+  const calls: string[][] = [];
+  Bun.spawn = ((argv: string[]) => {
+    calls.push([...argv]);
+    const response = responses.shift() ?? {};
+    return {
+      stdout: new Blob([response.stdout ?? ""]).stream(),
+      exited: Promise.resolve(response.exitCode ?? 0),
+    };
+  }) as unknown as typeof Bun.spawn;
+  return {
+    calls,
+    restore: () => {
+      Bun.spawn = original;
+    },
+  };
+}
+
+async function withClientTty<T>(
+  value: string | undefined,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = process.env.CCMUX_CLIENT_TTY;
+  if (value === undefined) delete process.env.CCMUX_CLIENT_TTY;
+  else process.env.CCMUX_CLIENT_TTY = value;
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) delete process.env.CCMUX_CLIENT_TTY;
+    else process.env.CCMUX_CLIENT_TTY = previous;
+  }
+}
+
+describe("switchToPane", () => {
+  it("pins the switch to the client tty captured by the picker binding", async () => {
+    const spawn = withSpawn([{}]);
+    try {
+      const result = await withClientTty("/dev/ttys005", () =>
+        switchToPane("%42"),
+      );
+
+      expect(result).toBe(true);
+      expect(spawn.calls).toEqual([
+        ["tmux", "switch-client", "-c", "/dev/ttys005", "-t", "%42"],
+      ]);
+    } finally {
+      spawn.restore();
+    }
+  });
+
+  it("falls back to the current tmux client for legacy picker launches", async () => {
+    const spawn = withSpawn([{ stdout: "/dev/pts/7\n" }, {}]);
+    try {
+      const result = await withClientTty(undefined, () => switchToPane("%8"));
+
+      expect(result).toBe(true);
+      expect(spawn.calls).toEqual([
+        ["tmux", "display-message", "-p", "#{client_tty}"],
+        ["tmux", "switch-client", "-c", "/dev/pts/7", "-t", "%8"],
+      ]);
+    } finally {
+      spawn.restore();
+    }
+  });
+
+  it("refuses an explicitly invalid client tty without falling back", async () => {
+    const spawn = withSpawn([]);
+    try {
+      const result = await withClientTty("", () => switchToPane("%8"));
+
+      expect(result).toBe("client-unavailable");
+      expect(spawn.calls).toEqual([]);
+    } finally {
+      spawn.restore();
+    }
+  });
+
+  it("refuses when a legacy launch has no current tmux client", async () => {
+    const spawn = withSpawn([{ exitCode: 1 }]);
+    try {
+      const result = await withClientTty(undefined, () => switchToPane("%8"));
+
+      expect(result).toBe("client-unavailable");
+      expect(spawn.calls).toEqual([
+        ["tmux", "display-message", "-p", "#{client_tty}"],
+      ]);
+    } finally {
+      spawn.restore();
+    }
+  });
+
+  it("reports a directed switch failure", async () => {
+    const spawn = withSpawn([{ exitCode: 1 }]);
+    try {
+      const result = await withClientTty("/dev/ttys005", () =>
+        switchToPane("%42"),
+      );
+
+      expect(result).toBe("switch-failed");
+    } finally {
+      spawn.restore();
+    }
+  });
+});

--- a/src/tui/utils/client-switch.test.ts
+++ b/src/tui/utils/client-switch.test.ts
@@ -93,6 +93,18 @@ describe("switchToPane", () => {
     }
   });
 
+  it("refuses a client tty that is not a device path", async () => {
+    const spawn = withSpawn([]);
+    try {
+      const result = await withClientTty("ttys005", () => switchToPane("%8"));
+
+      expect(result).toBe("client-unavailable");
+      expect(spawn.calls).toEqual([]);
+    } finally {
+      spawn.restore();
+    }
+  });
+
   it("refuses when a legacy launch has no current tmux client", async () => {
     const spawn = withSpawn([{ exitCode: 1 }]);
     try {

--- a/src/tui/utils/client-switch.ts
+++ b/src/tui/utils/client-switch.ts
@@ -1,0 +1,35 @@
+import {
+  CLIENT_TTY_PATTERN,
+  resolveCurrentTmuxClientTty,
+} from "../../lib/tmux-client";
+import { tmuxArgv } from "../../lib/tmux-exec";
+
+export type SwitchToPaneResult = true | "client-unavailable" | "switch-failed";
+
+export async function switchToPane(
+  target: string,
+): Promise<SwitchToPaneResult> {
+  const capturedClientTty = process.env.CCMUX_CLIENT_TTY;
+  const clientTty =
+    capturedClientTty === undefined
+      ? await resolveCurrentTmuxClientTty()
+      : capturedClientTty;
+  if (!clientTty || !CLIENT_TTY_PATTERN.test(clientTty)) {
+    return "client-unavailable";
+  }
+
+  try {
+    const proc = Bun.spawn(
+      tmuxArgv("switch-client", "-c", clientTty, "-t", target),
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    const exitCode = await proc.exited;
+    return exitCode === 0 ? true : "switch-failed";
+  } catch {
+    return "switch-failed";
+  }
+}

--- a/src/tui/utils/tmux.ts
+++ b/src/tui/utils/tmux.ts
@@ -7,6 +7,8 @@ import { PANE_FIELD_SEP } from "../../lib/tmux-format";
 import { tmuxArgv, tmuxShellPrefix } from "../../lib/tmux-exec";
 import { theme } from "../theme";
 
+export { switchToPane } from "./client-switch";
+
 /**
  * Capture a pane's visible content. THROWS on failure (spawn error or non-zero
  * `tmux capture-pane` exit — the pane is gone). We await the exit code so a dead
@@ -37,20 +39,6 @@ export async function capturePane(
     );
   }
   return output;
-}
-
-export async function switchToPane(target: string): Promise<boolean> {
-  try {
-    const proc = Bun.spawn(tmuxArgv("switch-client", "-t", target), {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const exitCode = await proc.exited;
-    return exitCode === 0;
-  } catch {
-    return false;
-  }
 }
 
 const SPECIAL_KEY_MAP: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Capture the tmux client tty that opens the picker popup and pass it into the picker.
- Pin pane selection to that client with `switch-client -c`, while retaining the current-client fallback for direct and legacy launches.
- Refuse the switch with a visible toast when no valid client can be identified, instead of risking another attached client.

## Related issue

Refs #75

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` passes (5602 passed, 2 skipped, 0 failed)
- [x] Verified the picker in a fully isolated tmux server with two attached clients
- [ ] Verified end to end with a real agent session (not required for session detection; the switch path was exercised with a process-matched stand-in)

## Notes for reviewers

Reproduced the regression with clients on `alpha` and `beta`: a bare `switch-client -t gamma` moved the wrong client. With this patch, opening the picker from `alpha` and selecting `gamma` moved only the initiating client; the client on `beta` remained in place.
