### PR TITLE
fix(tui): Prevent clipped help and overlapping preview headers

### DIFF
--- a/src/tui/components/HelpOverlay.test.tsx
+++ b/src/tui/components/HelpOverlay.test.tsx
@@ -15,20 +15,47 @@ function lineHasKey(line: string, key: string): boolean {
   return new RegExp(`(?:^|\\s{2,})${escapeRe(key)}\\s{2,}`).test(inner);
 }
 
-/** The description is on the key's row or the next few (wrap / compact). */
-function expectHelpEntry(frame: string, key: string, desc: string): void {
+/**
+ * The key's line index, plus the two-line window a description may occupy:
+ * the key's own row (picker, where key and desc share a row) or the row
+ * right below it (sidebar compact, which stacks desc under key).
+ *
+ * Joining the window with "\n" keeps `toContain` contiguous per line, since
+ * no description contains a newline. That is the point of these helpers: a
+ * clipped "Toggle prev" must not pass because a later row says "Scroll
+ * preview".
+ */
+function keyWindow(
+  frame: string,
+  key: string,
+): { lines: string[]; at: number } {
   const lines = frame.split("\n");
-  const keyLine = lines.findIndex((l) => lineHasKey(l, key));
-  expect(keyLine).toBeGreaterThan(-1);
-  const window = lines.slice(keyLine, keyLine + 5).join("\n");
-  // Words in order: two-column rows interleave the other column between
-  // wrapped desc lines, so a squished window is not contiguous.
-  let from = 0;
-  for (const word of desc.split(/\s+/)) {
-    const idx = window.indexOf(word, from);
-    expect(idx).toBeGreaterThan(-1);
-    from = idx + word.length;
-  }
+  const at = lines.findIndex((l) => lineHasKey(l, key));
+  expect(at).toBeGreaterThan(-1);
+  return { lines, at };
+}
+
+/** The FULL description sits on one line: the key's row or the next. */
+function expectHelpEntry(frame: string, key: string, desc: string): void {
+  const { lines, at } = keyWindow(frame, key);
+  expect(lines.slice(at, at + 2).join("\n")).toContain(desc);
+}
+
+/**
+ * A description that legitimately wraps at the tested width: `head` on the
+ * key's row or the next, `tail` contiguous on one of the three rows after
+ * whichever row held `head`.
+ */
+function expectWrappedHelpEntry(
+  frame: string,
+  key: string,
+  head: string,
+  tail: string,
+): void {
+  const { lines, at } = keyWindow(frame, key);
+  expect(lines.slice(at, at + 2).join("\n")).toContain(head);
+  const headLine = lines[at]!.includes(head) ? at : at + 1;
+  expect(lines.slice(headLine + 1, headLine + 4).join("\n")).toContain(tail);
 }
 
 type Setup = Awaited<ReturnType<typeof testRender>>;
@@ -244,7 +271,7 @@ describe("HelpOverlay narrow and wide picker (issue #200)", () => {
     expectHelpEntry(frame, "gg / G", "Jump to first / last");
     expectHelpEntry(frame, "1-9", "Jump to session N");
     expectHelpEntry(frame, "Enter", "Switch to session");
-    // Longer than the old 24-column description budget; must wrap, not clip.
+    // 29 columns against a 40-column single-column budget: one line, whole.
     expectHelpEntry(frame, "p", "Cycle prompt (inline/row/off)");
     expect(squish(frame)).toContain(squish("j/k scroll · ? or Esc to close"));
   });
@@ -284,7 +311,8 @@ describe("HelpOverlay narrow and wide picker (issue #200)", () => {
     expectHelpEntry(frame, "Alt+H/L", "Resize preview");
     expectHelpEntry(frame, "Tab", "Focus preview");
     expectHelpEntry(frame, "h / l", "Collapse / expand group");
-    expectHelpEntry(frame, "p", "Cycle prompt (inline/row/off)");
+    // 29 columns against the two-column budget of 24: wraps, never clips.
+    expectWrappedHelpEntry(frame, "p", "Cycle prompt", "(inline/row/off)");
     expect(squish(frame)).toContain(squish("j/k scroll · ? or Esc to close"));
   });
 
@@ -307,7 +335,7 @@ describe("HelpOverlay narrow and wide picker (issue #200)", () => {
       "Preview",
     );
     expectHelpEntry(wide, "P", "Toggle preview");
-    expectHelpEntry(wide, "p", "Cycle prompt (inline/row/off)");
+    expectWrappedHelpEntry(wide, "p", "Cycle prompt", "(inline/row/off)");
 
     setup.resize(60, 24);
     await setup.renderOnce();
@@ -349,6 +377,6 @@ describe("HelpOverlay sidebar compact wrap (issue #200)", () => {
     });
     await setup.renderOnce();
     const frame = setup.captureCharFrame();
-    expectHelpEntry(frame, "p", "Cycle prompt (inline/row/off)");
+    expectWrappedHelpEntry(frame, "p", "Cycle prompt", "(inline/row/off)");
   });
 });

