### PR TITLE
fix(columns): Strip task notifications, handoffs and ANSI from the prompt cell

### DIFF
--- a/src/lib/pane-summary.test.ts
+++ b/src/lib/pane-summary.test.ts
@@ -208,7 +208,8 @@ describe("summaryFromPaneTitle", () => {
     });
 
     it("strips the controls stripAnsi leaves behind", () => {
-      // `stripAnsi` handles CSI only. A BEL, a lone ESC and a C1 byte (here
+      // `stripAnsi` handles well-formed sequences. A BEL, a lone ESC and a
+      // C1 byte (here
       // U+0085 NEL, which JS `\s` does not match) would otherwise ride into a
       // rendered cell. Each becomes a space, so the words stay apart.
       expect(

--- a/src/lib/pane-summary.ts
+++ b/src/lib/pane-summary.ts
@@ -32,12 +32,12 @@ const HOSTNAME = hostname();
  * also unwraps Claude's `<command-name>` log markup, which is a property of
  * Claude's JSONL transcript and has no business being applied to a title.
  *
- * `stripAnsi` handles CSI only, so the control sweep after it is what catches
- * the rest: a lone ESC, a BEL, and the C1 block (U+0080-U+009F), which is the
- * practical residue once tmux's own title validation has had its say. Each
- * becomes a SPACE rather than nothing, so the `\s+` collapse behind it still
- * sees a separator: `\n` and `\t` fall under both rules, and deleting them
- * outright would weld two words together.
+ * `stripAnsi` handles well-formed sequences, so the control sweep after it is
+ * what catches the rest: a lone ESC, a BEL, and the C1 block (U+0080-U+009F),
+ * which is the practical residue once tmux's own title validation has had its
+ * say. Each becomes a SPACE rather than nothing, so the `\s+` collapse behind
+ * it still sees a separator: `\n` and `\t` fall under both rules, and
+ * deleting them outright would weld two words together.
  */
 function normalizeTitle(text: string): string {
   return stripAnsi(text)

--- a/src/lib/pane-summary.ts
+++ b/src/lib/pane-summary.ts
@@ -2,7 +2,7 @@ import { hostname } from "node:os";
 import { basename } from "node:path";
 import { BUILTIN_AGENTS } from "./agents";
 import type { SummaryTitleRule } from "./agents";
-import { stripAnsi } from "./strip-ansi";
+import { stripTerminalNoise } from "./strip-ansi";
 
 /**
  * Built once. The daemon asks for a session's summary on every enrich and
@@ -32,18 +32,13 @@ const HOSTNAME = hostname();
  * also unwraps Claude's `<command-name>` log markup, which is a property of
  * Claude's JSONL transcript and has no business being applied to a title.
  *
- * `stripAnsi` handles well-formed sequences, so the control sweep after it is
- * what catches the rest: a lone ESC, a BEL, and the C1 block (U+0080-U+009F),
- * which is the practical residue once tmux's own title validation has had its
- * say. Each becomes a SPACE rather than nothing, so the `\s+` collapse behind
- * it still sees a separator: `\n` and `\t` fall under both rules, and
- * deleting them outright would weld two words together.
+ * The reduction itself is `stripTerminalNoise`, shared with the TUI's prompt
+ * cell, which faces the same escape-carrying free text; its own comment
+ * carries the why. A title's practical residue, once tmux's own validation
+ * has had its say, is the lone ESC and C1 end of what that helper sweeps.
  */
 function normalizeTitle(text: string): string {
-  return stripAnsi(text)
-    .replace(/[\x00-\x1F\x7F-\x9F]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  return stripTerminalNoise(text);
 }
 
 /**

--- a/src/lib/strip-ansi.test.ts
+++ b/src/lib/strip-ansi.test.ts
@@ -21,4 +21,33 @@ describe("stripAnsi", () => {
   it("removes SGR codes with multiple parameters", () => {
     expect(stripAnsi("\x1B[38;5;196mcolor\x1B[0m")).toBe("color");
   });
+
+  it("removes private-mode CSI such as cursor hide and show", () => {
+    expect(stripAnsi("\x1B[?25lhidden\x1B[?25h")).toBe("hidden");
+  });
+
+  it("removes an OSC 8 hyperlink terminated by BEL", () => {
+    expect(stripAnsi("\x1B]8;;https://example.com\x07link\x1B]8;;\x07")).toBe(
+      "link",
+    );
+  });
+
+  it("removes an OSC terminated by ST", () => {
+    expect(stripAnsi("\x1B]0;window title\x1B\\after")).toBe("after");
+  });
+
+  it("leaves an unterminated OSC and the text after it intact", () => {
+    // The body excludes ESC and BEL and never runs to end-of-input, so
+    // nothing matches and the rest of the line is not eaten.
+    expect(stripAnsi("\x1B]8;;https://example.com and more")).toBe(
+      "\x1B]8;;https://example.com and more",
+    );
+  });
+
+  it("leaves the character after a lone ESC alone", () => {
+    // Two-byte `ESC <char>` is not matched on purpose: consuming the byte
+    // would weld `scroll` and `math` into one word. The caller's control
+    // sweep turns the surviving ESC into a separator.
+    expect(stripAnsi("scroll\x1Bmath")).toBe("scroll\x1Bmath");
+  });
 });

--- a/src/lib/strip-ansi.test.ts
+++ b/src/lib/strip-ansi.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { stripAnsi } from "./strip-ansi";
+import { stripAnsi, stripTerminalNoise } from "./strip-ansi";
 
 describe("stripAnsi", () => {
   it("removes color codes", () => {
@@ -49,5 +49,28 @@ describe("stripAnsi", () => {
     // would weld `scroll` and `math` into one word. The caller's control
     // sweep turns the surviving ESC into a separator.
     expect(stripAnsi("scroll\x1Bmath")).toBe("scroll\x1Bmath");
+  });
+});
+
+describe("stripTerminalNoise", () => {
+  it("removes escape sequences and collapses what is left", () => {
+    expect(
+      stripTerminalNoise(
+        "  \x1B[?25l\x1B]8;;https://example.com\x07LINKED\x1B]8;;\x07 " +
+          "\x1B[32mgreen\x1B[0m   file\x1B[?25h  ",
+      ),
+    ).toBe("LINKED green file");
+  });
+
+  it("turns a stray control byte into a separator, not a weld", () => {
+    // A BEL, a lone ESC and a C1 byte (U+0085 NEL, which JS `\s` does not
+    // match) each become a space, so the words stay apart.
+    expect(stripTerminalNoise("Fix\x07the\x85scroll\x1Bmath")).toBe(
+      "Fix the scroll math",
+    );
+  });
+
+  it("reduces text that is nothing but noise to the empty string", () => {
+    expect(stripTerminalNoise("\x1B[2J\x1B[H \t\n\x07")).toBe("");
   });
 });

--- a/src/lib/strip-ansi.ts
+++ b/src/lib/strip-ansi.ts
@@ -27,3 +27,28 @@ const ANSI_PATTERN =
 export function stripAnsi(text: string): string {
   return text.replace(ANSI_PATTERN, "");
 }
+
+/**
+ * Text that came off a terminal, reduced to what a single-line cell can
+ * paint: no escape sequences, no control bytes, no runs of whitespace, no
+ * surrounding space.
+ *
+ * `stripAnsi` takes out the well-formed sequences. The sweep behind it is
+ * for the residue a real pane still carries, a lone ESC, a BEL, a DEL, or a
+ * C1 byte (U+0080-U+009F), none of which belong to a sequence the pattern
+ * can recognize. Each becomes a SPACE rather than nothing, so two words a
+ * stray byte sat between never weld into one, and the collapse behind THAT
+ * is what turns the spaces it just introduced back into single separators.
+ * `\n` and `\t` fall under both rules for the same reason.
+ *
+ * The sweep is a regex here rather than `daemon/notify-text.ts`'s
+ * `stripControlChars`, which does the same job by codepoint scan: `lib` must
+ * not import from `daemon`. The two are deliberately independent; that one
+ * has newline and tab policy this has no use for.
+ */
+export function stripTerminalNoise(text: string): string {
+  return stripAnsi(text)
+    .replace(/[\x00-\x1F\x7F-\x9F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/src/lib/strip-ansi.ts
+++ b/src/lib/strip-ansi.ts
@@ -1,4 +1,28 @@
-const ANSI_PATTERN = /\x1B\[[0-9;]*[a-zA-Z]/g;
+/**
+ * One escape sequence, in the two shapes a real terminal actually sends into
+ * the text we render: a CSI (`ESC [`, private-parameter bytes and
+ * intermediates included, so `ESC [ ? 2 5 l` is one) and a string sequence
+ * (`ESC ]` OSC and its DCS/SOS/PM/APC siblings, closed by BEL or ST, which is
+ * how a hyperlink or a title-set arrives).
+ *
+ * This used to match CSI with numeric parameters only, which left the other
+ * shapes behind as PRINTABLE text: `\x1b[?25l` rendered as `[?25l` and an
+ * OSC 8 hyperlink as `]8;;https://…`. Sweeping control bytes does not help,
+ * because everything after the ESC is ordinary ASCII.
+ *
+ * Deliberately NOT matched: the two-byte `ESC <char>` forms. A lone ESC in
+ * free text is far commoner here than a real `ESC c`, and consuming the byte
+ * after it welds two words together (`pane-summary` has the regression test).
+ * A lone ESC is left for the caller's control sweep, which turns it into a
+ * separator instead.
+ *
+ * A string sequence's body excludes ESC and BEL, and there is no fallback to
+ * end-of-input, so an UNTERMINATED one matches nothing and survives whole.
+ * Bounded on purpose: the alternative eats every remaining character on the
+ * strength of one stray introducer.
+ */
+const ANSI_PATTERN =
+  /\x1B(?:\[[0-?]*[ -\/]*[@-~]|[\]P^_X][^\x07\x1B]*(?:\x07|\x1B\\))/g;
 
 export function stripAnsi(text: string): string {
   return text.replace(ANSI_PATTERN, "");

--- a/src/tui/components/session-columns.test.ts
+++ b/src/tui/components/session-columns.test.ts
@@ -411,6 +411,58 @@ describe("normalizePrompt", () => {
     ).toBe("OK");
   });
 
+  it("strips private-mode CSI, OSC hyperlinks and a BEL from stdout", () => {
+    // What a real pane hands `<local-command-stdout>`: a cursor hide/show
+    // pair, an OSC 8 hyperlink around the text, and a stray BEL. None of it
+    // is plain CSI, so none of it may reach the cell as `[?25l` or `]8;;…`.
+    expect(
+      normalizePrompt(
+        "<local-command-stdout>" +
+          "\x1b[?25l\x1b]8;;https://example.com\x07green\x1b]8;;\x07\x07 file" +
+          "\x1b[0m\x1b[?25h" +
+          "</local-command-stdout>",
+      ),
+    ).toBe("green file");
+  });
+
+  it("strips ANSI from a `!` shell turn's bash-stdout", () => {
+    // The exact shape a live Claude 2.1.263 logged for
+    // `! printf '\033]8;;…\aLINKED\033]8;;\a \033[32mgreen\033[0m file'`.
+    expect(
+      normalizePrompt(
+        "<bash-stdout>\x1b]8;;https://example.com\x07LINKED\x1b]8;;\x07 " +
+          "\x1b[?25l\x1b[32mgreen\x1b[0m\x1b[?25h file</bash-stdout>" +
+          "<bash-stderr></bash-stderr>",
+      ),
+    ).toBe("LINKED green file");
+  });
+
+  it("falls back to bash-stderr when the command printed nothing", () => {
+    expect(
+      normalizePrompt(
+        "<bash-stdout></bash-stdout><bash-stderr>no such file</bash-stderr>",
+      ),
+    ).toBe("no such file");
+  });
+
+  it("drops a `!` shell turn that produced no output at all", () => {
+    expect(
+      normalizePrompt("<bash-stdout></bash-stdout><bash-stderr></bash-stderr>"),
+    ).toBe("");
+  });
+
+  it("restores the `!` on a bash-input turn", () => {
+    expect(normalizePrompt("<bash-input>ls -la</bash-input>")).toBe("! ls -la");
+  });
+
+  it("prefers bash-stdout over bash-input in one text", () => {
+    expect(
+      normalizePrompt(
+        "<bash-input>ls</bash-input><bash-stdout>README.md</bash-stdout>",
+      ),
+    ).toBe("README.md");
+  });
+
   it("reduces a task notification to its summary", () => {
     expect(
       normalizePrompt(

--- a/src/tui/components/session-columns.test.ts
+++ b/src/tui/components/session-columns.test.ts
@@ -474,6 +474,21 @@ describe("normalizePrompt", () => {
     ).toBe("Agent finished the audit");
   });
 
+  it("keeps the summary when the result quotes an inner tag", () => {
+    // `<task-notification>` is the outermost wrapper and its `<result>` is
+    // an agent's own prose, so it can quote any tag the later branches
+    // match. Tested last, the bash branch would answer with the quote.
+    expect(
+      normalizePrompt(
+        "<task-notification><task-id>abc123</task-id>" +
+          "<status>completed</status>" +
+          "<summary>Agent finished the audit</summary>" +
+          "<result>the cell painted <bash-stdout>x</bash-stdout> raw" +
+          "</result></task-notification>",
+      ),
+    ).toBe("Agent finished the audit");
+  });
+
   it("drops a task notification with no summary", () => {
     expect(
       normalizePrompt(

--- a/src/tui/components/session-columns.test.ts
+++ b/src/tui/components/session-columns.test.ts
@@ -25,12 +25,14 @@ import {
   handoffBadge,
   HANDOFF_BADGE,
   ATTENTION_LABEL_MAX,
+  normalizePrompt,
   type ProjectCellDisplay,
 } from "./session-columns";
 import type { SubagentState } from "../../types";
 import { DEFAULT_BREAKPOINTS, type Responsive } from "../../lib/preferences";
 import { mockEnrichedSession } from "./test-helpers";
 import { displayWidth } from "../utils/format";
+import { formatHandoffHeader } from "../../daemon/handoff";
 
 /** A half of a surrogate pair with no partner: what a code-unit slice through
  *  an astral character leaves behind, rendered as `�`. */
@@ -397,6 +399,54 @@ describe("hasFieldData", () => {
     expect(hasFieldData(mockEnrichedSession({ paneCwd: "/a/b" }), "cwd")).toBe(
       true,
     );
+  });
+});
+
+describe("normalizePrompt", () => {
+  it("strips ANSI escapes from local-command-stdout", () => {
+    expect(
+      normalizePrompt(
+        "<local-command-stdout>\x1b[32mOK\x1b[0m</local-command-stdout>",
+      ),
+    ).toBe("OK");
+  });
+
+  it("reduces a task notification to its summary", () => {
+    expect(
+      normalizePrompt(
+        "<task-notification><task-id>abc123</task-id>" +
+          "<status>completed</status>" +
+          "<summary>Agent finished the audit</summary>" +
+          "<result>full report text here</result></task-notification>",
+      ),
+    ).toBe("Agent finished the audit");
+  });
+
+  it("drops a task notification with no summary", () => {
+    expect(
+      normalizePrompt(
+        "<task-notification><task-id>abc123</task-id>" +
+          "<status>completed</status></task-notification>",
+      ),
+    ).toBe("");
+  });
+
+  it("surfaces the payload of a relayed handoff, not the header", () => {
+    const header = formatHandoffHeader(
+      { sessionId: "sess-1", agentType: "codex", cwd: "/code/ccmux" },
+      new Date("2026-08-03T14:05:00"),
+    );
+    expect(normalizePrompt(`${header}\n\ntake it from here`)).toBe(
+      "take it from here",
+    );
+  });
+
+  it("drops a handoff header with no payload after it", () => {
+    const header = formatHandoffHeader(
+      { sessionId: "sess-1", agentType: "codex", cwd: "/code/ccmux" },
+      new Date("2026-08-03T14:05:00"),
+    );
+    expect(normalizePrompt(header)).toBe("");
   });
 });
 

--- a/src/tui/components/session-columns.ts
+++ b/src/tui/components/session-columns.ts
@@ -17,6 +17,8 @@ import {
 } from "../../lib/preferences";
 import type { EnrichedSession, BranchPR } from "../../types";
 import { displayWidth, sliceToWidth, truncateText } from "../utils/format";
+import { stripAnsi } from "../../lib/strip-ansi";
+import { HANDOFF_PREFIX } from "../../daemon/handoff";
 
 const RESPONSIVE_KEYS = new Set([
   "default",
@@ -361,32 +363,57 @@ export function applyPromptDisplay(
 
 /**
  * Claude logs store slash-command turns as XML-ish markup
- * (`<command-name>/clear</command-name><command-args>…</command-args>`) and
- * local-command output wrapped in `<local-command-stdout>`. Reduce those to
- * the command line / inner text so the subtitle reads as the user's intent.
+ * (`<command-name>/clear</command-name><command-args>…</command-args>`),
+ * local-command output wrapped in `<local-command-stdout>` (which can carry
+ * ANSI escapes straight from the terminal), and background-task completions
+ * wrapped in `<task-notification>` (only the `<summary>` inside is worth
+ * showing; a notification with none is dropped rather than shown raw).
+ * Reduce those to the text that reads as the user's intent.
  */
 function stripCommandMarkup(text: string): string {
-  const command = text.match(/<command-name>(.*?)<\/command-name>/);
+  const command = text.match(/<command-name>([\s\S]*?)<\/command-name>/);
   if (command) {
-    const args = text.match(/<command-args>(.*?)<\/command-args>/);
+    const args = text.match(/<command-args>([\s\S]*?)<\/command-args>/);
     return [command[1], args?.[1]].filter(Boolean).join(" ");
   }
   const stdout = text.match(
-    /<local-command-stdout>(.*?)<\/local-command-stdout>/,
+    /<local-command-stdout>([\s\S]*?)<\/local-command-stdout>/,
   );
-  if (stdout) return stdout[1];
+  if (stdout) return stripAnsi(stdout[1]);
+  const notification = text.match(
+    /<task-notification>([\s\S]*?)<\/task-notification>/,
+  );
+  if (notification) {
+    const summary = notification[1].match(/<summary>([\s\S]*?)<\/summary>/);
+    return summary ? summary[1] : "";
+  }
   return text;
+}
+
+/**
+ * A relayed `[ccmux handoff]` message (see `daemon/handoff.ts`) is the
+ * frozen provenance header, a blank line, then the payload a peer session
+ * actually sent. Surface the payload, not the header, as the prompt.
+ */
+function stripHandoffHeader(text: string): string {
+  if (!text.startsWith(HANDOFF_PREFIX)) return text;
+  const separator = text.indexOf("\n\n");
+  return separator === -1 ? "" : text.slice(separator + 2);
 }
 
 /**
  * The prompt as the subtitle renders it. Lives here (not SessionItem) so
  * `hasFieldData` can apply the same reduction: a prompt that normalizes
- * to "" (whitespace-only, or empty-inner markup like a quiet
- * `<local-command-stdout></local-command-stdout>`) must not earn row 2 a
- * line it would render blank.
+ * to "" (whitespace-only, empty-inner markup like a quiet
+ * `<local-command-stdout></local-command-stdout>`, or a task notification
+ * with no summary) must not earn row 2 a line it would render blank.
+ *
+ * The handoff header is stripped before whitespace is collapsed: its
+ * header/payload boundary is a blank line, which collapsing would destroy.
  */
 export function normalizePrompt(text: string): string {
-  return stripCommandMarkup(text.replace(/\s+/g, " ").trim()).trim();
+  const payload = stripHandoffHeader(text.trim());
+  return stripCommandMarkup(payload.replace(/\s+/g, " ").trim()).trim();
 }
 
 /**

--- a/src/tui/components/session-columns.ts
+++ b/src/tui/components/session-columns.ts
@@ -17,8 +17,7 @@ import {
 } from "../../lib/preferences";
 import type { EnrichedSession, BranchPR } from "../../types";
 import { displayWidth, sliceToWidth, truncateText } from "../utils/format";
-import { stripAnsi } from "../../lib/strip-ansi";
-import { stripControlChars } from "../../daemon/notify-text";
+import { stripTerminalNoise } from "../../lib/strip-ansi";
 import { HANDOFF_PREFIX } from "../../daemon/handoff";
 
 const RESPONSIVE_KEYS = new Set([
@@ -363,22 +362,6 @@ export function applyPromptDisplay(
 }
 
 /**
- * Text that came from a terminal, reduced to what a cell can paint.
- *
- * `stripAnsi` takes out the well-formed sequences; the control sweep behind
- * it is for the residue a real pane still carries, a lone ESC, a BEL, a DEL,
- * or a C1 byte, none of which belong to a sequence the pattern can
- * recognize. Each becomes a SPACE rather than nothing, so two words never
- * weld together, which is also why the collapse runs again here:
- * `normalizePrompt` already collapsed before it could see any of this.
- */
-function cleanTerminalText(text: string): string {
-  return stripControlChars(stripAnsi(text), { replacement: " " })
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-/**
  * Claude logs store slash-command turns as XML-ish markup
  * (`<command-name>/clear</command-name><command-args>…</command-args>`),
  * local-command output wrapped in `<local-command-stdout>` (which can carry
@@ -397,8 +380,25 @@ function cleanTerminalText(text: string): string {
  * reduces to "" so the row drops like the other empty shapes. `<bash-input>`
  * renders with its `!` restored, the shape Claude's own last-prompt records
  * use.
+ *
+ * ORDER IS THE POLICY, not a formality. `<task-notification>` is tested
+ * FIRST because it is the outermost wrapper: its `<result>` carries an
+ * agent's own prose, which can quote any of the tags below it. Tested last,
+ * a notification that mentioned `<bash-stdout>` would be answered by the
+ * bash branch reading the quote. Every other shape is a leaf, so among them
+ * order is only the stdout-beats-input preference above.
+ *
+ * `stripTerminalNoise` is what makes an escape-carrying payload paintable;
+ * its own comment carries the why.
  */
 function stripCommandMarkup(text: string): string {
+  const notification = text.match(
+    /<task-notification>([\s\S]*?)<\/task-notification>/,
+  );
+  if (notification) {
+    const summary = notification[1].match(/<summary>([\s\S]*?)<\/summary>/);
+    return summary ? summary[1] : "";
+  }
   const command = text.match(/<command-name>([\s\S]*?)<\/command-name>/);
   if (command) {
     const args = text.match(/<command-args>([\s\S]*?)<\/command-args>/);
@@ -407,25 +407,18 @@ function stripCommandMarkup(text: string): string {
   const stdout = text.match(
     /<local-command-stdout>([\s\S]*?)<\/local-command-stdout>/,
   );
-  if (stdout) return cleanTerminalText(stdout[1]);
+  if (stdout) return stripTerminalNoise(stdout[1]);
   const bashOut = text.match(/<bash-stdout>([\s\S]*?)<\/bash-stdout>/);
   const bashErr = text.match(/<bash-stderr>([\s\S]*?)<\/bash-stderr>/);
   if (bashOut || bashErr)
     return (
-      cleanTerminalText(bashOut?.[1] ?? "") ||
-      cleanTerminalText(bashErr?.[1] ?? "")
+      stripTerminalNoise(bashOut?.[1] ?? "") ||
+      stripTerminalNoise(bashErr?.[1] ?? "")
     );
   const bashIn = text.match(/<bash-input>([\s\S]*?)<\/bash-input>/);
   if (bashIn) {
-    const cmd = cleanTerminalText(bashIn[1]);
+    const cmd = stripTerminalNoise(bashIn[1]);
     return cmd ? `! ${cmd}` : "";
-  }
-  const notification = text.match(
-    /<task-notification>([\s\S]*?)<\/task-notification>/,
-  );
-  if (notification) {
-    const summary = notification[1].match(/<summary>([\s\S]*?)<\/summary>/);
-    return summary ? summary[1] : "";
   }
   return text;
 }

--- a/src/tui/components/session-columns.ts
+++ b/src/tui/components/session-columns.ts
@@ -18,6 +18,7 @@ import {
 import type { EnrichedSession, BranchPR } from "../../types";
 import { displayWidth, sliceToWidth, truncateText } from "../utils/format";
 import { stripAnsi } from "../../lib/strip-ansi";
+import { stripControlChars } from "../../daemon/notify-text";
 import { HANDOFF_PREFIX } from "../../daemon/handoff";
 
 const RESPONSIVE_KEYS = new Set([
@@ -362,6 +363,22 @@ export function applyPromptDisplay(
 }
 
 /**
+ * Text that came from a terminal, reduced to what a cell can paint.
+ *
+ * `stripAnsi` takes out the well-formed sequences; the control sweep behind
+ * it is for the residue a real pane still carries, a lone ESC, a BEL, a DEL,
+ * or a C1 byte, none of which belong to a sequence the pattern can
+ * recognize. Each becomes a SPACE rather than nothing, so two words never
+ * weld together, which is also why the collapse runs again here:
+ * `normalizePrompt` already collapsed before it could see any of this.
+ */
+function cleanTerminalText(text: string): string {
+  return stripControlChars(stripAnsi(text), { replacement: " " })
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
  * Claude logs store slash-command turns as XML-ish markup
  * (`<command-name>/clear</command-name><command-args>…</command-args>`),
  * local-command output wrapped in `<local-command-stdout>` (which can carry
@@ -369,6 +386,17 @@ export function applyPromptDisplay(
  * wrapped in `<task-notification>` (only the `<summary>` inside is worth
  * showing; a notification with none is dropped rather than shown raw).
  * Reduce those to the text that reads as the user's intent.
+ *
+ * A `!` shell turn is a THIRD pair of shapes, not the local-command one:
+ * Claude Code 2.1.x writes the command as `<bash-input>` and its result as
+ * `<bash-stdout>…</bash-stdout><bash-stderr>…</bash-stderr>`, and reserves
+ * `<local-command-stdout>` for built-ins like `/model`. The bash pair is
+ * where raw escapes actually arrive, since the payload is a real command's
+ * output. stdout wins over input when one text carries both, and stderr is
+ * the fallback for a command that only complained; a turn with neither
+ * reduces to "" so the row drops like the other empty shapes. `<bash-input>`
+ * renders with its `!` restored, the shape Claude's own last-prompt records
+ * use.
  */
 function stripCommandMarkup(text: string): string {
   const command = text.match(/<command-name>([\s\S]*?)<\/command-name>/);
@@ -379,7 +407,19 @@ function stripCommandMarkup(text: string): string {
   const stdout = text.match(
     /<local-command-stdout>([\s\S]*?)<\/local-command-stdout>/,
   );
-  if (stdout) return stripAnsi(stdout[1]);
+  if (stdout) return cleanTerminalText(stdout[1]);
+  const bashOut = text.match(/<bash-stdout>([\s\S]*?)<\/bash-stdout>/);
+  const bashErr = text.match(/<bash-stderr>([\s\S]*?)<\/bash-stderr>/);
+  if (bashOut || bashErr)
+    return (
+      cleanTerminalText(bashOut?.[1] ?? "") ||
+      cleanTerminalText(bashErr?.[1] ?? "")
+    );
+  const bashIn = text.match(/<bash-input>([\s\S]*?)<\/bash-input>/);
+  if (bashIn) {
+    const cmd = cleanTerminalText(bashIn[1]);
+    return cmd ? `! ${cmd}` : "";
+  }
   const notification = text.match(
     /<task-notification>([\s\S]*?)<\/task-notification>/,
   );


### PR DESCRIPTION
## Overview

Reduces the noisy shapes Claude writes into the transcript (task notifications, relayed handoffs, local-command and `!` shell output) to the text the user actually cares about before they reach the prompt, promptLines and summary-fallback cells, and strips real terminal escapes from them.

Resolves #184

## Motivation

Rows after a background task, a handoff, or a shell command painted raw XML tags, provenance headers, and escape bytes like `[?25l` or `]8;;https://…` in the prompt cell. The prompt cell exists to show intent at a glance, and these shapes hid it behind machinery.

## Changes

### Prompt reduction

- **session-columns.ts** - `stripCommandMarkup` handles three more shapes: a `<task-notification>` reduces to its `<summary>` (dropped entirely with none), a `[ccmux handoff]` message shows the relayed payload instead of its frozen header, and `<bash-stdout>` (with `<bash-stderr>` as fallback, `<bash-input>` shown as `! <cmd>`) is reduced like `<local-command-stdout>`. Claude Code 2.1.x records a `!` command as the `<bash-*>` pair, not `<local-command-stdout>`, which only built-ins like `/model` still write. `<task-notification>` is tested first because it is the outermost wrapper and its `<result>` can quote any tag below it. Both stdout shapes go through `stripTerminalNoise`: `stripAnsi`, a control sweep that turns the residue into spaces, then a whitespace re-collapse.

### Escape stripping

- **strip-ansi.ts** - `ANSI_PATTERN` matched CSI with numeric parameters only, so the escapes a spinner actually emits (`\x1b[?25l` cursor hide, OSC 8 hyperlinks, title sets) survived as printable text. It now matches private-parameter CSI and BEL/ST-terminated string sequences. Two-byte `ESC x` forms stay unmatched on purpose so a lone ESC never eats the next character, and an unterminated string sequence matches nothing rather than the rest of the line. Every other caller gets strictly more removal.
- **strip-ansi.ts** - Adds `stripTerminalNoise`, the strip + control sweep + collapse chain the prompt cell and the pane-title summary both need.
- **pane-summary.ts** - `normalizeTitle` calls `stripTerminalNoise` instead of carrying its own copy of the chain.

### Tests

- **session-columns.test.ts** - One case per shape: ANSI in local-command stdout, task notification with and without a summary, handoff with and without a payload, the exact `<bash-stdout>` shape observed live, the stderr fallback, the both-empty drop, `<bash-input>`, stdout winning over input, and a notification whose `<result>` quotes a `<bash-stdout>` tag still reducing to its summary.
- **strip-ansi.test.ts** - Private-mode CSI, OSC by BEL and by ST, lone ESC preserved, unterminated OSC preserved, and `stripTerminalNoise` reduction, stray-byte separators and noise-only input.

## Breaking Changes

None

## Testing

- [x] `bun test src/tui/components/session-columns.test.ts` (154 pass)
- [x] `bun test` (full suite, 5808 pass)
- [x] `bun run typecheck`
- [x] Live picker capture from this branch's build against a real Claude Code 2.1.263 session running `! printf` with an OSC 8 hyperlink, cursor hide/show and a BEL: the row went from `<bash-stdout> ]8;;https://example.com LINKED ]8;; …` to `LINKED green file`

