### PR TITLE
feat(preview): Show the session summary in the preview header

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ The daemon starts automatically the first time you run a ccmux command (picker, 
 
 Press <kbd>P</kbd> to split the picker and preview the highlighted session's live pane content side by side. Press <kbd>Tab</kbd> to focus the preview and act in place: your keystrokes go straight to that agent's pane, so you can approve a permission, answer a question, or type a follow-up without ever leaving ccmux.
 
+The preview header names the session: the project in bold, then the agent's own summary of the session on agents that publish one (Claude Code, OpenCode, Cursor, oh-my-pi, and Copilot do; on the rest the line is omitted), then the working directory and the branch/version/target metadata.
+
 When the session has agents running, an **Agents** section lists each one with its runtime. Finished agents drop off the list.
 
 https://github.com/user-attachments/assets/7e0d42b3-4e7b-43b8-8d06-72a2d69dd694

--- a/src/tui/components/Preview.test.tsx
+++ b/src/tui/components/Preview.test.tsx
@@ -77,6 +77,119 @@ describe("Preview", () => {
     expect(frame).toContain("~/Code/myapp");
   });
 
+  it("shows the session summary on its own header line", async () => {
+    const home = process.env.HOME || "";
+    const frame = await renderPreview(
+      mockEnrichedSession({
+        project: "myapp",
+        cwd: `${home}/Code/myapp`,
+        summary: "Detect themes across projects",
+        tmuxTarget: "dev:1",
+        tmuxPane: "%1",
+      }),
+    );
+    const lines = frame.split("\n");
+    const summaryLine = lines.findIndex((l) =>
+      l.includes("Detect themes across projects"),
+    );
+    expect(summaryLine).toBeGreaterThan(-1);
+    const projectLine = lines.findIndex((l) => l.includes("myapp"));
+    expect(projectLine).toBeGreaterThan(-1);
+    expect(projectLine).toBeLessThan(summaryLine);
+    expect(lines[summaryLine + 1]).toContain("~/Code/myapp");
+    const metadataLine = lines.findIndex((l) => l.includes("dev:1"));
+    expect(metadataLine).toBe(summaryLine + 2);
+    expect(lines[metadataLine + 1]).toContain("───");
+  });
+
+  it("keeps the four-row header when the agent publishes no summary", async () => {
+    const home = process.env.HOME || "";
+    const frame = await renderPreview(
+      mockEnrichedSession({
+        project: "myapp",
+        cwd: `${home}/Code/myapp`,
+        tmuxTarget: "dev:1",
+        tmuxPane: "%1",
+      }),
+    );
+    const lines = frame.split("\n");
+    const projectLine = lines.findIndex((l) => l.includes("myapp"));
+    expect(projectLine).toBeGreaterThan(-1);
+    expect(lines[projectLine + 1]).toContain("~/Code/myapp");
+    const metadataLine = lines.findIndex((l) => l.includes("dev:1"));
+    expect(metadataLine).toBe(projectLine + 2);
+    expect(lines[metadataLine + 1]).toContain("───");
+  });
+
+  it("renders a late-arriving summary in the header", async () => {
+    const home = process.env.HOME || "";
+    const [tick] = createSignal(0);
+    const [session, setSession] = createSignal<EnrichedSession>(
+      mockEnrichedSession({
+        project: "myapp",
+        cwd: `${home}/Code/myapp`,
+        tmuxTarget: "dev:1",
+        tmuxPane: "%1",
+      }),
+    );
+    setup = await testRender(
+      () => (
+        <TickContext.Provider value={{ tick }}>
+          <Preview session={session()} width={40} />
+        </TickContext.Provider>
+      ),
+      { width: 100, height: 15 },
+    );
+    await setup.renderOnce();
+    setSession(
+      mockEnrichedSession({
+        project: "myapp",
+        cwd: `${home}/Code/myapp`,
+        summary: "Arrived-after-mount summary",
+        tmuxTarget: "dev:1",
+        tmuxPane: "%1",
+      }),
+    );
+    await setup.renderOnce();
+    const lines = setup.captureCharFrame().split("\n");
+    const summaryLine = lines.findIndex((l) =>
+      l.includes("Arrived-after-mount summary"),
+    );
+    expect(summaryLine).toBeGreaterThan(-1);
+    expect(lines[summaryLine + 1]).toContain("~/Code/myapp");
+    const metadataLine = lines.findIndex((l) => l.includes("dev:1"));
+    expect(metadataLine).toBe(summaryLine + 2);
+    expect(lines[metadataLine + 1]).toContain("───");
+  });
+
+  it("truncates a summary wider than the header instead of wrapping", async () => {
+    const home = process.env.HOME || "";
+    const long =
+      "Investigate why the flaky auth integration tests fail on windows runners";
+    const frame = await renderPreview(
+      mockEnrichedSession({
+        project: "myapp",
+        cwd: `${home}/Code/myapp`,
+        summary: long,
+        tmuxTarget: "dev:1",
+        tmuxPane: "%1",
+      }),
+      30,
+    );
+    const lines = frame.split("\n");
+    const summaryLine = lines.findIndex((l) =>
+      l.includes("Investigate why the flaky"),
+    );
+    expect(summaryLine).toBeGreaterThan(-1);
+    // Clipped, not wrapped: the tail renders nowhere, and the rows below
+    // the summary keep their slots.
+    expect(lines.some((l) => l.includes("windows runners"))).toBe(false);
+    expect(lines[summaryLine]).toContain("…");
+    expect(lines[summaryLine + 1]).toContain("~/Code/myapp");
+    const metadataLine = lines.findIndex((l) => l.includes("dev:1"));
+    expect(lines[metadataLine + 1]).toContain("───");
+  });
+
   it("shows metadata with branch and version", async () => {
     const frame = await renderPreview(
       mockEnrichedSession({

--- a/src/tui/components/Preview.tsx
+++ b/src/tui/components/Preview.tsx
@@ -34,6 +34,7 @@ import {
   formatSubagentName,
   formatVersion,
   shortenCwd,
+  truncateText,
 } from "../utils/format";
 
 /**
@@ -413,6 +414,14 @@ export const Preview: Component<PreviewProps> = (props) => {
   const AGENTS_SHOWN_MAX = 4;
   const liveSubagents = () => props.session?.subagents ?? [];
 
+  /**
+   * The agent's own summary of what this session is doing
+   * (`EnrichedSession.summary`, derived daemon-side from the pane title),
+   * on the agents that publish one. Renders as its own header line so the
+   * preview names the session's work, not just the project it sits in.
+   */
+  const title = () => props.session?.summary ?? null;
+
   const metadataLine = () => {
     const s = props.session;
     if (!s) return "";
@@ -446,7 +455,7 @@ export const Preview: Component<PreviewProps> = (props) => {
         when={props.session}
         fallback={<text fg={theme.overlay}>Select a session to preview</text>}
       >
-        <box height={4} flexDirection="column">
+        <box height={title() ? 5 : 4} flexDirection="column">
           <box flexDirection="row">
             <box flexGrow={1}>
               <text fg={theme.text}>
@@ -456,6 +465,17 @@ export const Preview: Component<PreviewProps> = (props) => {
             <text fg={statusColor()}>
               {statusIcon()} {statusText()}
             </text>
+          </box>
+          {/* Stable wrapper: a summary can land after first render (enrich
+              arrives over SSE), and a bare <Show> mounted late would append
+              to the END of the parent box (opentui insertion anchor),
+              landing the title under the separator. The always-mounted box
+              pins its slot in the column order. Same fix pattern as the
+              transcript slot in BackgroundPeek. */}
+          <box flexDirection="column">
+            <Show when={title()}>
+              <text fg={theme.text}>{truncateText(title() ?? "", separatorWidth())}</text>
+            </Show>
           </box>
           <text fg={theme.subtext}>
             {shortenCwd(props.session!.paneCwd ?? props.session!.cwd)}


### PR DESCRIPTION
## Summary

- The picker preview header showed the project, cwd, and branch/version/target metadata — but not the **agent's own summary of the session**, so two sessions in one project were indistinguishable in the preview.
- Agents with a `summaryTitle` rule (Claude, OpenCode, Cursor, oh-my-pi, Copilot) already ship that summary as `session.summary` (derived daemon-side from the pane title), and the `summary` column renders it in list rows. The preview header simply never used it.
- Now the summary renders as its own header line between the project row and the cwd; the header budget grows from four rows to five when one is present. Sessions without one render exactly as before.
- The summary is pre-truncated to the header's inner width (`truncateText(title(), separatorWidth())`, the idiom `ConfirmationDialog`/`ContextMenu`/`DropdownField` use), so a summary wider than the preview clips with an ellipsis instead of wrapping inside the fixed-height box.
- The line sits in an always-mounted wrapper box: the summary can land over SSE after first mount, and a bare `<Show>` mounted late would append to the END of the parent box — the same opentui insertion-anchor trap the transcript slot in `BackgroundPeek` guards against. (Note: the late-arriving test passes with the wrapper removed too, so it pins the layout but does not by itself distinguish wrapper vs bare `<Show>`; the wrapper is kept for the reason above.)

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` — 200 files / 5841 tests pass, including four new `Preview.test.tsx` cases:
  - summary on its own header line, separator pinned at `metadataLine + 1`
  - four-row header preserved without a summary, separator pinned at `metadataLine + 1`
  - late-arriving summary renders in the header, separator pinned at `metadataLine + 1`
  - a summary wider than the header truncates to one line (no wrapped continuation, rows below keep their slots) — verified this test fails without the `truncateText` fix
- [x] Live render per AGENTS.md: isolated tmux server + daemon (`CCMUX_TMUX_SOCKET`, `CCMUX_PORT`, `CCMUX_HOME`), fake OpenCode session with pane title `OC | Fix flaky auth tests across suites`, `ccmux picker --preview`:

```
 ● Sessions (1)
 ▼ mling_ir (1)                                                     │ mling_ir                                   ● idle
 1 ● idle  embed-flo-sch…mling_ir  Fix flaky auth tes…  OpenCode    │ Fix flaky auth tests across suites
                                                                    │ /data/1d/embed-flo-schneider/mling_ir
                                                                    │ v9.4 · work:1.1
                                                                    │ ───────────────────────────────────────────
```

Also re-captured at 100 cols; header layout holds.
