### PR TITLE
fix(release): Make the Homebrew binary executable before generating completions

### DIFF
--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -61,6 +61,10 @@ class Ccmux < Formula
   def install
     binary_name = stable.url.split("/").last
     bin.install binary_name => "ccmux"
+    # The release asset is a bare binary, downloaded as 0644. Homebrew only
+    # fixes bin/ permissions after `install` returns, so make it executable
+    # here or the completion step below fails with EACCES.
+    chmod 0755, bin/"ccmux"
 
     # \`ccmux completion <shell>\` only prints a static script: no daemon,
     # tmux, or HOME involved, so it is safe to run in the build sandbox.


### PR DESCRIPTION
## Summary

\`brew install epilande/tap/ccmux\` and every \`brew upgrade\` to 1.4.x failed with:

\`\`\`
brew: exec failed (EACCES): /opt/homebrew/Cellar/ccmux/1.4.1/bin/ccmux
Error: epilande/tap/ccmux: Failure while executing; `{"SHELL" => "bash"} /opt/homebrew/Cellar/ccmux/1.4.1/bin/ccmux completion bash` exited with 1.
\`\`\`

The release asset is a bare binary, which Homebrew downloads as 0644. \`bin.install\` keeps that mode, and Homebrew only chmods \`bin/\` contents after \`install\` returns. The \`generate_completions_from_executable\` call added in 1.4.0 (#169) runs inside \`install\`, so it execs a non-executable file. Existing installs were unaffected because the failed upgrade aborts before unlinking the old keg.

This adds \`chmod 0755, bin/"ccmux"\` to the formula template before the completion call. The tap formula was hotfixed by hand in epilande/homebrew-tap@7f7e8e9 so 1.4.1 installs today; this change keeps the next generated formula from regressing.

## Verification

Reproduced the failure upgrading 1.2.0 to 1.4.1 locally, then re-ran with the patched formula: upgrade succeeded, Cellar binary is 0555, bash/zsh/fish completions linked, notifier app staged in libexec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Homebrew installations now correctly mark the command-line executable as runnable, ensuring the binary works immediately after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->