--- a/src/tui/components/HelpOverlay.test.tsx
+++ b/src/tui/components/HelpOverlay.test.tsx
@@ -2,6 +2,34 @@ import type { ScrollBoxRenderable } from "@opentui/core";
 import { describe, it, expect, afterEach } from "bun:test";
 import { testRender } from "@opentui/solid";
 import { HelpOverlay } from "./HelpOverlay";
+import { squish } from "./test-helpers";
+
+function escapeRe(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Key as its own column, not a letter inside "Jump" / "group". */
+function lineHasKey(line: string, key: string): boolean {
+  const inner = line.replace(/[│┌┐└┘─█▀▄]/g, " ");
+  if (inner.replace(/\s+/g, " ").trim() === key) return true;
+  return new RegExp(`(?:^|\\s{2,})${escapeRe(key)}\\s{2,}`).test(inner);
+}
+
+/** The description is on the key's row or the next few (wrap / compact). */
+function expectHelpEntry(frame: string, key: string, desc: string): void {
+  const lines = frame.split("\n");
+  const keyLine = lines.findIndex((l) => lineHasKey(l, key));
+  expect(keyLine).toBeGreaterThan(-1);
+  const window = lines.slice(keyLine, keyLine + 5).join("\n");
+  // Words in order: two-column rows interleave the other column between
+  // wrapped desc lines, so a squished window is not contiguous.
+  let from = 0;
+  for (const word of desc.split(/\s+/)) {
+    const idx = window.indexOf(word, from);
+    expect(idx).toBeGreaterThan(-1);
+    from = idx + word.length;
+  }
+}
 
 type Setup = Awaited<ReturnType<typeof testRender>>;
 let setup: Setup;
@@ -195,5 +223,132 @@ describe("HelpOverlay reviewable", () => {
     await setup.renderOnce();
     const frame = setup.captureCharFrame();
     expect(frame).not.toContain("Working tree / branch");
+  });
+});
+
+describe("HelpOverlay narrow and wide picker (issue #200)", () => {
+  it("keeps complete descriptions at 60x24 in a single column", async () => {
+    setup = await testRender(() => <HelpOverlay />, {
+      width: 60,
+      height: 24,
+    });
+    await setup.renderOnce();
+    const frame = setup.captureCharFrame();
+    const lines = frame.split("\n");
+    const nav = lines.find((l) => l.includes("Navigation"));
+    expect(nav).toBeDefined();
+    // Two-column clip: Preview sat on the Navigation row and lost its
+    // descriptions off the right edge. One column stacks the sections.
+    expect(nav!).not.toContain("Preview");
+    expectHelpEntry(frame, "j/k ↑/↓", "Navigate sessions");
+    expectHelpEntry(frame, "gg / G", "Jump to first / last");
+    expectHelpEntry(frame, "1-9", "Jump to session N");
+    expectHelpEntry(frame, "Enter", "Switch to session");
+    // Longer than the old 24-column description budget; must wrap, not clip.
+    expectHelpEntry(frame, "p", "Cycle prompt (inline/row/off)");
+    expect(squish(frame)).toContain(squish("j/k scroll · ? or Esc to close"));
+  });
+
+  it("reveals complete Preview entries after scrolling at 60x24", async () => {
+    let ref: ScrollBoxRenderable | undefined;
+    setup = await testRender(
+      () => <HelpOverlay onScrollboxRef={(r) => (ref = r)} />,
+      { width: 60, height: 24 },
+    );
+    await setup.renderOnce();
+    expect(ref).toBeDefined();
+    // Single-column content is taller than 24 rows; the right-hand
+    // section is below the fold instead of clipped beside Navigation.
+    ref!.scrollBy(20);
+    await setup.renderOnce();
+    const frame = setup.captureCharFrame();
+    expectHelpEntry(frame, "P", "Toggle preview");
+    expectHelpEntry(frame, "Ctrl+D/U", "Scroll preview");
+    expectHelpEntry(frame, "Alt+H/L", "Resize preview");
+    expectHelpEntry(frame, "Tab", "Focus preview");
+  });
+
+  it("keeps two columns and complete descriptions at 120x35", async () => {
+    setup = await testRender(() => <HelpOverlay />, {
+      width: 120,
+      height: 35,
+    });
+    await setup.renderOnce();
+    const frame = setup.captureCharFrame();
+    const nav = frame.split("\n").find((l) => l.includes("Navigation"));
+    expect(nav).toBeDefined();
+    expect(nav!).toContain("Preview");
+    expectHelpEntry(frame, "j/k ↑/↓", "Navigate sessions");
+    expectHelpEntry(frame, "P", "Toggle preview");
+    expectHelpEntry(frame, "Ctrl+D/U", "Scroll preview");
+    expectHelpEntry(frame, "Alt+H/L", "Resize preview");
+    expectHelpEntry(frame, "Tab", "Focus preview");
+    expectHelpEntry(frame, "h / l", "Collapse / expand group");
+    expectHelpEntry(frame, "p", "Cycle prompt (inline/row/off)");
+    expect(squish(frame)).toContain(squish("j/k scroll · ? or Esc to close"));
+  });
+
+  it("switches between one and two columns when the picker is resized", async () => {
+    setup = await testRender(() => <HelpOverlay />, {
+      width: 60,
+      height: 24,
+    });
+    await setup.renderOnce();
+    const narrow = setup.captureCharFrame();
+    expect(
+      narrow.split("\n").find((l) => l.includes("Navigation")),
+    ).not.toContain("Preview");
+    expectHelpEntry(narrow, "p", "Cycle prompt (inline/row/off)");
+
+    setup.resize(120, 35);
+    await setup.renderOnce();
+    const wide = setup.captureCharFrame();
+    expect(wide.split("\n").find((l) => l.includes("Navigation"))).toContain(
+      "Preview",
+    );
+    expectHelpEntry(wide, "P", "Toggle preview");
+    expectHelpEntry(wide, "p", "Cycle prompt (inline/row/off)");
+
+    setup.resize(60, 24);
+    await setup.renderOnce();
+    const again = setup.captureCharFrame();
+    expect(
+      again.split("\n").find((l) => l.includes("Navigation")),
+    ).not.toContain("Preview");
+    expectHelpEntry(again, "p", "Cycle prompt (inline/row/off)");
+  });
+});
+
+describe("HelpOverlay sidebar compact wrap (issue #200)", () => {
+  it("keeps compact help readable at 30x35", async () => {
+    setup = await testRender(() => <HelpOverlay sidebar />, {
+      width: 30,
+      height: 35,
+    });
+    await setup.renderOnce();
+    const frame = setup.captureCharFrame();
+    expect(frame).not.toContain("Preview");
+    expect(frame).not.toContain("Toggle preview");
+    expectHelpEntry(frame, "j/k ↑/↓", "Navigate sessions");
+    expectHelpEntry(frame, "gg / G", "Jump to first / last");
+    expectHelpEntry(frame, "Enter", "Switch to session");
+    // Compact is key-above-description; the key and its first desc
+    // line are consecutive, not sharing a two-column row with Groups.
+    const lines = frame.split("\n");
+    const keyLine = lines.findIndex((l) => l.includes("j/k ↑/↓"));
+    expect(keyLine).toBeGreaterThan(-1);
+    expect(lines[keyLine]!).not.toContain("Navigate sessions");
+    expect(lines[keyLine + 1]!).toContain("Navigate sessions");
+    expect(squish(frame)).toContain(squish("j/k scroll · ? close"));
+  });
+
+  it("wraps the cycle-prompt description instead of clipping it", async () => {
+    setup = await testRender(() => <HelpOverlay sidebar />, {
+      width: 30,
+      height: 70,
+    });
+    await setup.renderOnce();
+    const frame = setup.captureCharFrame();
+    expectHelpEntry(frame, "p", "Cycle prompt (inline/row/off)");
   });
 });

--- a/src/tui/components/HelpOverlay.tsx
+++ b/src/tui/components/HelpOverlay.tsx
@@ -1,11 +1,17 @@
 import type { ScrollBoxRenderable } from "@opentui/core";
 import type { Component, JSX, ParentComponent } from "solid-js";
+import { createMemo } from "solid-js";
 import { theme } from "../theme";
+import { useSharedTerminalDimensions } from "../utils/use-shared-dimensions";
+import { truncateText, wrapText } from "../utils/format";
 
 const KEY_COL_WIDTH = 14;
 const COL_WIDTH = 38;
 const COL_GAP = 3;
-const MAX_WIDTH = COL_WIDTH * 2 + COL_GAP + 4 + 2; // cols + padding(2+2) + border(2)
+const PAD_X = 4; // picker paddingLeft + paddingRight
+const SIDEBAR_PAD_X = 2;
+const BORDER = 2;
+const MAX_WIDTH = COL_WIDTH * 2 + COL_GAP + PAD_X + BORDER; // cols + padding + border
 
 type Group = { section: string; items: { key: string; desc: string }[] };
 
@@ -41,8 +47,8 @@ const leftGroups = (reviewable?: boolean): Group[] => [
       // uncommitted, `D` what the branch changed), so naming the two diffs
       // in key order says it without a second row - which Actions has no
       // height for anyway (see `keeps the last row visible`). The
-      // description sits inside the column's budget, COL_WIDTH minus
-      // KEY_COL_WIDTH.
+      // description sits inside the column's budget, KEY_COL_WIDTH plus
+      // whatever remains; wrapText below spends extra rows when it cannot.
       ...(reviewable ? [{ key: "d / D", desc: "Working tree / branch" }] : []),
     ],
   },
@@ -88,8 +94,38 @@ const rightGroups = (sidebar?: boolean): Group[] => [
   },
 ];
 
-const renderColumn = (columnGroups: Group[]): JSX.Element => (
-  <box flexDirection="column" width={COL_WIDTH}>
+/**
+ * A shortcut row whose description is pre-wrapped to `descWidth`.
+ *
+ * The wrap happens here rather than in the renderer because the row height
+ * IS the line count: a renderer wrap past a height-1 box clips the tail
+ * (or paints it over the next shortcut). Lines from wrapText already fit,
+ * so nothing can wrap a second time.
+ */
+const renderShortcut = (
+  item: { key: string; desc: string },
+  colWidth: number,
+): JSX.Element => {
+  const descWidth = Math.max(1, colWidth - KEY_COL_WIDTH);
+  const descLines = wrapText(item.desc, descWidth);
+  return (
+    <box height={descLines.length} flexDirection="row" flexShrink={0}>
+      <box width={KEY_COL_WIDTH} height={1} flexShrink={0}>
+        <text fg={theme.mauve}>{item.key.padEnd(KEY_COL_WIDTH)}</text>
+      </box>
+      <box flexDirection="column" width={descWidth} flexShrink={0}>
+        {descLines.map((line) => (
+          <box height={1}>
+            <text fg={theme.subtext}>{line}</text>
+          </box>
+        ))}
+      </box>
+    </box>
+  );
+};
+
+const renderColumn = (columnGroups: Group[], colWidth: number): JSX.Element => (
+  <box flexDirection="column" width={colWidth}>
     {columnGroups.map((group, gi) => (
       <>
         {gi > 0 && <box height={1} />}
@@ -98,14 +134,7 @@ const renderColumn = (columnGroups: Group[]): JSX.Element => (
             <strong>{group.section}</strong>
           </text>
         </box>
-        {group.items.map((item) => (
-          <box height={1} flexDirection="row">
-            <box width={KEY_COL_WIDTH}>
-              <text fg={theme.mauve}>{item.key.padEnd(KEY_COL_WIDTH)}</text>
-            </box>
-            <text fg={theme.subtext}>{item.desc}</text>
-          </box>
-        ))}
+        {group.items.map((item) => renderShortcut(item, colWidth))}
       </>
     ))}
   </box>
@@ -120,8 +149,15 @@ const renderColumn = (columnGroups: Group[]): JSX.Element => (
  * of a full-height rail — silently, since the scrollbox simply scrolls. The
  * alternating mauve key and dim description are what separate one entry from
  * the next; the air was costing a third of the overlay to say the same thing.
+ *
+ * Descriptions wrap to `contentWidth` with one row per line, same reason as
+ * {@link renderShortcut}: a height-1 box at 30 columns clips
+ * "Cycle prompt (inline/row/off)".
  */
-const renderCompactColumn = (columnGroups: Group[]): JSX.Element => (
+const renderCompactColumn = (
+  columnGroups: Group[],
+  contentWidth: number,
+): JSX.Element => (
   <box flexDirection="column">
     {columnGroups.map((group, gi) => (
       <>
@@ -131,16 +167,21 @@ const renderCompactColumn = (columnGroups: Group[]): JSX.Element => (
             <strong>{group.section}</strong>
           </text>
         </box>
-        {group.items.map((item) => (
-          <>
-            <box height={1}>
-              <text fg={theme.mauve}>{item.key}</text>
-            </box>
-            <box height={1}>
-              <text fg={theme.subtext}>{item.desc}</text>
-            </box>
-          </>
-        ))}
+        {group.items.map((item) => {
+          const descLines = wrapText(item.desc, contentWidth);
+          return (
+            <>
+              <box height={1}>
+                <text fg={theme.mauve}>{item.key}</text>
+              </box>
+              {descLines.map((line) => (
+                <box height={1}>
+                  <text fg={theme.subtext}>{line}</text>
+                </box>
+              ))}
+            </>
+          );
+        })}
       </>
     ))}
   </box>
@@ -164,7 +205,7 @@ const HelpLayout: ParentComponent<{
       {props.children}
     </scrollbox>
 
-    <box justifyContent="center" width="100%" height={1}>
+    <box justifyContent="center" width="100%" height={1} flexShrink={0}>
       <text fg={theme.overlay}>{props.hint}</text>
     </box>
   </>
@@ -177,15 +218,56 @@ interface HelpOverlayProps {
 }
 
 export const HelpOverlay: Component<HelpOverlayProps> = (props) => {
+  const dims = useSharedTerminalDimensions();
+
   const filteredRightGroups = () =>
     props.sidebar
       ? rightGroups(props.sidebar).filter((g) => g.section !== "Preview")
       : rightGroups(props.sidebar);
 
-  const groups = leftGroups(props.reviewable);
+  const groups = () => leftGroups(props.reviewable);
+
+  /**
+   * Inner columns of the picker modal: the overlay is `min(term, MAX_WIDTH)`
+   * minus border and horizontal padding. Two fixed COL_WIDTH columns plus
+   * the gap need 79 of those; a 60-column picker only has 54, so the
+   * ordinary two-column grid clips the right-hand descriptions off the
+   * edge. One stacked column uses the full inner width instead.
+   */
+  const innerWidth = createMemo(() =>
+    Math.max(1, Math.min(dims().width, MAX_WIDTH) - BORDER - PAD_X),
+  );
+
+  const twoColumns = createMemo(
+    () => innerWidth() >= COL_WIDTH * 2 + COL_GAP,
+  );
+
+  const columnWidth = createMemo(() =>
+    twoColumns()
+      ? Math.floor((innerWidth() - COL_GAP) / 2)
+      : innerWidth(),
+  );
+
+  const compactWidth = createMemo(() =>
+    Math.max(1, dims().width - BORDER - SIDEBAR_PAD_X),
+  );
+
+  const pickerHint = createMemo(() =>
+    truncateText("j/k scroll · ? or Esc to close", innerWidth()),
+  );
+
+  const sidebarHint = createMemo(() =>
+    truncateText("j/k scroll · ? close", compactWidth()),
+  );
+
+  const pickerColumns = createMemo((): Group[][] => {
+    const left = groups();
+    const right = filteredRightGroups();
+    return twoColumns() ? [left, right] : [[...left, ...right]];
+  });
 
   if (props.sidebar) {
-    const allGroups = [...groups, ...filteredRightGroups()];
+    const allGroups = [...groups(), ...filteredRightGroups()];
     return (
       <box
         position="absolute"
@@ -199,11 +281,11 @@ export const HelpOverlay: Component<HelpOverlayProps> = (props) => {
         flexDirection="column"
       >
         <HelpLayout
-          hint="j/k scroll · ? close"
+          hint={sidebarHint()}
           onScrollboxRef={props.onScrollboxRef}
         >
           <box flexDirection="column" paddingLeft={1} paddingRight={1}>
-            {renderCompactColumn(allGroups)}
+            {renderCompactColumn(allGroups, compactWidth())}
           </box>
         </HelpLayout>
       </box>
@@ -234,14 +316,17 @@ export const HelpOverlay: Component<HelpOverlayProps> = (props) => {
         paddingBottom={1}
       >
         <HelpLayout
-          hint="j/k scroll · ? or Esc to close"
+          hint={pickerHint()}
           onScrollboxRef={props.onScrollboxRef}
         >
           <box height={1} />
           <box flexDirection="row">
-            {renderColumn(groups)}
-            <box width={COL_GAP} />
-            {renderColumn(filteredRightGroups())}
+            {pickerColumns().map((column, i) => (
+              <>
+                {i > 0 && <box width={COL_GAP} />}
+                {renderColumn(column, columnWidth())}
+              </>
+            ))}
           </box>
         </HelpLayout>
       </box>

--- a/src/tui/components/Preview.test.tsx
+++ b/src/tui/components/Preview.test.tsx
@@ -337,6 +337,94 @@ describe("Preview", () => {
   });
 });
 
+describe("Preview header rows (issue #200)", () => {
+  const AUDIT = {
+    project: "api",
+    summary: "Improve narrow terminal layout",
+    cwd: "/tmp/ccmux-tui-audit/api",
+    gitBranch: "feature/worktree-cleanup-5",
+    version: "2.1.263",
+    tmuxTarget: "audit:0.0",
+    tmuxPane: "%1",
+    status: "waiting" as const,
+  };
+
+  async function renderAudit(termWidth: number, previewPct = 40) {
+    const [tick] = createSignal(0);
+    setup = await testRender(
+      () => (
+        <TickContext.Provider value={{ tick }}>
+          <Preview session={mockEnrichedSession(AUDIT)} width={previewPct} />
+        </TickContext.Provider>
+      ),
+      { width: termWidth, height: 30 },
+    );
+    await setup.renderOnce();
+    return setup.captureCharFrame();
+  }
+
+  function expectDistinctHeaderRows(frame: string): void {
+    const lines = frame.split("\n");
+    const projectLine = lines.findIndex((l) => /api\b/.test(l) && l.includes("waiting"));
+    const summaryLine = lines.findIndex((l) =>
+      l.includes("Improve narrow"),
+    );
+    const dirLine = lines.findIndex((l) => l.includes("/tmp/ccmux-tui-audit"));
+    // At 80×40% the header is ~29 columns, so the "-5" suffix is the
+    // first thing truncateText clips. The branch name still identifies
+    // the row.
+    const metaLine = lines.findIndex((l) =>
+      l.includes("feature/worktree-cleanup"),
+    );
+    const sepLine = lines.findIndex((l) => l.includes("───"));
+    expect(projectLine).toBeGreaterThan(-1);
+    expect(summaryLine).toBeGreaterThan(-1);
+    expect(dirLine).toBeGreaterThan(-1);
+    expect(metaLine).toBeGreaterThan(-1);
+    expect(sepLine).toBeGreaterThan(-1);
+    expect(projectLine).toBeLessThan(summaryLine);
+    expect(summaryLine).toBeLessThan(dirLine);
+    expect(dirLine).toBeLessThan(metaLine);
+    expect(metaLine).toBeLessThan(sepLine);
+    // Adjacent, not overlapping: each field owns the next row.
+    expect(summaryLine).toBe(projectLine + 1);
+    expect(dirLine).toBe(summaryLine + 1);
+    expect(metaLine).toBe(dirLine + 1);
+    expect(sepLine).toBe(metaLine + 1);
+    // The reported mashup: directory painted over the title suffix.
+    expect(lines[dirLine]!).not.toContain("layout");
+    expect(lines[dirLine]!).not.toContain("apilayout");
+    expect(lines[summaryLine]!).not.toContain("/tmp/");
+    expect(lines[metaLine]!).not.toContain("───");
+    expect(lines[sepLine]!).not.toContain("feature/worktree");
+  }
+
+  it("keeps title, directory, and metadata on distinct rows at 80/100/120 with 40% preview", async () => {
+    for (const width of [80, 100, 120]) {
+      const frame = await renderAudit(width);
+      expectDistinctHeaderRows(frame);
+      setup.renderer.destroy();
+    }
+  });
+
+  it("does not wrap metadata over the title at the 100x30 40% reproduction", async () => {
+    const frame = await renderAudit(100);
+    expect(frame).not.toContain("apilayout");
+    expectDistinctHeaderRows(frame);
+    const lines = frame.split("\n");
+    const dirLine = lines.find((l) => l.includes("/tmp/ccmux-tui-audit"));
+    expect(dirLine).toContain("/tmp/ccmux-tui-audit/api");
+    // Long metadata is clipped to the header width, not wrapped onto
+    // the separator (the wrap that used to steal the title's row).
+    const metaLine = lines.find((l) =>
+      l.includes("feature/worktree-cleanup"),
+    );
+    expect(metaLine).toBeDefined();
+    expect(metaLine!).toContain("…");
+    expect(metaLine!).not.toContain("1.263");
+  });
+});
+
 describe("Preview pane capture", () => {
   async function renderReactive(initial: EnrichedSession) {
     const [session, setSession] = createSignal<EnrichedSession>(initial);

--- a/src/tui/components/Preview.test.tsx
+++ b/src/tui/components/Preview.test.tsx
@@ -365,10 +365,10 @@ describe("Preview header rows (issue #200)", () => {
 
   function expectDistinctHeaderRows(frame: string): void {
     const lines = frame.split("\n");
-    const projectLine = lines.findIndex((l) => /api\b/.test(l) && l.includes("waiting"));
-    const summaryLine = lines.findIndex((l) =>
-      l.includes("Improve narrow"),
+    const projectLine = lines.findIndex(
+      (l) => /api\b/.test(l) && l.includes("waiting"),
     );
+    const summaryLine = lines.findIndex((l) => l.includes("Improve narrow"));
     const dirLine = lines.findIndex((l) => l.includes("/tmp/ccmux-tui-audit"));
     // At 80×40% the header is ~29 columns, so the "-5" suffix is the
     // first thing truncateText clips. The branch name still identifies
@@ -416,12 +416,42 @@ describe("Preview header rows (issue #200)", () => {
     expect(dirLine).toContain("/tmp/ccmux-tui-audit/api");
     // Long metadata is clipped to the header width, not wrapped onto
     // the separator (the wrap that used to steal the title's row).
-    const metaLine = lines.find((l) =>
-      l.includes("feature/worktree-cleanup"),
-    );
+    const metaLine = lines.find((l) => l.includes("feature/worktree-cleanup"));
     expect(metaLine).toBeDefined();
     expect(metaLine!).toContain("…");
     expect(metaLine!).not.toContain("1.263");
+  });
+
+  it("truncates a long project name instead of shrinking the status badge", async () => {
+    // Both cells of the first header row were unbounded, so a 40-column
+    // project name shrank the badge and clipped "waiting" off the end.
+    const longProject = "ccmux-worktree-with-a-really-long-name-x";
+    const [tick] = createSignal(0);
+    setup = await testRender(
+      () => (
+        <TickContext.Provider value={{ tick }}>
+          <Preview
+            session={mockEnrichedSession({
+              ...AUDIT,
+              project: longProject,
+            })}
+            width={40}
+          />
+        </TickContext.Provider>
+      ),
+      { width: 80, height: 30 },
+    );
+    await setup.renderOnce();
+    const frame = setup.captureCharFrame();
+    const headerRow = frame
+      .split("\n")
+      .find((l) => l.includes("ccmux-worktree"));
+    expect(headerRow).toBeDefined();
+    // Icon and word both intact at the end of the row.
+    expect(headerRow!).toMatch(/\S waiting\s*$/);
+    // The name is what gives instead.
+    expect(headerRow!).toContain("…");
+    expect(headerRow!).not.toContain(longProject);
   });
 });
 

--- a/src/tui/components/Preview.tsx
+++ b/src/tui/components/Preview.tsx
@@ -33,6 +33,7 @@ import {
   formatRelativeTime,
   formatSubagentName,
   formatVersion,
+  displayWidth,
   shortenCwd,
   truncateMiddle,
   truncateText,
@@ -410,6 +411,22 @@ export const Preview: Component<PreviewProps> = (props) => {
     return s.status === "idle" && attn ? "done" : (eff?.status ?? "");
   };
 
+  /**
+   * What the project name may spend on the header's first row.
+   *
+   * Both cells of that row used to be unbounded, so Yoga's default shrink
+   * split the overflow between them and a long project name ate the status
+   * badge. The badge is the row's fixed part (it is what the row exists to
+   * report), so it keeps its width and the name truncates into whatever is
+   * left, one column of gap included. Every other header row is already
+   * truncated to `separatorWidth`; this is the one that was not.
+   */
+  const statusBadge = createMemo(() => `${statusIcon()} ${statusText()}`);
+
+  const projectWidth = createMemo(() =>
+    Math.max(1, separatorWidth() - displayWidth(statusBadge()) - 1),
+  );
+
   /** Live subagents for the Agents section; capped so a large fan-out
    * doesn't crowd out the pane content below. */
   const AGENTS_SHOWN_MAX = 4;
@@ -465,10 +482,10 @@ export const Preview: Component<PreviewProps> = (props) => {
           <box flexDirection="row" height={1} flexShrink={0}>
             <box flexGrow={1}>
               <text fg={theme.text} wrapMode="none">
-                <b>{props.session!.project}</b>
+                <b>{truncateText(props.session!.project, projectWidth())}</b>
               </text>
             </box>
-            <text fg={statusColor()} wrapMode="none">
+            <text fg={statusColor()} wrapMode="none" flexShrink={0}>
               {statusIcon()} {statusText()}
             </text>
           </box>

--- a/src/tui/components/Preview.tsx
+++ b/src/tui/components/Preview.tsx
@@ -34,6 +34,7 @@ import {
   formatSubagentName,
   formatVersion,
   shortenCwd,
+  truncateMiddle,
   truncateText,
 } from "../utils/format";
 
@@ -455,14 +456,19 @@ export const Preview: Component<PreviewProps> = (props) => {
         when={props.session}
         fallback={<text fg={theme.overlay}>Select a session to preview</text>}
       >
-        <box height={title() ? 5 : 4} flexDirection="column">
-          <box flexDirection="row">
+        {/* Each header field is one locked row. Directory and metadata used
+            to wrap inside a title()?5:4 budget; Yoga then shrank the
+            summary wrapper and the directory painted over the title
+            (`/tmp/.../apilayout`). Truncate to the column and pin
+            height=1 / flexShrink=0 so wrap cannot steal a neighbour. */}
+        <box height={title() ? 5 : 4} flexDirection="column" flexShrink={0}>
+          <box flexDirection="row" height={1} flexShrink={0}>
             <box flexGrow={1}>
-              <text fg={theme.text}>
+              <text fg={theme.text} wrapMode="none">
                 <b>{props.session!.project}</b>
               </text>
             </box>
-            <text fg={statusColor()}>
+            <text fg={statusColor()} wrapMode="none">
               {statusIcon()} {statusText()}
             </text>
           </box>
@@ -471,17 +477,31 @@ export const Preview: Component<PreviewProps> = (props) => {
               to the END of the parent box (opentui insertion anchor),
               landing the title under the separator. The always-mounted box
               pins its slot in the column order. Same fix pattern as the
-              transcript slot in BackgroundPeek. */}
-          <box flexDirection="column">
+              transcript slot in BackgroundPeek. height 0 when empty so the
+              four-row header does not keep a blank gap. */}
+          <box height={title() ? 1 : 0} flexDirection="column" flexShrink={0}>
             <Show when={title()}>
-              <text fg={theme.text}>{truncateText(title() ?? "", separatorWidth())}</text>
+              <text fg={theme.text} wrapMode="none">
+                {truncateText(title() ?? "", separatorWidth())}
+              </text>
             </Show>
           </box>
-          <text fg={theme.subtext}>
-            {shortenCwd(props.session!.paneCwd ?? props.session!.cwd)}
-          </text>
-          <text fg={theme.overlay}>{metadataLine()}</text>
-          <text fg={theme.border}>{"─".repeat(separatorWidth())}</text>
+          <box height={1} flexShrink={0}>
+            <text fg={theme.subtext} wrapMode="none">
+              {truncateMiddle(
+                shortenCwd(props.session!.paneCwd ?? props.session!.cwd),
+                separatorWidth(),
+              )}
+            </text>
+          </box>
+          <box height={1} flexShrink={0}>
+            <text fg={theme.overlay} wrapMode="none">
+              {truncateText(metadataLine(), separatorWidth())}
+            </text>
+          </box>
+          <box height={1} flexShrink={0}>
+            <text fg={theme.border}>{"─".repeat(separatorWidth())}</text>
+          </box>
         </box>
 
         <Show when={liveSubagents().length > 0}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Stops the picker help overlay from clipping shortcut descriptions at narrow widths, and stops the preview header from painting the directory over the task title.

Resolves #200

## Motivation

At 60×24 the ordinary picker kept two fixed-width columns, so Preview/Groups keys stayed on screen while their descriptions ran off the right edge. `Cycle prompt (inline/row/off)` clipped even when the overlay was wide enough for two columns. In the preview, directory and metadata wrapped inside a `title()?5:4` budget, Yoga shrank the summary row, and a path like `/tmp/ccmux-tui-audit/api` overwrote `Improve narrow terminal layout` into `/tmp/ccmux-tui-audit/apilayout`.


## Demo

Screen recording, sped up. At 60×24 the help overlay stacks into one column so shortcut descriptions (including `Cycle prompt (inline/row/off)`) stay fully readable. After widening to 100×30 with the preview pane (~40%), header rows stay distinct: project, title, directory, and metadata no longer overlap.

https://github.com/user-attachments/assets/e94b3635-b583-465c-9d56-1d7654e89f8b

## Changes

### Help overlay

- **HelpOverlay.tsx** - Switch the picker to a single column when two `COL_WIDTH` columns do not fit. Pre-wrap each description to the column and set the row height to the line count. Compact sidebar help wraps the same way at 30 columns.
- **HelpOverlay.test.tsx** - Assert complete descriptions and section row order at 60×24 and 120×35, after a narrow/widen resize, and in sidebar compact at 30×35.

### Preview header

- **Preview.tsx** - Lock project, summary, directory, metadata, and separator to distinct `height={1}` rows. Truncate the directory (middle) and metadata (end) to the column so wrap cannot steal a neighbour.
- **Preview.test.tsx** - Reproduce the 100×30 / 40% mashup and assert adjacent row order at picker widths 80, 100, and 120.

## Breaking Changes

None

## Testing

- [x] `bun run typecheck` passes
- [x] `bun test` (5890 pass, 3 skip, 0 fail) with `commit.gpgsign=false`
- [x] Detached tmux picker (`-L ccmux-hlp`) at 60×24, resized to 120×35, then back to 60×24
- [x] Detached sidebar help at 30×35
- [ ] Not verified against a real agent (renderer-only)

## Notes for reviewers

Separate from #198.

Help at 60 stacks into one column. Preview/Groups sit below the fold; scroll shows complete entries. Two columns return at 120. `Cycle prompt (inline/row/off)` wraps onto a second row instead of clipping.

Preview keeps the 5/4-row header. Long metadata clips to the column (`api:feature/worktree-cleanup-5 · v2.…`) rather than wrapping over the title.

Detached picker after `?` at 60×24:

```
Navigation
j/k ↑/↓       Navigate sessions
...
p             Cycle prompt (inline/row/off)
```

Same session after widen to 120×35:

```
Navigation                               Preview
j/k ↑/↓       Navigate sessions          P             Toggle preview
p             Cycle prompt               ?             Help
              (inline/row/off)           q / Esc       Quit
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1dce3358-fbe7-47eb-8592-a2ae645a130f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dce3358-fbe7-47eb-8592-a2ae645a130f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Help overlays now adapt to terminal width, switching between one- and two-column layouts as needed.
  - Help descriptions wrap fully instead of being clipped, including in narrow sidebars and pickers.
  - Preview headers now keep project, title, directory, metadata, and separators on distinct rows.
  - Long project names, directory paths, and metadata are truncated cleanly while preserving status indicators and the preview layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
